### PR TITLE
Add colored diagnostics test to match yamllint across formats

### DIFF
--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -216,6 +216,26 @@ fn colored_format_omits_rule_suffix_for_syntax_errors() {
 }
 
 #[test]
+fn colored_format_matches_reference_layout() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("layout.yaml");
+    fs::write(&file, "list: [1,2]\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("--format").arg("colored").arg(&file));
+    assert_eq!(code, 1, "colored format should exit 1 when errors occur");
+    assert!(
+        stdout.is_empty(),
+        "colored format diagnostics must print on stderr"
+    );
+    let expected = format!(
+        "\u{001b}[4m{path}\u{001b}[0m\n  \u{001b}[2m1:1\u{001b}[0m       \u{001b}[33mwarning\u{001b}[0m  missing document start \"---\"  \u{001b}[2m(document-start)\u{001b}[0m\n  \u{001b}[2m1:10\u{001b}[0m      \u{001b}[31merror\u{001b}[0m    too few spaces after comma  \u{001b}[2m(commas)\u{001b}[0m\n\n",
+        path = file.display()
+    );
+    assert_eq!(stderr, expected, "colored diagnostic payload mismatch");
+}
+
+#[test]
 fn standard_format_remains_plain_text() {
     let dir = tempdir().unwrap();
     let cfg = disable_doc_start_config(dir.path());

--- a/tests/yamllint_compat_colors.rs
+++ b/tests/yamllint_compat_colors.rs
@@ -1,0 +1,78 @@
+use std::fs;
+
+use tempfile::tempdir;
+
+#[path = "common/compat.rs"]
+mod compat;
+
+use compat::{
+    SCENARIOS, build_ryl_command, build_yamllint_command, capture_with_env,
+    ensure_yamllint_installed,
+};
+
+struct Case {
+    label: &'static str,
+    config_path: Option<std::path::PathBuf>,
+    expected_exit: i32,
+}
+
+#[test]
+fn colored_diagnostics_match_yamllint_across_formats() {
+    ensure_yamllint_installed();
+
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("layout.yaml");
+    fs::write(&file, "list: [1,2]\n").unwrap();
+
+    let warning_cfg = dir.path().join("layout-warning.yml");
+    fs::write(&warning_cfg, "rules:\n  commas:\n    level: warning\n").unwrap();
+
+    let cases = [
+        Case {
+            label: "default-config",
+            config_path: None,
+            expected_exit: 1,
+        },
+        Case {
+            label: "commas-warning",
+            config_path: Some(warning_cfg.clone()),
+            expected_exit: 0,
+        },
+    ];
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+
+    for scenario in SCENARIOS {
+        for case in &cases {
+            let mut ryl_cmd = build_ryl_command(exe, scenario.ryl_format);
+            if let Some(cfg) = &case.config_path {
+                ryl_cmd.arg("-c").arg(cfg);
+            }
+            ryl_cmd.arg(&file);
+            let (ryl_code, ryl_output) = capture_with_env(ryl_cmd, scenario.envs);
+
+            let mut yam_cmd = build_yamllint_command(scenario.yam_format);
+            if let Some(cfg) = &case.config_path {
+                yam_cmd.arg("-c").arg(cfg);
+            }
+            yam_cmd.arg(&file);
+            let (yam_code, yam_output) = capture_with_env(yam_cmd, scenario.envs);
+
+            assert_eq!(
+                ryl_code, case.expected_exit,
+                "ryl exit code mismatch (scenario: {}, case: {})",
+                scenario.label, case.label
+            );
+            assert_eq!(
+                yam_code, case.expected_exit,
+                "yamllint exit code mismatch (scenario: {}, case: {})",
+                scenario.label, case.label
+            );
+            assert_eq!(
+                ryl_output, yam_output,
+                "diagnostic mismatch (scenario: {}, case: {})",
+                scenario.label, case.label
+            );
+        }
+    }
+}


### PR DESCRIPTION
I wanted to confirm the terminal colours match between yamllint and ryl