### PR TITLE
Add quoted strings rule for YAML linting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +482,7 @@ dependencies = [
  "globset",
  "ignore",
  "rayon",
+ "regex",
  "saphyr",
  "saphyr-parser",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ saphyr-parser = "0.0.6"
 saphyr = "0.0.6"
 globset = "0.4.14"
 dirs = "6.0.0"
+regex = "1"
 
 [dev-dependencies]
 semver = "1"

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::config::{RuleLevel, YamlLintConfig};
-use crate::rules::{new_line_at_end_of_file, new_lines, trailing_spaces, truthy};
+use crate::rules::{new_line_at_end_of_file, new_lines, quoted_strings, trailing_spaces, truthy};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
@@ -82,6 +82,21 @@ pub fn lint_file(
                 level: level.into(),
                 message: hit.message,
                 rule: Some(new_lines::ID),
+            });
+        }
+    }
+
+    if let Some(level) = cfg.rule_level(quoted_strings::ID)
+        && !cfg.is_rule_ignored(quoted_strings::ID, path, base_dir)
+    {
+        let rule_cfg = quoted_strings::Config::resolve(cfg);
+        for hit in quoted_strings::check(&content, &rule_cfg) {
+            diagnostics.push(LintProblem {
+                line: hit.line,
+                column: hit.column,
+                level: level.into(),
+                message: hit.message,
+                rule: Some(quoted_strings::ID),
             });
         }
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,4 +1,5 @@
 pub mod new_line_at_end_of_file;
 pub mod new_lines;
+pub mod quoted_strings;
 pub mod trailing_spaces;
 pub mod truthy;

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -1,0 +1,563 @@
+use regex::Regex;
+use saphyr::Yaml;
+use saphyr_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver, Tag};
+
+use crate::config::YamlLintConfig;
+
+pub const ID: &str = "quoted-strings";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuoteType {
+    Any,
+    Single,
+    Double,
+}
+
+impl QuoteType {
+    const fn matches(self, style: Option<QuoteStyle>) -> bool {
+        match self {
+            Self::Any => style.is_some(),
+            Self::Single => matches!(style, Some(QuoteStyle::Single)),
+            Self::Double => matches!(style, Some(QuoteStyle::Double)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuoteStyle {
+    Single,
+    Double,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequiredMode {
+    Always,
+    Never,
+    OnlyWhenNeeded,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    quote_type: QuoteType,
+    quote_type_label: &'static str,
+    required: RequiredMode,
+    extra_required: Vec<Regex>,
+    extra_allowed: Vec<Regex>,
+    allow_quoted_quotes: bool,
+    pub check_keys: bool,
+}
+
+impl Config {
+    /// Resolve the rule configuration from the parsed yamllint configuration.
+    ///
+    /// # Panics
+    ///
+    /// Panics when option types are invalid. Configuration parsing validates
+    /// options before resolution, so this only occurs when constructing configs
+    /// manually in tests.
+    #[must_use]
+    pub fn resolve(cfg: &YamlLintConfig) -> Self {
+        let (quote_type, quote_type_label) = match cfg.rule_option_str(ID, "quote-type") {
+            Some("single") => (QuoteType::Single, "single"),
+            Some("double") => (QuoteType::Double, "double"),
+            _ => (QuoteType::Any, "any"),
+        };
+
+        let required = cfg
+            .rule_option(ID, "required")
+            .map_or(RequiredMode::Always, |node| {
+                if node.as_bool() == Some(false) {
+                    RequiredMode::Never
+                } else if node.as_str() == Some("only-when-needed") {
+                    RequiredMode::OnlyWhenNeeded
+                } else {
+                    RequiredMode::Always
+                }
+            });
+
+        let mut extra_required: Vec<Regex> = Vec::new();
+        if let Some(node) = cfg.rule_option(ID, "extra-required")
+            && let Some(seq) = node.as_sequence()
+        {
+            for item in seq {
+                let pattern = item
+                    .as_str()
+                    .expect("quoted-strings extra-required entries should be strings");
+                let regex = Regex::new(pattern)
+                    .expect("quoted-strings extra-required should contain valid regex");
+                extra_required.push(regex);
+            }
+        }
+
+        let mut extra_allowed: Vec<Regex> = Vec::new();
+        if let Some(node) = cfg.rule_option(ID, "extra-allowed")
+            && let Some(seq) = node.as_sequence()
+        {
+            for item in seq {
+                let pattern = item
+                    .as_str()
+                    .expect("quoted-strings extra-allowed entries should be strings");
+                let regex = Regex::new(pattern)
+                    .expect("quoted-strings extra-allowed should contain valid regex");
+                extra_allowed.push(regex);
+            }
+        }
+
+        let allow_quoted_quotes = cfg
+            .rule_option(ID, "allow-quoted-quotes")
+            .and_then(saphyr::YamlOwned::as_bool)
+            .unwrap_or(false);
+
+        let check_keys = cfg
+            .rule_option(ID, "check-keys")
+            .and_then(saphyr::YamlOwned::as_bool)
+            .unwrap_or(false);
+
+        Self {
+            quote_type,
+            quote_type_label,
+            required,
+            extra_required,
+            extra_allowed,
+            allow_quoted_quotes,
+            check_keys,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+#[must_use]
+pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
+    let mut parser = Parser::new_from_str(buffer);
+    let mut receiver = QuotedStringsReceiver::new(cfg, buffer);
+    let _ = parser.load(&mut receiver, true);
+    receiver.diagnostics
+}
+
+struct QuotedStringsReceiver<'cfg> {
+    state: QuotedStringsState<'cfg>,
+    diagnostics: Vec<Violation>,
+}
+
+impl<'cfg> QuotedStringsReceiver<'cfg> {
+    const fn new(cfg: &'cfg Config, buffer: &'cfg str) -> Self {
+        Self {
+            state: QuotedStringsState::new(cfg, buffer),
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+impl SpannedEventReceiver<'_> for QuotedStringsReceiver<'_> {
+    fn on_event(&mut self, event: Event<'_>, span: Span) {
+        match event {
+            Event::StreamStart => self.state.reset_stream(),
+            Event::DocumentStart(_) => self.state.document_start(),
+            Event::DocumentEnd => self.state.document_end(),
+            Event::SequenceStart(_, _) => {
+                let flow = is_flow_sequence(self.state.buffer, span);
+                self.state.enter_sequence(flow);
+            }
+            Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
+            Event::MappingStart(_, _) => {
+                let flow = is_flow_mapping(self.state.buffer, span);
+                self.state.enter_mapping(flow);
+            }
+            Event::Scalar(value, style, _, tag) => {
+                self.state.handle_scalar(
+                    style,
+                    value.as_ref(),
+                    tag.as_deref(),
+                    span,
+                    &mut self.diagnostics,
+                );
+            }
+            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+        }
+    }
+}
+
+struct QuotedStringsState<'cfg> {
+    config: &'cfg Config,
+    buffer: &'cfg str,
+    containers: Vec<ContainerState>,
+    key_depth: usize,
+}
+
+impl<'cfg> QuotedStringsState<'cfg> {
+    const fn new(config: &'cfg Config, buffer: &'cfg str) -> Self {
+        Self {
+            config,
+            buffer,
+            containers: Vec::new(),
+            key_depth: 0,
+        }
+    }
+
+    fn reset_stream(&mut self) {
+        self.containers.clear();
+        self.key_depth = 0;
+    }
+
+    fn document_start(&mut self) {
+        self.containers.clear();
+        self.key_depth = 0;
+    }
+
+    fn document_end(&mut self) {
+        self.containers.clear();
+        self.key_depth = 0;
+    }
+
+    fn enter_mapping(&mut self, flow: bool) {
+        let active_key = self.begin_node();
+        self.containers.push(ContainerState {
+            kind: ContainerKind::Mapping { expect_key: true },
+            key_context: active_key,
+            flow,
+        });
+    }
+
+    fn enter_sequence(&mut self, flow: bool) {
+        let active_key = self.begin_node();
+        self.containers.push(ContainerState {
+            kind: ContainerKind::Sequence,
+            key_context: active_key,
+            flow,
+        });
+    }
+
+    fn exit_container(&mut self) {
+        if let Some(container) = self.containers.pop()
+            && container.key_context
+            && self.key_depth > 0
+        {
+            self.key_depth -= 1;
+        }
+    }
+
+    fn handle_scalar(
+        &mut self,
+        style: ScalarStyle,
+        value: &str,
+        tag: Option<&Tag>,
+        span: Span,
+        diagnostics: &mut Vec<Violation>,
+    ) {
+        let active_key = self.begin_node();
+        let resolves_to_string = matches!(
+            Yaml::value_from_str(value),
+            Yaml::Value(saphyr::Scalar::String(_))
+        );
+
+        if self.should_skip_scalar(style, tag, active_key, resolves_to_string) {
+            self.finish_scalar(active_key);
+            return;
+        }
+
+        if let Some(violation) =
+            self.evaluate_scalar(style, value, active_key, resolves_to_string, span)
+        {
+            diagnostics.push(violation);
+        }
+
+        self.finish_scalar(active_key);
+    }
+
+    fn in_flow(&self) -> bool {
+        self.containers.iter().any(|container| container.flow)
+    }
+
+    fn begin_node(&mut self) -> bool {
+        let mut is_key_node = false;
+        if let Some(ContainerState {
+            kind: ContainerKind::Mapping { expect_key },
+            ..
+        }) = self.containers.last_mut()
+        {
+            if *expect_key {
+                is_key_node = true;
+                *expect_key = false;
+            } else {
+                *expect_key = true;
+            }
+        }
+
+        let active_key = is_key_node || self.key_depth > 0;
+        if active_key {
+            self.key_depth += 1;
+        }
+        active_key
+    }
+
+    const fn finish_scalar(&mut self, active_key: bool) {
+        if active_key && self.key_depth > 0 {
+            self.key_depth -= 1;
+        }
+    }
+
+    fn should_skip_scalar(
+        &self,
+        style: ScalarStyle,
+        tag: Option<&Tag>,
+        active_key: bool,
+        resolves_to_string: bool,
+    ) -> bool {
+        if matches!(style, ScalarStyle::Literal | ScalarStyle::Folded) {
+            return true;
+        }
+
+        if active_key && !self.config.check_keys {
+            return true;
+        }
+
+        if let Some(tag) = tag
+            && is_core_tag(tag)
+        {
+            return true;
+        }
+
+        matches!(style, ScalarStyle::Plain) && !resolves_to_string
+    }
+
+    fn evaluate_scalar(
+        &self,
+        style: ScalarStyle,
+        value: &str,
+        active_key: bool,
+        resolves_to_string: bool,
+        span: Span,
+    ) -> Option<Violation> {
+        let node_label = if active_key { "key" } else { "value" };
+        let quote_style = match style {
+            ScalarStyle::SingleQuoted => Some(QuoteStyle::Single),
+            ScalarStyle::DoubleQuoted => Some(QuoteStyle::Double),
+            ScalarStyle::Plain | ScalarStyle::Literal | ScalarStyle::Folded => None,
+        };
+
+        let has_quoted_quotes = match style {
+            ScalarStyle::SingleQuoted => value.contains('"'),
+            ScalarStyle::DoubleQuoted => value.contains('\''),
+            _ => false,
+        };
+
+        let extra_required = self
+            .config
+            .extra_required
+            .iter()
+            .any(|re| re.is_match(value));
+        let extra_allowed = self
+            .config
+            .extra_allowed
+            .iter()
+            .any(|re| re.is_match(value));
+        let quotes_needed = matches!(style, ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted)
+            && quotes_are_needed(style, value, self.in_flow(), self.buffer, span);
+
+        let message = match self.config.required {
+            RequiredMode::Always => {
+                if quote_style.is_none()
+                    || quote_style.is_some_and(|style_kind| {
+                        self.mismatched_quote(style_kind, has_quoted_quotes)
+                    })
+                {
+                    Some(format!(
+                        "string {node_label} is not quoted with {} quotes",
+                        self.config.quote_type_label
+                    ))
+                } else {
+                    None
+                }
+            }
+            RequiredMode::Never => quote_style.map_or_else(
+                || {
+                    if extra_required {
+                        Some(format!("string {node_label} is not quoted"))
+                    } else {
+                        None
+                    }
+                },
+                |style_kind| {
+                    if self.mismatched_quote(style_kind, has_quoted_quotes) {
+                        Some(format!(
+                            "string {node_label} is not quoted with {} quotes",
+                            self.config.quote_type_label
+                        ))
+                    } else {
+                        None
+                    }
+                },
+            ),
+            RequiredMode::OnlyWhenNeeded => quote_style.map_or_else(
+                || {
+                    if extra_required {
+                        Some(format!("string {node_label} is not quoted"))
+                    } else {
+                        None
+                    }
+                },
+                |style_kind| {
+                    if resolves_to_string && !value.is_empty() && !quotes_needed {
+                        if extra_required || extra_allowed {
+                            None
+                        } else {
+                            Some(format!(
+                                "string {node_label} is redundantly quoted with {} quotes",
+                                self.config.quote_type_label
+                            ))
+                        }
+                    } else if self.mismatched_quote(style_kind, has_quoted_quotes) {
+                        Some(format!(
+                            "string {node_label} is not quoted with {} quotes",
+                            self.config.quote_type_label
+                        ))
+                    } else {
+                        None
+                    }
+                },
+            ),
+        }?;
+
+        Some(build_violation(span, message))
+    }
+
+    const fn mismatched_quote(&self, style_kind: QuoteStyle, has_quoted_quotes: bool) -> bool {
+        !(self.config.quote_type.matches(Some(style_kind))
+            || (self.config.allow_quoted_quotes && has_quoted_quotes))
+    }
+}
+
+struct ContainerState {
+    kind: ContainerKind,
+    key_context: bool,
+    flow: bool,
+}
+
+enum ContainerKind {
+    Mapping { expect_key: bool },
+    Sequence,
+}
+
+fn build_violation(span: Span, message: String) -> Violation {
+    Violation {
+        line: span.start.line(),
+        column: span.start.col() + 1,
+        message,
+    }
+}
+
+fn is_flow_sequence(buffer: &str, span: Span) -> bool {
+    matches!(char_at(buffer, span.start.index()), Some('['))
+}
+
+fn is_flow_mapping(buffer: &str, span: Span) -> bool {
+    matches!(char_at(buffer, span.start.index()), Some('{'))
+}
+
+fn char_at(text: &str, idx: usize) -> Option<char> {
+    text.chars().nth(idx)
+}
+
+fn is_core_tag(tag: &Tag) -> bool {
+    tag.handle == "tag:yaml.org,2002:"
+}
+
+fn quotes_are_needed(
+    style: ScalarStyle,
+    value: &str,
+    is_inside_flow: bool,
+    buffer: &str,
+    span: Span,
+) -> bool {
+    if is_inside_flow
+        && value
+            .chars()
+            .any(|c| matches!(c, ',' | '[' | ']' | '{' | '}'))
+    {
+        return true;
+    }
+
+    if matches!(style, ScalarStyle::DoubleQuoted) {
+        if contains_non_printable(value) {
+            return true;
+        }
+        if has_backslash_line_ending(buffer, span) {
+            return true;
+        }
+    }
+
+    plain_scalar_equivalent(value).is_none_or(|result| !result)
+}
+
+fn plain_scalar_equivalent(value: &str) -> Option<bool> {
+    let snippet = format!("key: {value}\n");
+    let mut parser = Parser::new_from_str(&snippet);
+    let mut checker = PlainScalarChecker::new(value);
+    if parser.load(&mut checker, true).is_err() {
+        return Some(false);
+    }
+    checker.result.or(Some(false))
+}
+
+struct PlainScalarChecker<'a> {
+    expected: &'a str,
+    seen_key: bool,
+    result: Option<bool>,
+}
+
+impl<'a> PlainScalarChecker<'a> {
+    const fn new(expected: &'a str) -> Self {
+        Self {
+            expected,
+            seen_key: false,
+            result: None,
+        }
+    }
+}
+
+impl SpannedEventReceiver<'_> for PlainScalarChecker<'_> {
+    fn on_event(&mut self, event: Event<'_>, _span: Span) {
+        if let Event::Scalar(value, style, _, _) = event {
+            if !self.seen_key {
+                self.seen_key = true;
+            } else if self.result.is_none() {
+                let is_plain_scalar = matches!(style, ScalarStyle::Plain);
+                let matches_expected = value.as_ref() == self.expected;
+                self.result = Some(is_plain_scalar && matches_expected);
+            }
+        }
+    }
+}
+
+fn contains_non_printable(value: &str) -> bool {
+    value.chars().any(|ch| {
+        let code = ch as u32;
+        !(matches!(ch, '\u{9}' | '\u{A}' | '\u{D}')
+            || (0x20..=0x7E).contains(&code)
+            || code == 0x85
+            || (0xA0..=0xD7FF).contains(&code)
+            || (0xE000..=0xFFFD).contains(&code)
+            || (0x1_0000..=0x10_FFFF).contains(&code))
+    })
+}
+
+fn has_backslash_line_ending(buffer: &str, span: Span) -> bool {
+    if span.start.line() == span.end.line() {
+        return false;
+    }
+
+    let slice_start = span.start.index().saturating_add(1).min(buffer.len());
+    let mut slice_end = span.end.index().saturating_sub(1);
+    slice_end = slice_end.min(buffer.len());
+    slice_end = slice_end.max(slice_start);
+    let content = &buffer[slice_start..slice_end];
+    let has_unix_backslash = content.contains("\\\n");
+    let has_windows_backslash = content.contains("\\\r\n");
+    has_unix_backslash || has_windows_backslash
+}

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -1,0 +1,46 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
+    if stderr.is_empty() { stdout } else { stderr }
+}
+
+#[test]
+fn quoted_strings_reports_redundant_quotes() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(&file, "foo: \"bar\"\n").unwrap();
+
+    let config = dir.path().join("config.yaml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 1,
+        "expected lint failure: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert!(
+        output.contains("string value is redundantly quoted with any quotes"),
+        "missing redundant quote message: {output}"
+    );
+    assert!(
+        output.contains("quoted-strings"),
+        "rule label missing: {output}"
+    );
+}

--- a/tests/config_quoted_strings.rs
+++ b/tests/config_quoted_strings.rs
@@ -1,0 +1,175 @@
+use ryl::config::{RuleLevel, YamlLintConfig};
+use ryl::rules::quoted_strings;
+
+#[test]
+fn error_when_quote_type_invalid() {
+    let err = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    quote-type: bad\n")
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"quote-type\" of \"quoted-strings\" should be in ('any', 'single', 'double')"
+    );
+}
+
+#[test]
+fn error_when_quote_type_not_string() {
+    let err = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    quote-type: 1\n")
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"quote-type\" of \"quoted-strings\" should be in ('any', 'single', 'double')"
+    );
+}
+
+#[test]
+fn error_when_required_invalid() {
+    let err =
+        YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    required: 3\n").unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"required\" of \"quoted-strings\" should be in (True, False, 'only-when-needed')"
+    );
+}
+
+#[test]
+fn error_when_extra_required_not_sequence() {
+    let err = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    extra-required: foo\n")
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"extra-required\" of \"quoted-strings\" should only contain values in [<class 'str'>]"
+    );
+}
+
+#[test]
+fn error_when_extra_required_contains_non_string() {
+    let err = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    extra-required: [1]\n")
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"extra-required\" of \"quoted-strings\" should only contain values in [<class 'str'>]"
+    );
+}
+
+#[test]
+fn error_when_extra_allowed_contains_non_string() {
+    let err =
+        YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    extra-allowed: [true]\n")
+            .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"extra-allowed\" of \"quoted-strings\" should only contain values in [<class 'str'>]"
+    );
+}
+
+#[test]
+fn error_when_allow_quoted_quotes_not_bool() {
+    let err =
+        YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    allow-quoted-quotes: 1\n")
+            .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"allow-quoted-quotes\" of \"quoted-strings\" should be bool"
+    );
+}
+
+#[test]
+fn error_when_check_keys_not_bool() {
+    let err = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    check-keys: 2\n")
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: option \"check-keys\" of \"quoted-strings\" should be bool"
+    );
+}
+
+#[test]
+fn error_when_required_true_and_extra_required() {
+    let err =
+        YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    extra-required: ['^http']\n")
+            .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: quoted-strings: cannot use both \"required: true\" and \"extra-required\""
+    );
+}
+
+#[test]
+fn error_when_required_true_and_extra_allowed() {
+    let err =
+        YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    extra-allowed: ['^http']\n")
+            .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: quoted-strings: cannot use both \"required: true\" and \"extra-allowed\""
+    );
+}
+
+#[test]
+fn error_when_required_false_and_extra_allowed() {
+    let err = YamlLintConfig::from_yaml_str(
+        "rules:\n  quoted-strings:\n    required: false\n    extra-allowed: ['^http']\n",
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: quoted-strings: cannot use both \"required: false\" and \"extra-allowed\""
+    );
+}
+
+#[test]
+fn error_when_extra_required_regex_invalid() {
+    let err = YamlLintConfig::from_yaml_str(
+        "rules:\n  quoted-strings:\n    required: false\n    extra-required: ['[']\n",
+    )
+    .unwrap_err();
+    assert!(
+        err.starts_with(
+            "invalid config: regex \"[\" in option \"extra-required\" of \"quoted-strings\" is invalid:"
+        ),
+        "unexpected message: {err}"
+    );
+}
+
+#[test]
+fn allows_level_option_to_pass_validation() {
+    let cfg = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    level: warning\n")
+        .expect("config with level should be accepted");
+    assert_eq!(cfg.rule_level("quoted-strings"), Some(RuleLevel::Warning));
+}
+
+#[test]
+fn error_when_rule_ignore_contains_non_string_pattern() {
+    let err =
+        YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    ignore: [1]\n").unwrap_err();
+    assert_eq!(err, "invalid config: ignore should contain file patterns");
+}
+
+#[test]
+fn error_when_unknown_quoted_strings_option() {
+    let err = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    unknown: value\n")
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: unknown option \"unknown\" for rule \"quoted-strings\""
+    );
+}
+
+#[test]
+fn error_when_option_key_not_string() {
+    let err =
+        YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    1: true\n").unwrap_err();
+    assert_eq!(
+        err,
+        "invalid config: unknown option \"1\" for rule \"quoted-strings\""
+    );
+}
+
+#[test]
+fn resolve_required_true_sets_mode() {
+    let cfg = YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    required: true\n")
+        .expect("config parses");
+    let resolved = quoted_strings::Config::resolve(&cfg);
+    let hits = quoted_strings::check("foo: bar\n", &resolved);
+    assert_eq!(hits.len(), 1);
+}

--- a/tests/rule_quoted_strings.rs
+++ b/tests/rule_quoted_strings.rs
@@ -1,0 +1,271 @@
+use ryl::config::YamlLintConfig;
+use ryl::rules::quoted_strings::{self, Config};
+
+fn build_config(yaml: &str) -> Config {
+    let cfg = YamlLintConfig::from_yaml_str(yaml).expect("config should parse");
+    Config::resolve(&cfg)
+}
+
+#[test]
+fn required_true_flags_plain_values() {
+    let cfg = build_config("rules:\n  document-start: disable\n  quoted-strings: enable\n");
+    let hits = quoted_strings::check("foo: bar\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].line, 1);
+    assert_eq!(hits[0].column, 6);
+    assert_eq!(
+        hits[0].message,
+        "string value is not quoted with any quotes"
+    );
+}
+
+#[test]
+fn quote_type_single_requires_single_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n",
+    );
+    let hits = quoted_strings::check("foo: \"bar\"\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].message,
+        "string value is not quoted with single quotes"
+    );
+}
+
+#[test]
+fn non_string_plain_values_are_ignored() {
+    let cfg = build_config("rules:\n  document-start: disable\n  quoted-strings: enable\n");
+    let hits = quoted_strings::check("foo: 123\n", &cfg);
+    assert!(hits.is_empty(), "numeric scalars should be skipped");
+}
+
+#[test]
+fn required_false_respects_extra_required() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: false\n    extra-required: ['^http']\n",
+    );
+    let hits = quoted_strings::check("- http://example.com\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].message, "string value is not quoted");
+}
+
+#[test]
+fn only_when_needed_flags_redundant_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let hits = quoted_strings::check("foo: \"bar\"\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].message,
+        "string value is redundantly quoted with any quotes"
+    );
+}
+
+#[test]
+fn only_when_needed_respects_extra_allowed() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n    extra-allowed: ['^http']\n",
+    );
+    let hits = quoted_strings::check("foo: \"http://example\"\n", &cfg);
+    assert!(hits.is_empty(), "quoted URL should be allowed");
+}
+
+#[test]
+fn required_false_flags_mismatched_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: false\n    quote-type: single\n",
+    );
+    let hits = quoted_strings::check("foo: \"bar\"\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].message.contains("single quotes"));
+}
+
+#[test]
+fn only_when_needed_extra_required_enforces_quoting() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n    extra-required: ['^foo']\n",
+    );
+    let hits = quoted_strings::check("foo: foo\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].message.contains("not quoted"));
+}
+
+#[test]
+fn only_when_needed_flags_mismatched_quote_type() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n    quote-type: single\n",
+    );
+    let hits = quoted_strings::check("foo: \"bar\"\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].message.contains("single quotes"));
+}
+
+#[test]
+fn only_when_needed_mismatched_quote_type_when_quotes_required() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n    quote-type: single\n",
+    );
+    let hits = quoted_strings::check("foo: \"!bar\"\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].message,
+        "string value is not quoted with single quotes"
+    );
+}
+
+#[test]
+fn tagged_scalars_are_skipped() {
+    let cfg = build_config("rules:\n  document-start: disable\n  quoted-strings: enable\n");
+    let hits = quoted_strings::check("foo: !!str yes\n", &cfg);
+    assert!(
+        hits.is_empty(),
+        "explicitly tagged scalars should be ignored"
+    );
+}
+
+#[test]
+fn literal_block_is_ignored() {
+    let cfg = build_config("rules:\n  document-start: disable\n  quoted-strings: enable\n");
+    let hits = quoted_strings::check("foo: |\n  line\n", &cfg);
+    assert!(hits.is_empty(), "literal blocks are outside rule scope");
+}
+
+#[test]
+fn double_quoted_non_printable_is_considered_needed() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let yaml = "foo: \"\u{0007}\"\n";
+    let hits = quoted_strings::check(yaml, &cfg);
+    assert!(hits.is_empty(), "non-printable characters require quotes");
+}
+
+#[test]
+fn quoted_value_starting_with_bang_keeps_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let hits = quoted_strings::check("foo: \"!foo\"\n", &cfg);
+    assert!(hits.is_empty(), "values starting with bang need quotes");
+}
+
+#[test]
+fn required_false_allows_plain_strings_without_extras() {
+    let cfg =
+        build_config("rules:\n  document-start: disable\n  quoted-strings:\n    required: false\n");
+    let hits = quoted_strings::check("foo: bar\n", &cfg);
+    assert!(hits.is_empty(), "plain values should be allowed");
+}
+
+#[test]
+fn required_false_respects_matching_quote_type() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: false\n    quote-type: double\n",
+    );
+    let hits = quoted_strings::check("foo: \"bar\"\n", &cfg);
+    assert!(hits.is_empty(), "matching quotes should be permitted");
+}
+
+#[test]
+fn complex_keys_do_not_suppress_value_diagnostics() {
+    let cfg = build_config("rules:\n  document-start: disable\n  quoted-strings: enable\n");
+    let yaml = "? { key: value }\n: data\n";
+    let hits = quoted_strings::check(yaml, &cfg);
+    assert_eq!(hits.len(), 1, "expected value diagnostic, got: {:?}", hits);
+    assert_eq!(hits[0].line, 2);
+    assert_eq!(hits[0].column, 3);
+    assert_eq!(
+        hits[0].message,
+        "string value is not quoted with any quotes"
+    );
+}
+
+#[test]
+fn allow_quoted_quotes_permits_mismatched_quotes_with_inner_quote() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n    allow-quoted-quotes: true\n",
+    );
+    let hits = quoted_strings::check("foo: 'bar\"baz'\n", &cfg);
+    assert!(hits.is_empty(), "mismatched quoting should be permitted");
+}
+
+#[test]
+fn check_keys_true_flags_keys() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n    check-keys: true\n    extra-required: ['[:]']\n",
+    );
+    let hits = quoted_strings::check("foo:bar: baz\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].line, 1);
+    assert_eq!(hits[0].column, 1);
+    assert_eq!(hits[0].message, "string key is not quoted");
+}
+
+#[test]
+fn flow_context_retain_quotes_when_needed() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let hits = quoted_strings::check("items: [\"a,b\"]\n", &cfg);
+    assert!(
+        hits.is_empty(),
+        "quotes are required in flow contexts containing commas"
+    );
+}
+
+#[test]
+fn multiline_backslash_requires_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let yaml = "foo: \"line1\\\n  line2\"\n";
+    let hits = quoted_strings::check(yaml, &cfg);
+    assert!(
+        hits.is_empty(),
+        "backslash line continuations should require quotes"
+    );
+}
+
+#[test]
+fn multiline_flow_tokens_require_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let yaml = "foo: \"{ missing\"\n";
+    let hits = quoted_strings::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unbalanced flow tokens should keep quotes");
+}
+
+#[test]
+fn multiline_backslash_with_crlf_requires_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let yaml = "foo: \"line1\\\r\n  line2\"\n";
+    let hits = quoted_strings::check(yaml, &cfg);
+    assert!(
+        hits.is_empty(),
+        "CRLF backslash continuations should require quotes"
+    );
+}
+
+#[test]
+fn multiline_empty_double_quoted_value_is_handled() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let yaml = "foo: \"\n\"\n";
+    let hits = quoted_strings::check(yaml, &cfg);
+    assert!(hits.is_empty(), "blank multi-line content should not panic");
+}
+
+#[test]
+fn inner_double_quotes_are_preserved() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let yaml = "foo: \"\\\"bar\\\"\"\n";
+    let hits = quoted_strings::check(yaml, &cfg);
+    assert!(hits.is_empty(), "embedded quotes should keep outer quoting");
+}

--- a/tests/yamllint_compat_quoted_strings.rs
+++ b/tests/yamllint_compat_quoted_strings.rs
@@ -1,0 +1,154 @@
+use std::fs;
+
+use tempfile::tempdir;
+
+#[path = "common/compat.rs"]
+mod compat;
+
+use compat::{
+    SCENARIOS, build_ryl_command, build_yamllint_command, capture_with_env,
+    ensure_yamllint_installed,
+};
+
+struct Case<'a> {
+    label: &'a str,
+    config: &'a std::path::Path,
+    file: &'a std::path::Path,
+    exit: i32,
+}
+
+#[test]
+fn quoted_strings_rule_matches_yamllint() {
+    ensure_yamllint_installed();
+
+    let dir = tempdir().unwrap();
+
+    let default_cfg = dir.path().join("default.yaml");
+    fs::write(
+        &default_cfg,
+        "rules:\n  document-start: disable\n  quoted-strings: enable\n",
+    )
+    .unwrap();
+
+    let only_needed_cfg = dir.path().join("only-needed.yaml");
+    fs::write(
+        &only_needed_cfg,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    )
+    .unwrap();
+
+    let extra_required_cfg = dir.path().join("extra-required.yaml");
+    fs::write(
+        &extra_required_cfg,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: false\n    extra-required: ['^http']\n",
+    )
+    .unwrap();
+
+    let extra_allowed_cfg = dir.path().join("extra-allowed.yaml");
+    fs::write(
+        &extra_allowed_cfg,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n    extra-allowed: ['^http']\n",
+    )
+    .unwrap();
+
+    let double_allow_cfg = dir.path().join("double-allow.yaml");
+    fs::write(
+        &double_allow_cfg,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n    allow-quoted-quotes: true\n",
+    )
+    .unwrap();
+
+    let check_keys_cfg = dir.path().join("check-keys.yaml");
+    fs::write(
+        &check_keys_cfg,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n    check-keys: true\n    extra-required: ['[:]']\n",
+    )
+    .unwrap();
+
+    let plain_file = dir.path().join("plain.yaml");
+    fs::write(&plain_file, "foo: bar\n").unwrap();
+
+    let quoted_file = dir.path().join("quoted.yaml");
+    fs::write(&quoted_file, "foo: \"bar\"\n").unwrap();
+
+    let url_file = dir.path().join("urls.yaml");
+    fs::write(&url_file, "- http://example.com\n").unwrap();
+
+    let allowed_url_file = dir.path().join("allowed-url.yaml");
+    fs::write(&allowed_url_file, "foo: \"http://example.com\"\n").unwrap();
+
+    let quoted_quotes_file = dir.path().join("quoted-quotes.yaml");
+    fs::write(&quoted_quotes_file, "foo: 'bar\"baz'\n").unwrap();
+
+    let key_file = dir.path().join("key.yaml");
+    fs::write(&key_file, "foo:bar: baz\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+
+    let cases = [
+        Case {
+            label: "default-plain",
+            config: &default_cfg,
+            file: &plain_file,
+            exit: 1,
+        },
+        Case {
+            label: "only-needed-quoted",
+            config: &only_needed_cfg,
+            file: &quoted_file,
+            exit: 1,
+        },
+        Case {
+            label: "extra-required-url",
+            config: &extra_required_cfg,
+            file: &url_file,
+            exit: 1,
+        },
+        Case {
+            label: "extra-allowed-url",
+            config: &extra_allowed_cfg,
+            file: &allowed_url_file,
+            exit: 0,
+        },
+        Case {
+            label: "double-allow-quotes",
+            config: &double_allow_cfg,
+            file: &quoted_quotes_file,
+            exit: 0,
+        },
+        Case {
+            label: "check-keys",
+            config: &check_keys_cfg,
+            file: &key_file,
+            exit: 1,
+        },
+    ];
+
+    for scenario in SCENARIOS {
+        for case in &cases {
+            let mut ryl_cmd = build_ryl_command(exe, scenario.ryl_format);
+            ryl_cmd.arg("-c").arg(case.config).arg(case.file);
+            let (ryl_code, ryl_msg) = capture_with_env(ryl_cmd, scenario.envs);
+
+            let mut yam_cmd = build_yamllint_command(scenario.yam_format);
+            yam_cmd.arg("-c").arg(case.config).arg(case.file);
+            let (yam_code, yam_msg) = capture_with_env(yam_cmd, scenario.envs);
+
+            assert_eq!(
+                ryl_code, case.exit,
+                "ryl exit mismatch {} ({})",
+                case.label, scenario.label
+            );
+            assert_eq!(
+                yam_code, case.exit,
+                "yamllint exit mismatch {} ({})",
+                case.label, scenario.label
+            );
+            assert_eq!(
+                ryl_msg, yam_msg,
+                "diagnostics mismatch {} ({})",
+                case.label, scenario.label
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Implemented a new linting rule for quoted strings in YAML files.
- Added configuration options for quote type, required quoting, and extra required/allowed patterns.
- Integrated the new rule into the linting process and diagnostics reporting.
- Created comprehensive tests for the quoted strings rule, including validation of configuration options and expected linting behavior.
- Ensured compatibility with existing YAML linting tools by adding tests that compare outputs with yamllint.