### PR TITLE
feat: update version to 0.3.0 and add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,10 +269,84 @@ jobs:
           name: wheels-sdist
           path: dist
 
+  create-github-release:
+    name: Create GitHub release
+    needs:
+      - smoke-manylinux
+      - smoke-musllinux
+      - smoke-windows
+      - smoke-macos
+      - sdist
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Create release
+        uses: taiki-e/create-gh-release-action@26b80501670402f1999aff4b934e1574ef2d3705
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-release-binaries:
+    name: Upload release binaries
+    needs: create-github-release
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
+          - runner: ubuntu-22.04
+            target: armv7-unknown-linux-gnueabihf
+          - runner: ubuntu-22.04
+            target: i686-unknown-linux-gnu
+          - runner: ubuntu-22.04
+            target: powerpc64le-unknown-linux-gnu
+          - runner: ubuntu-22.04
+            target: s390x-unknown-linux-gnu
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+          - runner: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - runner: windows-latest
+            target: aarch64-pc-windows-msvc
+          - runner: macos-13
+            target: x86_64-apple-darwin
+          - runner: macos-14
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Upload binaries for ${{ matrix.target }}
+        uses: taiki-e/upload-rust-binary-action@3962470d6e7f1993108411bc3f75a135ec67fc8c
+        with:
+          bin: ryl
+          target: ${{ matrix.target }}
+          locked: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [smoke-manylinux, smoke-musllinux, smoke-windows, smoke-macos, sdist]
+    needs:
+      - smoke-manylinux
+      - smoke-musllinux
+      - smoke-windows
+      - smoke-macos
+      - sdist
+      - upload-release-binaries
     if: >-
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'workflow_dispatch' && inputs.publish == true)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Fast YAML linter written in Rust"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fast YAML linter (Rust) packaged for PyPI"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Updating the release workflow to create binary artifacts for each platform.

At present not code signing Windows or Mac executables... will leave that as a potential future improvement if ryl seems popular enough.