### PR TITLE
feat(anchors): implement anchors rule for YAML linting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -665,6 +665,7 @@ fn validate_rule_value(name: &str, value: &YamlOwned) -> Result<(), String> {
             }
 
             match name {
+                "anchors" => validate_anchors_option(key, val)?,
                 "braces" => validate_brace_like_option("braces", key, val)?,
                 "brackets" => validate_brace_like_option("brackets", key, val)?,
                 "document-end" => validate_document_end_option(key, val)?,
@@ -799,6 +800,30 @@ fn validate_brace_like_option(rule: &str, key: &YamlOwned, val: &YamlOwned) -> R
         }),
         other => Err(format!(
             "invalid config: unknown option \"{other}\" for rule \"{rule}\""
+        )),
+    }
+}
+
+fn validate_anchors_option(key: &YamlOwned, val: &YamlOwned) -> Result<(), String> {
+    let Some(name) = key.as_str() else {
+        let key_name = describe_rule_option_key(key);
+        return Err(format!(
+            "invalid config: unknown option \"{key_name}\" for rule \"anchors\""
+        ));
+    };
+
+    match name {
+        "forbid-undeclared-aliases" | "forbid-duplicated-anchors" | "forbid-unused-anchors" => {
+            if val.as_bool().is_some() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "invalid config: option \"{name}\" of \"anchors\" should be bool"
+                ))
+            }
+        }
+        other => Err(format!(
+            "invalid config: unknown option \"{other}\" for rule \"anchors\""
         )),
     }
 }

--- a/src/rules/anchors.rs
+++ b/src/rules/anchors.rs
@@ -1,0 +1,496 @@
+use std::collections::HashMap;
+
+use crate::config::YamlLintConfig;
+
+pub const ID: &str = "anchors";
+pub const MESSAGE_UNDECLARED_ALIAS: &str = "found undeclared alias";
+pub const MESSAGE_DUPLICATED_ANCHOR: &str = "found duplicated anchor";
+pub const MESSAGE_UNUSED_ANCHOR: &str = "found unused anchor";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Config {
+    forbid_undeclared_aliases: bool,
+    forbid_duplicated_anchors: bool,
+    forbid_unused_anchors: bool,
+}
+
+impl Config {
+    #[must_use]
+    pub fn resolve(cfg: &YamlLintConfig) -> Self {
+        let forbid_undeclared_aliases = cfg
+            .rule_option(ID, "forbid-undeclared-aliases")
+            .and_then(saphyr::YamlOwned::as_bool)
+            .unwrap_or(true);
+        let forbid_duplicated_anchors = cfg
+            .rule_option(ID, "forbid-duplicated-anchors")
+            .and_then(saphyr::YamlOwned::as_bool)
+            .unwrap_or(false);
+        let forbid_unused_anchors = cfg
+            .rule_option(ID, "forbid-unused-anchors")
+            .and_then(saphyr::YamlOwned::as_bool)
+            .unwrap_or(false);
+
+        Self {
+            forbid_undeclared_aliases,
+            forbid_duplicated_anchors,
+            forbid_unused_anchors,
+        }
+    }
+
+    #[must_use]
+    pub const fn new_for_tests(
+        forbid_undeclared_aliases: bool,
+        forbid_duplicated_anchors: bool,
+        forbid_unused_anchors: bool,
+    ) -> Self {
+        Self {
+            forbid_undeclared_aliases,
+            forbid_duplicated_anchors,
+            forbid_unused_anchors,
+        }
+    }
+
+    #[must_use]
+    pub const fn forbid_undeclared_aliases(&self) -> bool {
+        self.forbid_undeclared_aliases
+    }
+
+    #[must_use]
+    pub const fn forbid_duplicated_anchors(&self) -> bool {
+        self.forbid_duplicated_anchors
+    }
+
+    #[must_use]
+    pub const fn forbid_unused_anchors(&self) -> bool {
+        self.forbid_unused_anchors
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+#[must_use]
+pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
+    let mut analyzer = Analyzer::new(buffer, cfg);
+    analyzer.run();
+    analyzer.into_violations()
+}
+
+struct Analyzer<'cfg, 'src> {
+    source: &'src str,
+    cfg: &'cfg Config,
+    doc: DocState,
+    block_state: Option<BlockState>,
+    in_single_quote: bool,
+    in_double_quote: bool,
+    violations: Vec<Violation>,
+}
+
+impl<'cfg, 'src> Analyzer<'cfg, 'src> {
+    fn new(source: &'src str, cfg: &'cfg Config) -> Self {
+        Self {
+            source,
+            cfg,
+            doc: DocState::new(),
+            block_state: None,
+            in_single_quote: false,
+            in_double_quote: false,
+            violations: Vec::new(),
+        }
+    }
+
+    fn run(&mut self) {
+        if self.source.is_empty() {
+            return;
+        }
+
+        let mut line_start = 0usize;
+        let mut line_number = 1usize;
+        while line_start <= self.source.len() {
+            let line_end = match self.source[line_start..].find('\n') {
+                Some(rel) => line_start + rel + 1,
+                None => self.source.len(),
+            };
+            let mut line = &self.source[line_start..line_end];
+            if line.ends_with('\n') {
+                line = &line[..line.len() - 1];
+            }
+            if line.ends_with('\r') {
+                line = &line[..line.len() - 1];
+            }
+            self.process_line(line, line_number);
+            if line_end == self.source.len() {
+                break;
+            }
+            line_start = line_end;
+            line_number += 1;
+        }
+
+        self.finish_doc();
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn process_line(&mut self, line: &str, line_number: usize) {
+        let chars: Vec<char> = line.chars().collect();
+        let indent_count = chars
+            .iter()
+            .take_while(|ch| matches!(ch, ' ' | '\t'))
+            .count();
+
+        if self.handle_block_state(indent_count, line) {
+            return;
+        }
+
+        if chars.is_empty() {
+            return;
+        }
+
+        let skip_until = if self.detect_doc_boundary(&chars, indent_count) {
+            (indent_count + 3).min(chars.len())
+        } else {
+            0usize
+        };
+
+        let mut idx = 0usize;
+        let mut column = 1usize;
+        let mut comment_active = false;
+
+        while idx < chars.len() {
+            if idx < skip_until {
+                idx += 1;
+                column += 1;
+                continue;
+            }
+
+            let ch = chars[idx];
+            if comment_active {
+                break;
+            }
+
+            if self.in_single_quote {
+                if ch == '\'' {
+                    if idx + 1 < chars.len() && chars[idx + 1] == '\'' {
+                        idx += 2;
+                        column += 2;
+                    } else {
+                        self.in_single_quote = false;
+                        idx += 1;
+                        column += 1;
+                    }
+                } else {
+                    idx += 1;
+                    column += 1;
+                }
+                continue;
+            }
+
+            if self.in_double_quote {
+                if ch == '"' {
+                    let escaped = idx > 0 && chars[idx - 1] == '\\';
+                    if !escaped {
+                        self.in_double_quote = false;
+                    }
+                }
+                idx += 1;
+                column += 1;
+                continue;
+            }
+
+            match ch {
+                '\'' => {
+                    self.in_single_quote = true;
+                    idx += 1;
+                    column += 1;
+                }
+                '"' => {
+                    self.in_double_quote = true;
+                    idx += 1;
+                    column += 1;
+                }
+                '#' => {
+                    comment_active = true;
+                }
+                '|' | '>' => {
+                    if self.is_block_indicator(&chars, idx, indent_count) {
+                        let explicit = parse_explicit_indent(&chars, idx + 1);
+                        self.block_state = Some(BlockState {
+                            indent_base: indent_count,
+                            explicit_indent: explicit,
+                            required_indent: None,
+                            activate_next_line: true,
+                            active: false,
+                        });
+                    }
+                    idx += 1;
+                    column += 1;
+                }
+                '&' => {
+                    if let Some((anchor_name, len)) = parse_name(&chars, idx + 1) {
+                        self.register_anchor(&anchor_name, line_number, column);
+                        idx += len + 1;
+                        column += len + 1;
+                    } else {
+                        idx += 1;
+                        column += 1;
+                    }
+                }
+                '*' => {
+                    if let Some((alias_name, len)) = parse_name(&chars, idx + 1) {
+                        self.register_alias(&alias_name, line_number, column);
+                        idx += len + 1;
+                        column += len + 1;
+                    } else {
+                        idx += 1;
+                        column += 1;
+                    }
+                }
+                _ => {
+                    idx += 1;
+                    column += 1;
+                }
+            }
+        }
+    }
+
+    fn handle_block_state(&mut self, indent_count: usize, line: &str) -> bool {
+        if let Some(block) = self.block_state.as_mut() {
+            if block.activate_next_line {
+                block.activate_next_line = false;
+                block.active = true;
+                if line.trim().is_empty() {
+                    return true;
+                }
+            }
+
+            if line.trim().is_empty() {
+                return true;
+            }
+            let explicit_indent = block.explicit_indent.map(|value| block.indent_base + value);
+            let required_indent = match (explicit_indent, block.required_indent) {
+                (Some(explicit), _) => explicit,
+                (None, Some(required)) => required,
+                (None, None) => {
+                    if indent_count > block.indent_base {
+                        block.required_indent = Some(indent_count);
+                        indent_count
+                    } else {
+                        self.block_state = None;
+                        return false;
+                    }
+                }
+            };
+            let stays_in_block = indent_count >= required_indent;
+            if !stays_in_block {
+                self.block_state = None;
+            }
+            return stays_in_block;
+        }
+        false
+    }
+
+    fn detect_doc_boundary(&mut self, chars: &[char], indent_count: usize) -> bool {
+        if self.in_single_quote || self.in_double_quote {
+            return false;
+        }
+        if chars.len() < indent_count + 3 {
+            return false;
+        }
+
+        let candidate = &chars[indent_count..];
+        let marker = &candidate[..3];
+        let is_boundary_marker = matches!(marker, ['-', '-', '-'] | ['.', '.', '.']);
+        if is_boundary_marker
+            && (candidate.len() == 3 || candidate.get(3).is_some_and(|ch| ch.is_whitespace()))
+        {
+            self.finish_doc();
+            self.reset_block_and_quotes();
+            return true;
+        }
+        false
+    }
+
+    const fn reset_block_and_quotes(&mut self) {
+        self.block_state = None;
+        self.in_single_quote = false;
+        self.in_double_quote = false;
+    }
+
+    fn register_anchor(&mut self, name: &str, line: usize, column: usize) {
+        let is_duplicate = self.doc.add_anchor(name.to_string(), line, column);
+        if self.cfg.forbid_duplicated_anchors() && is_duplicate {
+            self.violations.push(Violation {
+                line,
+                column,
+                message: format!("{MESSAGE_DUPLICATED_ANCHOR} \"{name}\""),
+            });
+        }
+    }
+
+    fn register_alias(&mut self, name: &str, line: usize, column: usize) {
+        if self.doc.mark_alias(name) {
+            return;
+        }
+        if self.cfg.forbid_undeclared_aliases() {
+            self.violations.push(Violation {
+                line,
+                column,
+                message: format!("{MESSAGE_UNDECLARED_ALIAS} \"{name}\""),
+            });
+        }
+    }
+
+    fn finish_doc(&mut self) {
+        if self.cfg.forbid_unused_anchors() {
+            for anchor in &self.doc.anchors {
+                if !anchor.used {
+                    self.violations.push(Violation {
+                        line: anchor.line,
+                        column: anchor.column,
+                        message: format!("{MESSAGE_UNUSED_ANCHOR} \"{}\"", anchor.name),
+                    });
+                }
+            }
+        }
+        self.doc = DocState::new();
+    }
+
+    fn into_violations(self) -> Vec<Violation> {
+        self.violations
+    }
+
+    fn is_block_indicator(&self, chars: &[char], idx: usize, indent_count: usize) -> bool {
+        debug_assert!(!self.in_single_quote && !self.in_double_quote);
+        debug_assert!(idx >= indent_count);
+        let prefix = &chars[..idx];
+        let last_non_ws = prefix.iter().rev().find(|ch| !ch.is_whitespace());
+        matches!(last_non_ws, None | Some(':' | '-' | '?'))
+    }
+}
+
+struct DocState {
+    anchors: Vec<AnchorRecord>,
+    name_to_indices: HashMap<String, Vec<usize>>,
+}
+
+impl DocState {
+    fn new() -> Self {
+        Self {
+            anchors: Vec::new(),
+            name_to_indices: HashMap::new(),
+        }
+    }
+
+    fn add_anchor(&mut self, name: String, line: usize, column: usize) -> bool {
+        let entry_indices = self.name_to_indices.entry(name.clone()).or_default();
+        let duplicate = !entry_indices.is_empty();
+        let index = self.anchors.len();
+        entry_indices.push(index);
+        self.anchors.push(AnchorRecord {
+            name,
+            line,
+            column,
+            used: false,
+        });
+        duplicate
+    }
+
+    fn mark_alias(&mut self, name: &str) -> bool {
+        let Some(indices) = self.name_to_indices.get(name) else {
+            return false;
+        };
+        let last_index = *indices
+            .last()
+            .expect("anchor indices should contain at least one entry");
+        let anchor = self
+            .anchors
+            .get_mut(last_index)
+            .expect("anchor record must exist for referenced name");
+        anchor.used = true;
+        true
+    }
+}
+
+struct AnchorRecord {
+    name: String,
+    line: usize,
+    column: usize,
+    used: bool,
+}
+
+struct BlockState {
+    indent_base: usize,
+    explicit_indent: Option<usize>,
+    required_indent: Option<usize>,
+    activate_next_line: bool,
+    active: bool,
+}
+
+fn parse_name(chars: &[char], start: usize) -> Option<(String, usize)> {
+    if start >= chars.len() {
+        return None;
+    }
+    let mut idx = start;
+    while idx < chars.len() && is_name_char(chars[idx]) {
+        idx += 1;
+    }
+    if idx == start {
+        return None;
+    }
+    let name: String = chars[start..idx].iter().collect();
+    Some((name, idx - start))
+}
+
+const fn is_name_char(ch: char) -> bool {
+    !matches!(
+        ch,
+        ' ' | '\t'
+            | '\r'
+            | '\n'
+            | ','
+            | '['
+            | ']'
+            | '{'
+            | '}'
+            | '*'
+            | '&'
+            | '#'
+            | '!'
+            | '|'
+            | '>'
+            | '\''
+            | '"'
+            | '%'
+            | '@'
+            | ':'
+            | '?'
+    )
+}
+
+fn parse_explicit_indent(chars: &[char], mut idx: usize) -> Option<usize> {
+    let mut indent = None;
+    while idx < chars.len() {
+        match chars[idx] {
+            '+' | '-' => idx += 1,
+            ch if ch.is_ascii_digit() => {
+                let mut val = 0usize;
+                while idx < chars.len() && chars[idx].is_ascii_digit() {
+                    val = val
+                        .saturating_mul(10)
+                        .saturating_add((chars[idx] as u8 - b'0') as usize);
+                    idx += 1;
+                }
+                if val > 0 {
+                    indent = Some(val);
+                }
+                break;
+            }
+            ' ' | '\t' => idx += 1,
+            _ => break,
+        }
+    }
+    indent
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,3 +1,4 @@
+pub mod anchors;
 pub mod braces;
 pub mod brackets;
 pub mod colons;

--- a/tests/cli_anchors_rule.rs
+++ b/tests/cli_anchors_rule.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn anchors_reports_error() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("invalid.yaml");
+    fs::write(&file, "---\n- *missing\n- &missing value\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("found undeclared alias \"missing\""),
+        "missing message: {output}"
+    );
+    assert!(
+        output.contains("anchors"),
+        "rule id missing from output: {output}"
+    );
+}
+
+#[test]
+fn warning_level_does_not_fail() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("warn.yaml");
+    fs::write(&file, "---\n- *missing\n- &missing value\n").unwrap();
+    let config = dir.path().join("config.yml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  anchors:\n    level: warning\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "warnings should not fail: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("warning"),
+        "expected warning output: {output}"
+    );
+}
+
+#[test]
+fn duplicate_anchor_reports_error_when_enabled() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("dupe.yaml");
+    fs::write(&file, "---\n- &anchor one\n- &anchor two\n").unwrap();
+    let config = dir.path().join("config.yml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  anchors:\n    forbid-duplicated-anchors: true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("found duplicated anchor \"anchor\""),
+        "missing duplicate message: {output}"
+    );
+}
+
+#[test]
+fn unused_anchor_reports_error_when_enabled() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("unused.yaml");
+    fs::write(&file, "---\n- &anchor value\n- 1\n").unwrap();
+    let config = dir.path().join("config.yml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  anchors:\n    forbid-unused-anchors: true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("found unused anchor \"anchor\""),
+        "missing unused message: {output}"
+    );
+}
+
+#[test]
+fn rule_ignore_skips_file() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ignored.yaml");
+    fs::write(&file, "---\n- *missing\n").unwrap();
+    let config = dir.path().join("config.yml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  anchors:\n    ignore:\n      - ignored.yaml\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "ignored file should pass: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+}

--- a/tests/config_anchors.rs
+++ b/tests/config_anchors.rs
@@ -1,0 +1,84 @@
+use ryl::config::{Overrides, discover_config};
+
+#[test]
+fn anchors_allows_boolean_options() {
+    let cfg = r#"
+rules:
+  anchors:
+    forbid-undeclared-aliases: false
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+"#;
+
+    let ctx = discover_config(
+        &[],
+        &Overrides {
+            config_file: None,
+            config_data: Some(cfg.into()),
+        },
+    )
+    .expect("parse");
+
+    assert!(ctx.config.rule_names().iter().any(|r| r == "anchors"));
+}
+
+#[test]
+fn anchors_rejects_non_bool_option() {
+    let cfg = r#"
+rules:
+  anchors:
+    forbid-duplicated-anchors: "yes"
+"#;
+
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: None,
+            config_data: Some(cfg.into()),
+        },
+    )
+    .expect_err("invalid value");
+
+    assert!(err.contains("forbid-duplicated-anchors"));
+}
+
+#[test]
+fn anchors_rejects_unknown_option() {
+    let cfg = r#"
+rules:
+  anchors:
+    unknown: true
+"#;
+
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: None,
+            config_data: Some(cfg.into()),
+        },
+    )
+    .expect_err("unknown option");
+
+    assert!(err.contains("unknown option \"unknown\" for rule \"anchors\""));
+}
+
+#[test]
+fn anchors_rejects_non_string_option_key() {
+    let cfg = r#"
+rules:
+  anchors:
+    ? [1, 2]
+    : true
+"#;
+
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: None,
+            config_data: Some(cfg.into()),
+        },
+    )
+    .expect_err("non-string key");
+
+    assert!(err.contains("unknown option") && err.contains("anchors"));
+}

--- a/tests/config_merge.rs
+++ b/tests/config_merge.rs
@@ -8,7 +8,7 @@ fn rules_merge_deep_and_replace_scalars() {
 extends: default
 rules:
   anchors:
-    style: custom
+    forbid-duplicated-anchors: true
   comments:
     min-spaces-from-content: 1
     level: error

--- a/tests/config_rules_non_string_keys.rs
+++ b/tests/config_rules_non_string_keys.rs
@@ -8,7 +8,7 @@ fn rules_with_non_string_key_are_skipped() {
 rules:
   ? [1, 2]
   : { level: warning }
-  anchors: { style: custom }
+  anchors: { forbid-undeclared-aliases: false }
 "#;
     let ctx = discover_config(
         &[],

--- a/tests/rule_anchors.rs
+++ b/tests/rule_anchors.rs
@@ -1,0 +1,427 @@
+use ryl::rules::anchors::{
+    self, Config, MESSAGE_DUPLICATED_ANCHOR, MESSAGE_UNDECLARED_ALIAS, MESSAGE_UNUSED_ANCHOR,
+    Violation,
+};
+
+fn violation(line: usize, column: usize, message: &str) -> Violation {
+    Violation {
+        line,
+        column,
+        message: message.to_string(),
+    }
+}
+
+#[test]
+fn empty_input_produces_no_diagnostics() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let hits = anchors::check("", &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn handles_windows_line_endings() {
+    let cfg = Config::new_for_tests(true, false, false);
+    let yaml = "---\r\n- &anchor value\r\n- *anchor\r\n";
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn invalid_anchor_token_is_ignored() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = "---\n- & value\n- *missing\n";
+    let hits = anchors::check(yaml, &cfg);
+    assert_eq!(
+        hits,
+        vec![violation(
+            3,
+            3,
+            &format!(r#"{MESSAGE_UNDECLARED_ALIAS} "missing""#)
+        )]
+    );
+}
+
+#[test]
+fn allows_valid_usage() {
+    let cfg = Config::new_for_tests(true, false, false);
+    let yaml = "---\n- &anchor value\n- *anchor\n";
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn reports_undeclared_alias() {
+    let cfg = Config::new_for_tests(true, false, false);
+    let yaml = "---\n- *anchor\n- &anchor value\n";
+    let hits = anchors::check(yaml, &cfg);
+    assert_eq!(
+        hits,
+        vec![violation(
+            2,
+            3,
+            &format!(r#"{MESSAGE_UNDECLARED_ALIAS} "anchor""#)
+        )]
+    );
+}
+
+#[test]
+fn allows_forward_alias_when_disabled() {
+    let cfg = Config::new_for_tests(false, false, false);
+    let yaml = "---\n- *anchor\n- &anchor value\n";
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn reports_duplicate_anchor_when_enabled() {
+    let cfg = Config::new_for_tests(false, true, false);
+    let yaml = "---\n- &anchor first\n- &anchor second\n- *anchor\n";
+    let hits = anchors::check(yaml, &cfg);
+    assert_eq!(
+        hits,
+        vec![violation(
+            3,
+            3,
+            &format!(r#"{MESSAGE_DUPLICATED_ANCHOR} "anchor""#)
+        )]
+    );
+}
+
+#[test]
+fn reports_unused_anchor() {
+    let cfg = Config::new_for_tests(false, false, true);
+    let yaml = "---\n- &anchor value\n- 42\n";
+    let hits = anchors::check(yaml, &cfg);
+    assert_eq!(
+        hits,
+        vec![violation(
+            2,
+            3,
+            &format!(r#"{MESSAGE_UNUSED_ANCHOR} "anchor""#)
+        )]
+    );
+}
+
+#[test]
+fn resets_state_between_documents() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "---\n",
+        "- &anchor first\n",
+        "- *anchor\n",
+        "...\n",
+        "---\n",
+        "- &anchor second\n",
+        "- 1\n"
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert_eq!(
+        hits,
+        vec![violation(
+            6,
+            3,
+            &format!(r#"{MESSAGE_UNUSED_ANCHOR} "anchor""#)
+        )]
+    );
+}
+
+#[test]
+fn ignores_ampersand_in_strings_and_block_scalars() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "key: \"value &not\"\n",
+        "quote: '&still not'\n",
+        "literal: |\n",
+        "  line with &amp\n",
+        "folded: >\n",
+        "  still not &anchor\n",
+        "- &real anchor\n",
+        "- *real\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_scalar_activation_and_release() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "block: |\n",
+        "\n",
+        "  &ignored anchor\n",
+        "  still inside block\n",
+        "next: 1\n",
+        "- &real anchor\n",
+        "- *real\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_scalar_with_explicit_indent_and_chomping() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "literal: |+2\n",
+        "    &ignored anchor\n",
+        "    content\n",
+        "folded: |-\n",
+        "  &alsoignored anchor\n",
+        "after: value\n",
+        "- &real anchor\n",
+        "- *real\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn doc_boundary_inside_quotes_ignored() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!("---\n", "'---': &anchor value\n", "- *anchor\n",);
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn single_and_double_quote_handling() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "---\n",
+        "- \"escaped \\\" quote\"\n",
+        "- 'it''s fine'\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn comment_stops_scanning() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "---\n",
+        "- &anchor value # comment with *alias\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn blank_lines_are_ignored() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!("---\n", "\n", "\n", "- &anchor value\n", "- *anchor\n",);
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_scalar_allows_blank_lines_within_content() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "block: |\n",
+        "  first\n",
+        "\n",
+        "  second\n",
+        "after: value\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn nested_block_scalar_handles_outdent() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "outer:\n",
+        "  inner: |\n",
+        "    line\n",
+        "\n",
+        "  next: value\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_scalar_with_zero_indent_indicator() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "literal: |0\n",
+        "text\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn pipe_in_flow_is_not_block_indicator() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!("---\n", "- [|, &anchor value]\n", "- *anchor\n",);
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn alias_token_without_name_is_ignored() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!("---\n", "- *\n", "- &anchor value\n", "- *anchor\n",);
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_indicator_with_unexpected_suffix_is_not_special() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "value: |x\n",
+        "  text\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_indicator_with_spaces_before_indent_value() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "value: |  2\n",
+        "    text\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_scalar_dedent_releases_state_immediately() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "block: |\n",
+        "  inside\n",
+        "outdent: &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_scalar_without_indented_content_releases_state() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!("block: |\n", "value\n", "- &anchor value\n", "- *anchor\n",);
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn doc_boundary_with_leading_whitespace() {
+    let cfg = Config::new_for_tests(false, false, false);
+    let yaml = concat!(
+        "  ---\n",
+        "- &anchor value\n",
+        "  ...\n",
+        "---\n",
+        "- &other value\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn doc_boundary_with_trailing_whitespace_resets_state() {
+    let cfg = Config::new_for_tests(false, false, false);
+    let yaml = concat!(
+        "---   \n",
+        "- &anchor value\n",
+        "...   \n",
+        "---   \n",
+        "- &other value\n",
+        "- *other\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn doc_boundary_with_comment_is_detected() {
+    let cfg = Config::new_for_tests(false, false, false);
+    let yaml = concat!(
+        "- &anchor value\n",
+        "- *anchor\n",
+        "--- # next document\n",
+        "- &other value\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn partial_doc_marker_is_ignored() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!("--\n", "- &anchor value\n", "- *anchor\n",);
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn doc_boundary_detects_plain_markers() {
+    let cfg = Config::new_for_tests(false, false, false);
+    let yaml = concat!(
+        "---\n",
+        "- &anchor value\n",
+        "...\n",
+        "---\n",
+        "- &other value\n",
+        "- *other\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn doc_boundary_ignored_inside_multiline_single_quote() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "'value\n",
+        "---\n",
+        "line'\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn doc_start_marker_mid_stream_resets_state() {
+    let cfg = Config::new_for_tests(true, false, false);
+    let yaml = concat!("key: value\n", "---\n", "- &anchor value\n", "- *anchor\n",);
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}
+
+#[test]
+fn block_inconsistent_indent_clears_state() {
+    let cfg = Config::new_for_tests(true, true, true);
+    let yaml = concat!(
+        "block: |\n",
+        "    first\n",
+        "   second\n",
+        "- &anchor value\n",
+        "- *anchor\n",
+    );
+    let hits = anchors::check(yaml, &cfg);
+    assert!(hits.is_empty(), "unexpected diagnostics: {hits:?}");
+}

--- a/tests/yamllint_compat_anchors.rs
+++ b/tests/yamllint_compat_anchors.rs
@@ -1,0 +1,199 @@
+use std::fs;
+
+use tempfile::tempdir;
+
+#[path = "common/compat.rs"]
+mod compat;
+
+use compat::{
+    SCENARIOS, build_ryl_command, build_yamllint_command, capture_with_env,
+    ensure_yamllint_installed,
+};
+
+#[test]
+fn anchors_rule_matches_yamllint() {
+    ensure_yamllint_installed();
+
+    let dir = tempdir().unwrap();
+
+    let default_cfg = dir.path().join("anchors-default.yml");
+    fs::write(
+        &default_cfg,
+        "rules:\n  document-start: disable\n  anchors: enable\n",
+    )
+    .unwrap();
+
+    let allow_forward_cfg = dir.path().join("anchors-allow-forward.yml");
+    fs::write(
+        &allow_forward_cfg,
+        "rules:\n  document-start: disable\n  anchors:\n    forbid-undeclared-aliases: false\n",
+    )
+    .unwrap();
+
+    let duplicates_cfg = dir.path().join("anchors-duplicates.yml");
+    fs::write(
+        &duplicates_cfg,
+        "rules:\n  document-start: disable\n  anchors:\n    forbid-undeclared-aliases: false\n    forbid-duplicated-anchors: true\n",
+    )
+    .unwrap();
+
+    let unused_cfg = dir.path().join("anchors-unused.yml");
+    fs::write(
+        &unused_cfg,
+        "rules:\n  document-start: disable\n  anchors:\n    forbid-unused-anchors: true\n",
+    )
+    .unwrap();
+
+    let valid_file = dir.path().join("valid.yaml");
+    fs::write(&valid_file, "---\n- &anchor value\n- *anchor\n").unwrap();
+
+    let undeclared_file = dir.path().join("undeclared.yaml");
+    fs::write(&undeclared_file, "---\n- *missing\n- &missing value\n").unwrap();
+
+    let duplicate_file = dir.path().join("duplicate.yaml");
+    fs::write(&duplicate_file, "---\n- &anchor one\n- &anchor two\n").unwrap();
+
+    let unused_file = dir.path().join("unused.yaml");
+    fs::write(&unused_file, "---\n- &anchor value\n- 1\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+
+    for scenario in SCENARIOS {
+        // Default config: undeclared alias should fail
+        let mut ryl_default = build_ryl_command(exe, scenario.ryl_format);
+        ryl_default
+            .arg("-c")
+            .arg(&default_cfg)
+            .arg(&undeclared_file);
+        let (ryl_default_code, ryl_default_output) = capture_with_env(ryl_default, scenario.envs);
+
+        let mut yam_default = build_yamllint_command(scenario.yam_format);
+        yam_default
+            .arg("-c")
+            .arg(&default_cfg)
+            .arg(&undeclared_file);
+        let (yam_default_code, yam_default_output) = capture_with_env(yam_default, scenario.envs);
+
+        assert_eq!(
+            ryl_default_code, 1,
+            "ryl undeclared exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            yam_default_code, 1,
+            "yamllint undeclared exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            ryl_default_output, yam_default_output,
+            "undeclared diagnostics mismatch ({})",
+            scenario.label
+        );
+
+        // Forward alias allowed when disabled
+        let mut ryl_allow = build_ryl_command(exe, scenario.ryl_format);
+        ryl_allow
+            .arg("-c")
+            .arg(&allow_forward_cfg)
+            .arg(&undeclared_file);
+        let (ryl_allow_code, ryl_allow_output) = capture_with_env(ryl_allow, scenario.envs);
+
+        let mut yam_allow = build_yamllint_command(scenario.yam_format);
+        yam_allow
+            .arg("-c")
+            .arg(&allow_forward_cfg)
+            .arg(&undeclared_file);
+        let (yam_allow_code, yam_allow_output) = capture_with_env(yam_allow, scenario.envs);
+
+        assert_eq!(
+            ryl_allow_code, 0,
+            "ryl allow-forward exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            yam_allow_code, 0,
+            "yamllint allow-forward exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            ryl_allow_output, yam_allow_output,
+            "allow-forward diagnostics mismatch ({})",
+            scenario.label
+        );
+
+        // Duplicate anchors
+        let mut ryl_duplicate = build_ryl_command(exe, scenario.ryl_format);
+        ryl_duplicate
+            .arg("-c")
+            .arg(&duplicates_cfg)
+            .arg(&duplicate_file);
+        let (ryl_duplicate_code, ryl_duplicate_output) =
+            capture_with_env(ryl_duplicate, scenario.envs);
+
+        let mut yam_duplicate = build_yamllint_command(scenario.yam_format);
+        yam_duplicate
+            .arg("-c")
+            .arg(&duplicates_cfg)
+            .arg(&duplicate_file);
+        let (yam_duplicate_code, yam_duplicate_output) =
+            capture_with_env(yam_duplicate, scenario.envs);
+
+        assert_eq!(
+            ryl_duplicate_code, 1,
+            "ryl duplicate exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            yam_duplicate_code, 1,
+            "yamllint duplicate exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            ryl_duplicate_output, yam_duplicate_output,
+            "duplicate diagnostics mismatch ({})",
+            scenario.label
+        );
+
+        // Unused anchors
+        let mut ryl_unused = build_ryl_command(exe, scenario.ryl_format);
+        ryl_unused.arg("-c").arg(&unused_cfg).arg(&unused_file);
+        let (ryl_unused_code, ryl_unused_output) = capture_with_env(ryl_unused, scenario.envs);
+
+        let mut yam_unused = build_yamllint_command(scenario.yam_format);
+        yam_unused.arg("-c").arg(&unused_cfg).arg(&unused_file);
+        let (yam_unused_code, yam_unused_output) = capture_with_env(yam_unused, scenario.envs);
+
+        assert_eq!(ryl_unused_code, 1, "ryl unused exit ({})", scenario.label);
+        assert_eq!(
+            yam_unused_code, 1,
+            "yamllint unused exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            ryl_unused_output, yam_unused_output,
+            "unused diagnostics mismatch ({})",
+            scenario.label
+        );
+
+        // Valid file should pass
+        let mut ryl_valid = build_ryl_command(exe, scenario.ryl_format);
+        ryl_valid.arg("-c").arg(&default_cfg).arg(&valid_file);
+        let (ryl_valid_code, ryl_valid_output) = capture_with_env(ryl_valid, scenario.envs);
+
+        let mut yam_valid = build_yamllint_command(scenario.yam_format);
+        yam_valid.arg("-c").arg(&default_cfg).arg(&valid_file);
+        let (yam_valid_code, yam_valid_output) = capture_with_env(yam_valid, scenario.envs);
+
+        assert_eq!(ryl_valid_code, 0, "ryl valid exit ({})", scenario.label);
+        assert_eq!(
+            yam_valid_code, 0,
+            "yamllint valid exit ({})",
+            scenario.label
+        );
+        assert_eq!(
+            ryl_valid_output, yam_valid_output,
+            "valid diagnostics mismatch ({})",
+            scenario.label
+        );
+    }
+}


### PR DESCRIPTION
- Add a new rule for handling YAML anchors and aliases, including checks for undeclared aliases, duplicated anchors, and unused anchors.
- Introduce configuration options for the anchors rule in `YamlLintConfig`.
- Implement tests for various scenarios including error reporting for undeclared aliases, duplicated anchors, and unused anchors.
- Ensure compatibility with existing YAML linting tools by adding tests that compare outputs with `yamllint`.
- Update the rules module to include the new anchors rule.