### PR TITLE
Use crates.io trusted publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,8 +405,13 @@ jobs:
           pattern: wheels-*
           merge-multiple: true
           path: dist
+      - name: Authenticate with crates.io (Trusted Publishing)
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec
       - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f
         with:


### PR DESCRIPTION
Forgot to update the release workflow to use trusted publishing