### PR TITLE
Pass GitHub token to dry-run binary upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,6 +315,7 @@ jobs:
           bin: ryl
           target: ${{ matrix.target }}
           locked: true
+          token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: true
       - name: Collect release assets for ${{ matrix.target }}
         shell: bash


### PR DESCRIPTION
Passing a GitHub token to silence a false positive warning