### PR TITLE
feat: add decoder module and enhance file encoding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "dirs-next",
- "globset",
+ "encoding_rs",
  "ignore",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ ignore = "0.4.23"
 rayon = "1.11.0"
 saphyr-parser = "0.0.6"
 saphyr = "0.0.6"
-globset = "0.4.16"
 dirs-next = "2.0.0"
 regex = "1"
 unicode-normalization = "0.1"
+encoding_rs = "0.8"
 
 [dev-dependencies]
 semver = "1"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,302 @@
+use std::char;
+use std::env;
+use std::path::Path;
+
+use encoding_rs::Encoding;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Endian {
+    Big,
+    Little,
+}
+
+#[derive(Clone, Copy)]
+enum EncodingKind {
+    Utf8,
+    Utf8WithBom,
+    Utf16 { endian: Endian, skip_bom: bool },
+    Utf32 { endian: Endian, skip_bom: bool },
+    Latin1,
+    Custom(&'static Encoding),
+}
+
+fn normalize_label(label: &str) -> String {
+    label.trim().to_ascii_lowercase().replace('_', "-")
+}
+
+fn decode_error(kind: &str, detail: impl Into<String>) -> String {
+    let detail = detail.into();
+    format!("invalid {kind}: {detail}")
+}
+
+fn parse_override(bytes: &[u8], label: &str) -> Result<EncodingKind, String> {
+    let normalized = normalize_label(label);
+    if normalized.is_empty() {
+        return Err(decode_error(
+            "encoding",
+            "YAMLLINT_FILE_ENCODING cannot be empty",
+        ));
+    }
+    match normalized.as_str() {
+        "utf-8" => Ok(EncodingKind::Utf8),
+        "utf-8-sig" | "utf8-sig" => Ok(EncodingKind::Utf8WithBom),
+        "utf-16" => Ok(EncodingKind::Utf16 {
+            endian: detect_utf16_endian(bytes).unwrap_or(Endian::Little),
+            skip_bom: bytes.starts_with(&[0xFE, 0xFF]) || bytes.starts_with(&[0xFF, 0xFE]),
+        }),
+        "utf-16le" | "utf-16-le" | "utf16le" => Ok(EncodingKind::Utf16 {
+            endian: Endian::Little,
+            skip_bom: false,
+        }),
+        "utf-16be" | "utf-16-be" | "utf16be" => Ok(EncodingKind::Utf16 {
+            endian: Endian::Big,
+            skip_bom: false,
+        }),
+        "utf-32" => Ok(EncodingKind::Utf32 {
+            endian: detect_utf32_endian(bytes).unwrap_or(Endian::Little),
+            skip_bom: bytes.starts_with(&[0x00, 0x00, 0xFE, 0xFF])
+                || bytes.starts_with(&[0xFF, 0xFE, 0x00, 0x00]),
+        }),
+        "utf-32le" | "utf-32-le" | "utf32le" => Ok(EncodingKind::Utf32 {
+            endian: Endian::Little,
+            skip_bom: false,
+        }),
+        "utf-32be" | "utf-32-be" | "utf32be" => Ok(EncodingKind::Utf32 {
+            endian: Endian::Big,
+            skip_bom: false,
+        }),
+        "latin-1" | "latin1" | "iso-8859-1" | "iso8859-1" => Ok(EncodingKind::Latin1),
+        other => Encoding::for_label(other.as_bytes())
+            .map(EncodingKind::Custom)
+            .ok_or_else(|| decode_error("encoding", format!("unsupported label '{label}'"))),
+    }
+}
+
+fn detect_utf16_endian(bytes: &[u8]) -> Option<Endian> {
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        Some(Endian::Big)
+    } else if bytes.starts_with(&[0xFF, 0xFE]) {
+        Some(Endian::Little)
+    } else if bytes.len() >= 2 && bytes[0] == 0x00 {
+        Some(Endian::Big)
+    } else if bytes.len() >= 2 && bytes[1] == 0x00 {
+        Some(Endian::Little)
+    } else {
+        None
+    }
+}
+
+fn detect_utf32_endian(bytes: &[u8]) -> Option<Endian> {
+    if bytes.starts_with(&[0x00, 0x00, 0xFE, 0xFF]) {
+        Some(Endian::Big)
+    } else if bytes.starts_with(&[0xFF, 0xFE, 0x00, 0x00]) {
+        Some(Endian::Little)
+    } else if bytes.len() >= 4 && bytes[0..3] == [0x00, 0x00, 0x00] {
+        Some(Endian::Big)
+    } else if bytes.len() >= 4 && bytes[1..4] == [0x00, 0x00, 0x00] {
+        Some(Endian::Little)
+    } else {
+        None
+    }
+}
+
+fn detect_encoding(bytes: &[u8]) -> Result<EncodingKind, String> {
+    let override_label = env::var("YAMLLINT_FILE_ENCODING").map_or(None, |value| {
+        eprintln!(
+            "YAMLLINT_FILE_ENCODING is meant for temporary workarounds. It may be removed in a future version of yamllint."
+        );
+        Some(value)
+    });
+    detect_encoding_with_override(bytes, override_label.as_deref())
+}
+
+fn detect_encoding_with_override(
+    bytes: &[u8],
+    override_label: Option<&str>,
+) -> Result<EncodingKind, String> {
+    if let Some(label) = override_label {
+        return parse_override(bytes, label);
+    }
+
+    if bytes.starts_with(&[0x00, 0x00, 0xFE, 0xFF]) {
+        return Ok(EncodingKind::Utf32 {
+            endian: Endian::Big,
+            skip_bom: true,
+        });
+    }
+    if bytes.len() >= 4 && bytes[0..3] == [0x00, 0x00, 0x00] {
+        return Ok(EncodingKind::Utf32 {
+            endian: Endian::Big,
+            skip_bom: false,
+        });
+    }
+    if bytes.starts_with(&[0xFF, 0xFE, 0x00, 0x00]) {
+        return Ok(EncodingKind::Utf32 {
+            endian: Endian::Little,
+            skip_bom: true,
+        });
+    }
+    if bytes.len() >= 4 && bytes[1..4] == [0x00, 0x00, 0x00] {
+        return Ok(EncodingKind::Utf32 {
+            endian: Endian::Little,
+            skip_bom: false,
+        });
+    }
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        return Ok(EncodingKind::Utf16 {
+            endian: Endian::Big,
+            skip_bom: true,
+        });
+    }
+    if bytes.len() >= 2 && bytes[0] == 0x00 {
+        return Ok(EncodingKind::Utf16 {
+            endian: Endian::Big,
+            skip_bom: false,
+        });
+    }
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        return Ok(EncodingKind::Utf16 {
+            endian: Endian::Little,
+            skip_bom: true,
+        });
+    }
+    if bytes.len() >= 2 && bytes[1] == 0x00 {
+        return Ok(EncodingKind::Utf16 {
+            endian: Endian::Little,
+            skip_bom: false,
+        });
+    }
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        return Ok(EncodingKind::Utf8WithBom);
+    }
+    Ok(EncodingKind::Utf8)
+}
+
+fn decode_utf8(bytes: &[u8]) -> Result<String, String> {
+    String::from_utf8(bytes.to_vec()).map_err(|err| decode_error("utf-8 data", err.to_string()))
+}
+
+fn decode_utf8_bom(bytes: &[u8]) -> Result<String, String> {
+    let sliced = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(bytes);
+    decode_utf8(sliced)
+}
+
+fn decode_utf16(bytes: &[u8], endian: Endian, skip_bom: bool) -> Result<String, String> {
+    if bytes.is_empty() {
+        return Ok(String::new());
+    }
+    let data = if skip_bom {
+        bytes.get(2..).unwrap_or(&[])
+    } else {
+        bytes
+    };
+    if data.len() % 2 != 0 {
+        return Err(decode_error(
+            "utf-16 data",
+            format!("length {} is not even", data.len()),
+        ));
+    }
+    let mut units: Vec<u16> = Vec::with_capacity(data.len() / 2);
+    for chunk in data.chunks_exact(2) {
+        let value = match endian {
+            Endian::Big => u16::from_be_bytes([chunk[0], chunk[1]]),
+            Endian::Little => u16::from_le_bytes([chunk[0], chunk[1]]),
+        };
+        units.push(value);
+    }
+    String::from_utf16(&units).map_err(|err| decode_error("utf-16 data", err.to_string()))
+}
+
+fn decode_utf32(bytes: &[u8], endian: Endian, skip_bom: bool) -> Result<String, String> {
+    if bytes.is_empty() {
+        return Ok(String::new());
+    }
+    let data = if skip_bom {
+        bytes.get(4..).unwrap_or(&[])
+    } else {
+        bytes
+    };
+    if data.len() % 4 != 0 {
+        return Err(decode_error(
+            "utf-32 data",
+            format!("length {} is not divisible by 4", data.len()),
+        ));
+    }
+    let mut out = String::with_capacity(data.len() / 4);
+    for chunk in data.chunks_exact(4) {
+        let raw = match endian {
+            Endian::Big => u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]),
+            Endian::Little => u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]),
+        };
+        match char::from_u32(raw) {
+            Some(ch) => out.push(ch),
+            None => {
+                return Err(decode_error(
+                    "utf-32 data",
+                    format!("invalid scalar value 0x{raw:08X}"),
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn decode_latin1(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|&b| char::from_u32(u32::from(b)).unwrap())
+        .collect()
+}
+
+fn decode_with_custom(bytes: &[u8], encoding: &'static Encoding) -> Result<String, String> {
+    let (text, _encoding_used, had_errors) = encoding.decode(bytes);
+    if had_errors {
+        return Err(decode_error(
+            encoding.name(),
+            "decode error with replacement required",
+        ));
+    }
+    Ok(text.into_owned())
+}
+
+fn decode_with_kind(bytes: &[u8], encoding: EncodingKind) -> Result<String, String> {
+    match encoding {
+        EncodingKind::Utf8 => decode_utf8(bytes),
+        EncodingKind::Utf8WithBom => decode_utf8_bom(bytes),
+        EncodingKind::Utf16 { endian, skip_bom } => decode_utf16(bytes, endian, skip_bom),
+        EncodingKind::Utf32 { endian, skip_bom } => decode_utf32(bytes, endian, skip_bom),
+        EncodingKind::Latin1 => Ok(decode_latin1(bytes)),
+        EncodingKind::Custom(enc) => decode_with_custom(bytes, enc),
+    }
+}
+
+/// Decode raw bytes using yamllint-compatible encoding detection.
+///
+/// # Errors
+/// Returns an error string describing why decoding failed.
+pub fn decode_bytes(bytes: &[u8]) -> Result<String, String> {
+    let encoding = detect_encoding(bytes)?;
+    decode_with_kind(bytes, encoding)
+}
+
+/// Decode bytes using an explicit encoding override, bypassing environment lookups.
+///
+/// # Errors
+/// Returns an error string when the override label is unsupported or decoding fails.
+pub fn decode_bytes_with_override(
+    bytes: &[u8],
+    override_label: Option<&str>,
+) -> Result<String, String> {
+    let encoding = detect_encoding_with_override(bytes, override_label)?;
+    decode_with_kind(bytes, encoding)
+}
+
+/// Read a file from disk and decode it using yamllint-compatible detection.
+///
+/// # Errors
+/// Returns an error string when the file cannot be read or decoded.
+pub fn read_file(path: &Path) -> Result<String, String> {
+    let data =
+        std::fs::read(path).map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    decode_bytes(&data).map_err(|err| format!("failed to read {}: {err}", path.display()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod cli_support;
 pub mod conf;
 pub mod config;
+pub mod decoder;
 pub mod discover;
 pub mod lint;
 pub mod rules;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,7 +1,7 @@
-use std::fs;
 use std::path::Path;
 
 use crate::config::{RuleLevel, YamlLintConfig};
+use crate::decoder;
 use crate::rules::{
     anchors, braces, brackets, colons, commas, comments, comments_indentation, document_end,
     document_start, empty_lines, empty_values, float_values, hyphens, indentation, key_duplicates,
@@ -59,8 +59,7 @@ pub fn lint_file(
     cfg: &YamlLintConfig,
     base_dir: &Path,
 ) -> Result<Vec<LintProblem>, String> {
-    let content = fs::read_to_string(path)
-        .map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
+    let content = decoder::read_file(path)?;
 
     let mut diagnostics: Vec<LintProblem> = Vec::new();
 

--- a/tests/cli_file_encoding.rs
+++ b/tests/cli_file_encoding.rs
@@ -1,0 +1,201 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn write_utf16le(path: &Path, content: &str) {
+    let mut data = Vec::with_capacity(2 + content.len() * 2);
+    data.extend_from_slice(&[0xFF, 0xFE]);
+    for unit in content.encode_utf16() {
+        let bytes = unit.to_le_bytes();
+        data.extend_from_slice(&bytes);
+    }
+    fs::write(path, data).unwrap();
+}
+
+fn write_latin1(path: &Path, content: &str) {
+    let mut data = Vec::with_capacity(content.len());
+    for ch in content.chars() {
+        let code = ch as u32;
+        assert!(
+            code <= 0xFF,
+            "latin-1 helper only supports code points <= 0xFF"
+        );
+        data.push(code as u8);
+    }
+    fs::write(path, data).unwrap();
+}
+
+fn write_utf32le(path: &Path, content: &str) {
+    let mut data = Vec::with_capacity(4 + content.len() * 4);
+    data.extend_from_slice(&[0xFF, 0xFE, 0x00, 0x00]);
+    for ch in content.chars() {
+        let code = ch as u32;
+        data.extend_from_slice(&code.to_le_bytes());
+    }
+    fs::write(path, data).unwrap();
+}
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("failed to run command");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn cli_reads_utf16_config_file() {
+    let dir = tempdir().unwrap();
+    let cfg_path = dir.path().join("utf16-config.yml");
+    let yaml_path = dir.path().join("bad.yaml");
+
+    write_utf16le(&cfg_path, "rules:\n  truthy: enable\n");
+    fs::write(&yaml_path, "value: Yes\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&cfg_path).arg(&yaml_path));
+    assert_eq!(
+        code, 1,
+        "expected lint failures: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("truthy"),
+        "expected truthy diagnostics in output, got:\n{output}"
+    );
+}
+
+#[test]
+fn cli_reads_utf16_yaml_input() {
+    let dir = tempdir().unwrap();
+    let cfg_path = dir.path().join("config.yml");
+    let yaml_path = dir.path().join("utf16.yaml");
+
+    write_utf16le(&cfg_path, "rules:\n  truthy: enable\n");
+    write_utf16le(&yaml_path, "value: Yes\n");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&cfg_path).arg(&yaml_path));
+    assert_eq!(
+        code, 1,
+        "expected lint failures: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("truthy"),
+        "expected truthy diagnostics in output, got:\n{output}"
+    );
+}
+
+#[test]
+fn cli_honors_yamllint_file_encoding_override() {
+    let dir = tempdir().unwrap();
+    let cfg_path = dir.path().join("latin-config.yml");
+    let yaml_path = dir.path().join("latin.yaml");
+
+    write_latin1(&cfg_path, "rules:\n  truthy: enable\n");
+    write_latin1(&yaml_path, "acción: yes\n");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("YAMLLINT_FILE_ENCODING", "latin-1")
+        .arg("-c")
+        .arg(&cfg_path)
+        .arg(&yaml_path));
+
+    assert_eq!(
+        code, 1,
+        "expected lint failures: stdout={stdout} stderr={stderr}"
+    );
+    let message = if stderr.is_empty() {
+        stdout.clone()
+    } else {
+        stderr.clone()
+    };
+    assert!(
+        message.contains("truthy"),
+        "expected truthy diagnostics in output, got:\n{message}"
+    );
+    assert!(
+        stderr.contains("YAMLLINT_FILE_ENCODING is meant for temporary workarounds"),
+        "expected override warning on stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn cli_override_utf16_variants() {
+    let dir = tempdir().unwrap();
+    let yaml_path = dir.path().join("data.yaml");
+
+    write_utf16le(&yaml_path, "value: Yes\n");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("YAMLLINT_FILE_ENCODING", "UTF_16")
+        .arg("--config-data")
+        .arg("rules:\n  truthy: enable\n")
+        .arg(&yaml_path));
+
+    assert_eq!(
+        code, 1,
+        "expected lint failures: stdout={stdout} stderr={stderr}"
+    );
+    let message = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        message.contains("truthy"),
+        "expected truthy diagnostics, got:\n{message}"
+    );
+}
+
+#[test]
+fn cli_override_utf32_variants() {
+    let dir = tempdir().unwrap();
+    let yaml_path = dir.path().join("utf32.yaml");
+
+    write_utf32le(&yaml_path, "value: Yes\n");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("YAMLLINT_FILE_ENCODING", "utf32le")
+        .arg("--config-data")
+        .arg("rules:\n  truthy: enable\n")
+        .arg(&yaml_path));
+
+    assert_eq!(
+        code, 1,
+        "expected lint failures: stdout={stdout} stderr={stderr}"
+    );
+    let message = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        message.contains("truthy"),
+        "expected truthy diagnostics, got:\n{message}"
+    );
+}
+
+#[test]
+fn cli_override_unknown_label_errors() {
+    let dir = tempdir().unwrap();
+    let cfg_path = dir.path().join("config.yml");
+    let yaml_path = dir.path().join("file.yaml");
+
+    fs::write(&cfg_path, "rules:\n  truthy: enable\n").unwrap();
+    fs::write(&yaml_path, "value: Yes\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("YAMLLINT_FILE_ENCODING", "unsupported-encoding")
+        .arg("-c")
+        .arg(&cfg_path)
+        .arg(&yaml_path));
+
+    assert_eq!(
+        code, 2,
+        "expected usage error: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("unsupported label"),
+        "expected unsupported label error, got:\n{stderr}"
+    );
+}

--- a/tests/cli_yaml_files_negation.rs
+++ b/tests/cli_yaml_files_negation.rs
@@ -1,0 +1,44 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("failed to run command");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn yaml_files_negation_excludes_files_via_cli() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let cfg_path = root.join("config.yml");
+
+    fs::write(
+        &cfg_path,
+        "rules:\n  truthy: enable\nyaml-files: ['*.yaml', '!skip.yaml']\n",
+    )
+    .unwrap();
+    fs::write(root.join("keep.yaml"), "value: Yes\n").unwrap();
+    fs::write(root.join("skip.yaml"), "value: Yes\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&cfg_path).arg(root));
+
+    assert_eq!(
+        code, 1,
+        "expected lint failure: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("keep.yaml"),
+        "expected keep.yaml diagnostics, got:\n{output}"
+    );
+    assert!(
+        !output.contains("skip.yaml"),
+        "unexpected diagnostics for skip.yaml:\n{output}"
+    );
+}

--- a/tests/common/fake_env.rs
+++ b/tests/common/fake_env.rs
@@ -10,6 +10,7 @@ pub struct FakeEnv {
     exists: HashSet<PathBuf>,
     vars: HashMap<String, String>,
     config_dir: Option<PathBuf>,
+    home: Option<PathBuf>,
 }
 
 #[allow(dead_code)]
@@ -45,6 +46,11 @@ impl FakeEnv {
         self.vars.insert(key.into(), value.into());
         self
     }
+
+    pub fn with_home(mut self, path: impl Into<PathBuf>) -> Self {
+        self.home = Some(path.into());
+        self
+    }
 }
 
 impl Env for FakeEnv {
@@ -69,5 +75,12 @@ impl Env for FakeEnv {
 
     fn env_var(&self, key: &str) -> Option<String> {
         self.vars.get(key).cloned()
+    }
+
+    fn home_dir(&self) -> Option<PathBuf> {
+        self.home
+            .clone()
+            .or_else(|| self.vars.get("HOME").map(PathBuf::from))
+            .or_else(|| self.vars.get("USERPROFILE").map(PathBuf::from))
     }
 }

--- a/tests/config_env_missing.rs
+++ b/tests/config_env_missing.rs
@@ -1,4 +1,7 @@
-use ryl::config::{Overrides, discover_config_with_env};
+use std::fs;
+
+use ryl::config::{Env, Overrides, SystemEnv, discover_config_with_env};
+use tempfile::tempdir;
 
 #[test]
 fn env_points_to_missing_file_is_ignored() {
@@ -14,4 +17,43 @@ fn env_points_to_missing_file_is_ignored() {
     // Missing env config falls back to default preset
     assert!(ctx.source.is_none());
     assert!(ctx.config.rule_names().iter().any(|r| r == "anchors"));
+}
+
+#[test]
+fn env_tilde_path_uses_closure_home_dir() {
+    let dir = tempdir().unwrap();
+    let config_path = dir
+        .path()
+        .join(".config")
+        .join("yamllint")
+        .join("custom.yml");
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(&config_path, "rules: {}\n").unwrap();
+
+    let inputs: Vec<std::path::PathBuf> = vec![];
+    let ctx = discover_config_with_env(&inputs, &Overrides::default(), &|k| match k {
+        "YAMLLINT_CONFIG_FILE" => Some("~/.config/yamllint/custom.yml".into()),
+        "HOME" => Some(dir.path().to_str().unwrap().into()),
+        _ => None,
+    })
+    .expect("discover should succeed");
+
+    assert_eq!(ctx.source.as_deref(), Some(config_path.as_path()));
+}
+
+#[test]
+fn env_tilde_path_without_home_falls_back_to_system_home() {
+    let inputs: Vec<std::path::PathBuf> = vec![];
+    let _ = SystemEnv.home_dir();
+    let ctx = discover_config_with_env(&inputs, &Overrides::default(), &|k| {
+        if k == "YAMLLINT_CONFIG_FILE" {
+            Some("~/.config/yamllint/missing.yml".into())
+        } else {
+            None
+        }
+    })
+    .expect("discover should succeed");
+
+    // No config file found; default preset applies.
+    assert!(ctx.source.is_none());
 }

--- a/tests/config_explicit_file_parse_error.rs
+++ b/tests/config_explicit_file_parse_error.rs
@@ -31,6 +31,9 @@ impl ryl::config::Env for FakeEnv {
     fn path_exists(&self, p: &Path) -> bool {
         self.exists.contains(p)
     }
+    fn home_dir(&self) -> Option<PathBuf> {
+        None
+    }
     fn env_var(&self, _key: &str) -> Option<String> {
         None
     }

--- a/tests/config_extended_features.rs
+++ b/tests/config_extended_features.rs
@@ -101,8 +101,9 @@ fn extends_resolves_relative_file_paths() {
     let base = ctx.base_dir.clone();
 
     assert!(
-        ctx.config
-            .is_file_ignored(&td.path().join("base/one.yaml"), &base)
+        !ctx.config
+            .is_file_ignored(&td.path().join("base/one.yaml"), &base),
+        "parent ignore entries should be replaced by child overrides"
     );
     assert!(
         ctx.config

--- a/tests/config_find_project_two_files_in_cwd.rs
+++ b/tests/config_find_project_two_files_in_cwd.rs
@@ -22,6 +22,9 @@ impl ryl::config::Env for FakeEnv {
     fn path_exists(&self, p: &Path) -> bool {
         self.exists.contains(p)
     }
+    fn home_dir(&self) -> Option<PathBuf> {
+        None
+    }
     fn env_var(&self, _key: &str) -> Option<String> {
         None
     }

--- a/tests/config_ignore_overrides.rs
+++ b/tests/config_ignore_overrides.rs
@@ -1,0 +1,83 @@
+use std::path::PathBuf;
+
+use ryl::config::{Overrides, discover_config_with};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::fake_env::FakeEnv;
+
+#[test]
+fn child_ignore_patterns_replace_parent_entries() {
+    let root = PathBuf::from("/workspace");
+    let base_cfg = root.join("base.yml");
+    let child_cfg = root.join("child.yml");
+
+    let env = FakeEnv::new()
+        .with_cwd(root.clone())
+        .with_file(base_cfg.clone(), "rules: {}\nignore: ['parent.yaml']\n")
+        .with_file(
+            child_cfg.clone(),
+            "extends: base.yml\nignore: ['child.yaml']\nrules: {}\n",
+        );
+
+    let ctx = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(child_cfg),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("child config should parse");
+
+    let base_dir = ctx.base_dir.clone();
+    assert!(
+        ctx.config
+            .is_file_ignored(&base_dir.join("child.yaml"), &base_dir),
+        "child.yaml should be ignored by child config"
+    );
+    assert!(
+        !ctx.config
+            .is_file_ignored(&base_dir.join("parent.yaml"), &base_dir),
+        "parent.yaml should not use parent ignore entries"
+    );
+}
+
+#[test]
+fn child_ignore_from_file_replaces_parent_patterns() {
+    let root = PathBuf::from("/workspace");
+    let base_cfg = root.join("base.yml");
+    let child_cfg = root.join("child.yml");
+    let ignore_file = root.join("child.ignore");
+
+    let env = FakeEnv::new()
+        .with_cwd(root.clone())
+        .with_file(base_cfg.clone(), "rules: {}\nignore: ['parent.yaml']\n")
+        .with_file(
+            child_cfg.clone(),
+            "extends: base.yml\nignore-from-file: child.ignore\nrules: {}\n",
+        )
+        .with_file(ignore_file.clone(), "child.yaml\n");
+
+    let ctx = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(child_cfg),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("child config should parse");
+
+    let base_dir = ctx.base_dir.clone();
+    assert!(
+        ctx.config
+            .is_file_ignored(&base_dir.join("child.yaml"), &base_dir),
+        "child.yaml should respect child ignore-from-file entries"
+    );
+    assert!(
+        !ctx.config
+            .is_file_ignored(&base_dir.join("parent.yaml"), &base_dir),
+        "parent ignores should be replaced by child ignore-from-file"
+    );
+}

--- a/tests/config_yaml_files.rs
+++ b/tests/config_yaml_files.rs
@@ -39,3 +39,24 @@ fn yaml_files_invalid_pattern_is_skipped() {
     let base = ctx.base_dir.clone();
     assert!(!ctx.config.is_yaml_candidate(&base.join("file.yaml"), &base));
 }
+
+#[test]
+fn yaml_files_negation_excludes_matches() {
+    let ctx = discover_config(
+        &[],
+        &Overrides {
+            config_file: None,
+            config_data: Some("yaml-files: ['*.yaml', '!skip.yaml']\n".into()),
+        },
+    )
+    .expect("yaml-files with negation should parse");
+    let base = ctx.base_dir.clone();
+    assert!(
+        ctx.config.is_yaml_candidate(&base.join("keep.yaml"), &base),
+        "positive pattern should include keep.yaml"
+    );
+    assert!(
+        !ctx.config.is_yaml_candidate(&base.join("skip.yaml"), &base),
+        "negated pattern should exclude skip.yaml"
+    );
+}

--- a/tests/decoder_decode.rs
+++ b/tests/decoder_decode.rs
@@ -1,0 +1,334 @@
+use std::path::Path;
+
+use ryl::decoder;
+use tempfile::tempdir;
+
+#[test]
+fn decode_utf8_plain() {
+    assert_eq!(decoder::decode_bytes(b"hello").unwrap(), "hello");
+}
+
+#[test]
+fn decode_utf8_invalid_reports_error() {
+    let err = decoder::decode_bytes(&[0x80]).unwrap_err();
+    assert!(
+        err.contains("invalid utf-8 data"),
+        "expected utf-8 error, got: {err}"
+    );
+}
+
+#[test]
+fn decode_utf8_bom_is_stripped() {
+    let data = [0xEF, 0xBB, 0xBF, b'h', b'i'];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf8_sig_without_bom_is_identity() {
+    assert_eq!(
+        decoder::decode_bytes_with_override(b"hi", Some("utf-8-sig")).unwrap(),
+        "hi"
+    );
+}
+
+#[test]
+fn decode_utf16_big_endian_with_bom() {
+    let data = [0xFE, 0xFF, 0x00, b'h', 0x00, b'i'];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf16_little_endian_with_bom() {
+    let data = [0xFF, 0xFE, b'h', 0x00, b'i', 0x00];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf16_big_endian_without_bom() {
+    let data = [0x00, b'h', 0x00, b'i'];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf16_little_endian_without_bom() {
+    let data = [b'h', 0x00, b'i', 0x00];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf16_invalid_length_reports_error() {
+    let err = decoder::decode_bytes(&[0xFF, 0xFE, 0x00]).unwrap_err();
+    assert!(err.contains("invalid utf-16"), "unexpected error: {err}");
+}
+
+#[test]
+fn decode_utf32_big_endian_with_bom() {
+    let data = [
+        0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, b'h', 0x00, 0x00, 0x00, b'i',
+    ];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf32_little_endian_with_bom() {
+    let data = [
+        0xFF, 0xFE, 0x00, 0x00, b'h', 0x00, 0x00, 0x00, b'i', 0x00, 0x00, 0x00,
+    ];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf32_big_endian_without_bom() {
+    let data = [0x00, 0x00, 0x00, b'h', 0x00, 0x00, 0x00, b'i'];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf32_little_endian_without_bom() {
+    let data = [b'h', 0x00, 0x00, 0x00, b'i', 0x00, 0x00, 0x00];
+    assert_eq!(decoder::decode_bytes(&data).unwrap(), "hi");
+}
+
+#[test]
+fn decode_utf32_invalid_length_reports_error() {
+    let data = [0x00, 0x00, 0x00, b'h', 0x00];
+    let err = decoder::decode_bytes(&data).unwrap_err();
+    assert!(err.contains("invalid utf-32"), "unexpected error: {err}");
+}
+
+#[test]
+fn decode_utf32_invalid_scalar_reports_error() {
+    let data = [0x00, 0x00, 0xFE, 0xFF, 0x00, 0x11, 0x00, 0x00];
+    let err = decoder::decode_bytes(&data).unwrap_err();
+    assert!(
+        err.contains("invalid scalar value"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn decode_utf16_invalid_scalar_reports_error() {
+    let err = decoder::decode_bytes_with_override(&[0xD8, 0x00], Some("utf-16be")).unwrap_err();
+    assert!(err.contains("invalid utf-16"));
+}
+
+#[test]
+fn decode_with_override_utf16_variants() {
+    let big = [0xFE, 0xFF, 0x00, b'h', 0x00, b'i'];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&big, Some("utf-16")).unwrap(),
+        "hi"
+    );
+    let big_no_bom = [0x00, b'h', 0x00, b'i'];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&big_no_bom, Some("utf-16")).unwrap(),
+        "hi"
+    );
+    let little_bom = [0xFF, 0xFE, b'h', 0x00];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&little_bom, Some("UTF_16")).unwrap(),
+        "h"
+    );
+    let little = [b'h', 0x00, b'i', 0x00];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&little, Some("utf-16le")).unwrap(),
+        "hi"
+    );
+    let little_no_bom = [b'h', 0x00, b'i', 0x00];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&little_no_bom, Some("utf-16")).unwrap(),
+        "hi"
+    );
+}
+
+#[test]
+fn decode_with_override_utf16_fallbacks_to_little_when_ambiguous() {
+    let bytes = [0x2D, 0x4E, 0x87, 0x65]; // "中文" in little-endian without BOM or zero hints
+    assert_eq!(
+        decoder::decode_bytes_with_override(&bytes, Some("utf-16")).unwrap(),
+        "中文"
+    );
+}
+
+#[test]
+fn decode_with_override_utf32_variants() {
+    let big = [0x00, 0x00, 0x00, b'h', 0x00, 0x00, 0x00, b'i'];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&big, Some("utf-32")).unwrap(),
+        "hi"
+    );
+    let big_bom = [
+        0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, b'h', 0x00, 0x00, 0x00, b'i',
+    ];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&big_bom, Some("utf-32")).unwrap(),
+        "hi"
+    );
+    let little = [b'h', 0x00, 0x00, 0x00, b'i', 0x00, 0x00, 0x00];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&little, Some("utf-32le")).unwrap(),
+        "hi"
+    );
+    assert_eq!(
+        decoder::decode_bytes_with_override(&little, Some("utf-32")).unwrap(),
+        "hi"
+    );
+}
+
+#[test]
+fn decode_with_override_utf32_detects_little_without_bom() {
+    let bytes = [0x2D, 0x4E, 0x00, 0x00, 0x87, 0x65, 0x00, 0x00];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&bytes, Some("utf-32")).unwrap(),
+        "中文"
+    );
+}
+
+#[test]
+fn decode_with_override_utf32_missing_hint_errors() {
+    let err =
+        decoder::decode_bytes_with_override(&[0x01, 0x02, 0x03, 0x04], Some("utf-32")).unwrap_err();
+    assert!(err.contains("utf-32"), "unexpected error: {err}");
+}
+
+#[test]
+fn decode_with_override_utf8_alias() {
+    assert_eq!(
+        decoder::decode_bytes_with_override(b"hi", Some("utf-8")).unwrap(),
+        "hi"
+    );
+}
+
+#[test]
+fn decode_with_override_utf16be_explicit() {
+    let data = [0x00, b'h', 0x00, b'i'];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&data, Some("utf-16be")).unwrap(),
+        "hi"
+    );
+}
+
+#[test]
+fn decode_with_override_utf32be_explicit() {
+    let data = [0x00, 0x00, 0x00, b'h', 0x00, 0x00, 0x00, b'i'];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&data, Some("utf-32be")).unwrap(),
+        "hi"
+    );
+}
+
+#[test]
+fn decode_with_override_latin1_variants() {
+    let bytes = [0xA1, 0x21];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&bytes, Some("latin-1")).unwrap(),
+        "¡!"
+    );
+    let alias = [0xA1];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&alias, Some("ISO_8859_1")).unwrap(),
+        "¡"
+    );
+    assert_eq!(
+        decoder::decode_bytes_with_override(&alias, Some("latin1")).unwrap(),
+        "¡"
+    );
+}
+
+#[test]
+fn decode_with_override_utf8_sig() {
+    let data = [0xEF, 0xBB, 0xBF, b'h'];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&data, Some("utf8-sig")).unwrap(),
+        "h"
+    );
+}
+
+#[test]
+fn decode_with_override_utf16_only_bom() {
+    let data = [0xFF, 0xFE];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&data, Some("utf-16")).unwrap(),
+        ""
+    );
+}
+
+#[test]
+fn decode_with_override_utf32_only_bom() {
+    let data = [0xFF, 0xFE, 0x00, 0x00];
+    assert_eq!(
+        decoder::decode_bytes_with_override(&data, Some("utf-32")).unwrap(),
+        ""
+    );
+}
+
+#[test]
+fn decode_with_override_utf16_empty_input() {
+    assert_eq!(
+        decoder::decode_bytes_with_override(&[], Some("utf-16le")).unwrap(),
+        ""
+    );
+}
+
+#[test]
+fn decode_with_override_utf32_empty_input() {
+    assert_eq!(
+        decoder::decode_bytes_with_override(&[], Some("utf-32le")).unwrap(),
+        ""
+    );
+}
+
+#[test]
+fn decode_with_override_unknown_errors() {
+    let err = decoder::decode_bytes_with_override(b"data", Some("unsupported")).unwrap_err();
+    assert!(err.contains("unsupported label"));
+}
+
+#[test]
+fn decode_with_override_empty_label_errors() {
+    let err = decoder::decode_bytes_with_override(b"data", Some("  ")).unwrap_err();
+    assert!(err.contains("cannot be empty"));
+}
+
+#[test]
+fn decode_with_custom_encoding() {
+    let bytes = b"hello";
+    assert_eq!(
+        decoder::decode_bytes_with_override(bytes, Some("koi8-r")).unwrap(),
+        "hello"
+    );
+    assert_eq!(
+        decoder::decode_bytes_with_override(bytes, Some("KOI8_R")).unwrap(),
+        "hello"
+    );
+}
+
+#[test]
+fn decode_with_custom_encoding_errors() {
+    let err = decoder::decode_bytes_with_override(&[0x82], Some("shift_jis")).unwrap_err();
+    assert!(err.contains("decode error"));
+}
+
+#[test]
+fn read_file_decodes_utf8() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("sample.yml");
+    std::fs::write(&path, "key: value\n").unwrap();
+    let content = decoder::read_file(&path).unwrap();
+    assert!(content.contains("key: value"));
+}
+
+#[test]
+fn read_file_invalid_utf8_errors() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("invalid.yml");
+    std::fs::write(&path, [0xFF]).unwrap();
+    let err = decoder::read_file(&path).unwrap_err();
+    assert!(err.contains("invalid utf-8 data"));
+}
+
+#[test]
+fn read_file_missing_file_errors() {
+    let err = decoder::read_file(Path::new("no_such_decoder_file.yml")).unwrap_err();
+    assert!(err.contains("failed to read"));
+}

--- a/tests/yamllint_compat_yaml_files.rs
+++ b/tests/yamllint_compat_yaml_files.rs
@@ -1,0 +1,79 @@
+use std::fs;
+
+use tempfile::tempdir;
+
+#[path = "common/compat.rs"]
+mod compat;
+
+use compat::{
+    SCENARIOS, build_ryl_command, build_yamllint_command, capture_with_env,
+    ensure_yamllint_installed,
+};
+
+#[test]
+fn yaml_files_patterns_match_yamllint() {
+    ensure_yamllint_installed();
+
+    let dir = tempdir().unwrap();
+    let default_cfg = dir.path().join("yaml-files-default.yml");
+    let negated_cfg = dir.path().join("yaml-files-negated.yml");
+    fs::write(
+        &default_cfg,
+        "rules:\n  document-start: disable\n  truthy: enable\nyaml-files: ['*.yaml']\n",
+    )
+    .unwrap();
+    fs::write(
+        &negated_cfg,
+        "rules:\n  document-start: disable\n  truthy: enable\nyaml-files: ['*.yaml', '!skip.yaml']\n",
+    )
+    .unwrap();
+
+    let keep = dir.path().join("keep.yaml");
+    let skip = dir.path().join("skip.yaml");
+    let other = dir.path().join("note.yml");
+    fs::write(&keep, "value: Yes\n").unwrap();
+    fs::write(&skip, "value: Yes\n").unwrap();
+    fs::write(&other, "value: Yes\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+
+    for scenario in SCENARIOS {
+        let mut ryl_default = build_ryl_command(exe, scenario.ryl_format);
+        ryl_default.arg("-c").arg(&default_cfg).arg(dir.path());
+        let (ryl_default_code, ryl_default_out) = capture_with_env(ryl_default, scenario.envs);
+
+        let mut yam_default = build_yamllint_command(scenario.yam_format);
+        yam_default.arg("-c").arg(&default_cfg).arg(dir.path());
+        let (yam_default_code, yam_default_out) = capture_with_env(yam_default, scenario.envs);
+
+        assert_eq!(
+            ryl_default_code, yam_default_code,
+            "default yaml-files exit mismatch ({})",
+            scenario.label
+        );
+        assert_eq!(
+            ryl_default_out, yam_default_out,
+            "default yaml-files diagnostics mismatch ({})",
+            scenario.label
+        );
+
+        let mut ryl_negated = build_ryl_command(exe, scenario.ryl_format);
+        ryl_negated.arg("-c").arg(&negated_cfg).arg(dir.path());
+        let (ryl_neg_code, ryl_neg_out) = capture_with_env(ryl_negated, scenario.envs);
+
+        let mut yam_negated = build_yamllint_command(scenario.yam_format);
+        yam_negated.arg("-c").arg(&negated_cfg).arg(dir.path());
+        let (yam_neg_code, yam_neg_out) = capture_with_env(yam_negated, scenario.envs);
+
+        assert_eq!(
+            ryl_neg_code, yam_neg_code,
+            "negated yaml-files exit mismatch ({})",
+            scenario.label
+        );
+        assert_eq!(
+            ryl_neg_out, yam_neg_out,
+            "negated yaml-files diagnostics mismatch ({})",
+            scenario.label
+        );
+    }
+}


### PR DESCRIPTION
- Introduced a new `decoder` module for handling various file encodings.
- Updated `lint` module to utilize the new decoder for reading files.
- Added comprehensive tests for decoding different encodings including UTF-8, UTF-16, and UTF-32.
- Implemented tests for CLI to ensure proper handling of different file encodings and configurations.
- Enhanced environment handling in tests to support home directory resolution and tilde expansion.
- Added tests for YAML file patterns and negation to ensure compatibility with existing configurations.
- Improved error handling for invalid encodings and file read operations.