### PR TITLE
fix: require supported npm trusted publishing runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,8 +599,43 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '23'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+      - name: Verify Node and npm versions for Trusted Publishing
+        run: |
+          set -euo pipefail
+          node --version
+          npm --version
+          python - <<'PY'
+          import os
+          import subprocess
+          import sys
+
+          def parse(version: str) -> tuple[int, int, int]:
+              version = version.strip().removeprefix("v")
+              parts = version.split(".")
+              return tuple(int(part) for part in parts[:3])
+
+          node_version = subprocess.check_output(["node", "--version"], text=True).strip()
+          npm_version = subprocess.check_output(["npm", "--version"], text=True).strip()
+          min_node = (22, 14, 0)
+          min_npm = (11, 5, 1)
+
+          if parse(node_version) < min_node:
+              print(
+                  f"Node {node_version} is too old for npm Trusted Publishing; "
+                  f"need >= {'.'.join(map(str, min_node))}.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          if parse(npm_version) < min_npm:
+              print(
+                  f"npm {npm_version} is too old for npm Trusted Publishing; "
+                  f"need >= {'.'.join(map(str, min_npm))}.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
       - name: Read package metadata
         id: package_metadata
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,8 +625,6 @@ jobs:
       - name: Publish to NPM (Trusted Publishing)
         if: steps.npm_exists.outputs.already_published != 'true'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # setup-node expects this for OIDC even if not used directly
 
   finalize-github-release:
     name: Finalize GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,14 +582,62 @@ jobs:
           print-hash: true
           skip-existing: true
 
-  publish-npm:
-    name: Publish to NPM
+  stage_npm_packages:
+    name: Stage npm packages
     runs-on: ubuntu-latest
     needs:
       - draft-github-release
+      - upload-release-binaries
     if: >-
       startsWith(github.ref, 'refs/tags/v') &&
       (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
+    outputs:
+      platform_matrix: ${{ steps.platform_matrix.outputs.value }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          pattern: release-binaries-*
+          merge-multiple: true
+          path: release-assets
+      - name: Build npm package directories
+        run: python3 scripts/build_npm_packages.py --assets-dir release-assets --out-dir dist/npm
+      - name: Compute npm platform matrix
+        id: platform_matrix
+        run: |
+          set -euo pipefail
+          matrix_json="$(python3 - <<'PY'
+          import json
+          with open("npm-platforms.json", "r", encoding="utf-8") as handle:
+              platforms = json.load(handle)["platforms"]
+          matrix = [
+              {"folder_name": platform["folderName"], "package_name": platform["packageName"]}
+              for platform in platforms
+          ]
+          print(json.dumps(matrix, separators=(",", ":")))
+          PY
+          )"
+          echo "value=${matrix_json}" >> "${GITHUB_OUTPUT}"
+      - name: Upload staged npm packages
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: npm-packages
+          path: dist/npm
+
+  publish_npm_platforms:
+    name: Publish npm platform package
+    runs-on: ubuntu-latest
+    needs:
+      - stage_npm_packages
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') &&
+      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.stage_npm_packages.outputs.platform_matrix) }}
     permissions:
       id-token: write
       contents: read
@@ -601,6 +649,10 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: npm-packages
+          path: dist/npm
       - name: Verify Node and npm versions for Trusted Publishing
         run: |
           set -euo pipefail
@@ -640,8 +692,8 @@ jobs:
         id: package_metadata
         run: |
           set -euo pipefail
-          package_name=$(node -p "require('./package.json').name")
-          package_version=$(node -p "require('./package.json').version")
+          package_name=$(node -p "require('./dist/npm/${{ matrix.folder_name }}/package.json').name")
+          package_version=$(node -p "require('./dist/npm/${{ matrix.folder_name }}/package.json').version")
           echo "name=${package_name}" >> "${GITHUB_OUTPUT}"
           echo "version=${package_version}" >> "${GITHUB_OUTPUT}"
       - name: Check if NPM version already exists
@@ -657,16 +709,99 @@ jobs:
           else
             echo "already_published=false" >> "${GITHUB_OUTPUT}"
           fi
-      - name: Publish to NPM (Trusted Publishing)
+      - name: Publish npm platform package (Trusted Publishing)
         if: steps.npm_exists.outputs.already_published != 'true'
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public "./dist/npm/${{ matrix.folder_name }}"
+
+  publish_npm_meta:
+    name: Publish npm meta-package
+    runs-on: ubuntu-latest
+    needs:
+      - stage_npm_packages
+      - publish_npm_platforms
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') &&
+      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: npm-packages
+          path: dist/npm
+      - name: Verify Node and npm versions for Trusted Publishing
+        run: |
+          set -euo pipefail
+          node --version
+          npm --version
+          python - <<'PY'
+          import subprocess
+          import sys
+
+          def parse(version: str) -> tuple[int, int, int]:
+              version = version.strip().removeprefix("v")
+              parts = version.split(".")
+              return tuple(int(part) for part in parts[:3])
+
+          node_version = subprocess.check_output(["node", "--version"], text=True).strip()
+          npm_version = subprocess.check_output(["npm", "--version"], text=True).strip()
+          min_node = (22, 14, 0)
+          min_npm = (11, 5, 1)
+
+          if parse(node_version) < min_node:
+              print(
+                  f"Node {node_version} is too old for npm Trusted Publishing; "
+                  f"need >= {'.'.join(map(str, min_node))}.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          if parse(npm_version) < min_npm:
+              print(
+                  f"npm {npm_version} is too old for npm Trusted Publishing; "
+                  f"need >= {'.'.join(map(str, min_npm))}.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
+      - name: Read package metadata
+        id: package_metadata
+        run: |
+          set -euo pipefail
+          package_name=$(node -p "require('./dist/npm/ryl/package.json').name")
+          package_version=$(node -p "require('./dist/npm/ryl/package.json').version")
+          echo "name=${package_name}" >> "${GITHUB_OUTPUT}"
+          echo "version=${package_version}" >> "${GITHUB_OUTPUT}"
+      - name: Check if NPM version already exists
+        id: npm_exists
+        env:
+          PACKAGE_NAME: ${{ steps.package_metadata.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.package_metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version > /dev/null 2>&1; then
+            echo "already_published=true" >> "${GITHUB_OUTPUT}"
+            echo "NPM package ${PACKAGE_NAME} ${PACKAGE_VERSION} already published; skipping upload."
+          else
+            echo "already_published=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Publish npm meta-package (Trusted Publishing)
+        if: steps.npm_exists.outputs.already_published != 'true'
+        run: npm publish --provenance --access public ./dist/npm/ryl
 
   finalize-github-release:
     name: Finalize GitHub release
     needs:
       - publish-crates
       - publish-pypi
-      - publish-npm
+      - publish_npm_meta
     if: >-
       startsWith(github.ref, 'refs/tags/v') &&
       (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ manual_outputs/benchmarks/
 /bin/ryl.exe
 /bin/ryl-*.tar.gz
 /bin/ryl-*.zip
+
+# Local planning / scratch notes
+/scratch/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -37,24 +37,6 @@ uv tool install ryl
 npm install -g @owenlamont/ryl
 ```
 
-The npm package installs a platform-specific native binary from npm optional
-dependencies rather than downloading release archives at runtime.
-
-Currently supported npm platforms:
-
-- macOS arm64
-- Linux x64 musl
-- Linux arm64 musl
-- Linux armv7 GNU
-- Linux ia32 GNU
-- Linux ppc64le GNU
-- Linux s390x GNU
-- Windows x64 MSVC
-- Windows arm64 MSVC
-
-Intel macOS is not currently published via npm because this repo does not build
-that target in release automation.
-
 ### pip
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ uv tool install ryl
 npm install -g @owenlamont/ryl
 ```
 
+The npm package installs a platform-specific native binary from npm optional
+dependencies rather than downloading release archives at runtime.
+
+Currently supported npm platforms:
+
+- macOS arm64
+- Linux x64 musl
+- Linux arm64 musl
+- Linux armv7 GNU
+- Linux ia32 GNU
+- Linux ppc64le GNU
+- Linux s390x GNU
+- Windows x64 MSVC
+- Windows arm64 MSVC
+
+Intel macOS is not currently published via npm because this repo does not build
+that target in release automation.
+
 ### pip
 
 ```bash

--- a/bin/ryl.js
+++ b/bin/ryl.js
@@ -1,175 +1,74 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
 const path = require('path');
-const https = require('https');
-const os = require('os');
 const { spawnSync } = require('child_process');
 
 const pkg = require('../package.json');
-const version = pkg.version;
+const platforms = require('../npm-platforms.json');
 const binName = process.platform === 'win32' ? 'ryl.exe' : 'ryl';
-
-// Support user-writable cache directory to avoid EACCES in global installs
-function getCacheDir() {
-  if (process.platform === 'win32') {
-    return process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
-  }
-  if (process.platform === 'darwin') {
-    return path.join(os.homedir(), 'Library', 'Caches');
-  }
-  return process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
-}
-
-const rylCacheDir = path.join(getCacheDir(), 'ryl', version);
-const cacheBinPath = path.join(rylCacheDir, binName);
 const localBinPath = path.join(__dirname, binName);
 
-const PLATFORMS = {
-  darwin: {
-    arm64: 'aarch64-apple-darwin'
-  },
-  linux: {
-    x64: 'x86_64-unknown-linux-musl',
-    arm64: 'aarch64-unknown-linux-musl',
-    arm: 'armv7-unknown-linux-gnueabihf',
-    ia32: 'i686-unknown-linux-gnu',
-    ppc64: 'powerpc64le-unknown-linux-gnu',
-    s390x: 's390x-unknown-linux-gnu'
-  },
-  win32: {
-    x64: 'x86_64-pc-windows-msvc',
-    arm64: 'aarch64-pc-windows-msvc'
-  }
-};
-
-function getBinaryName() {
-  const platform = PLATFORMS[process.platform];
-  if (!platform) return null;
-  const target = platform[process.arch];
-  if (!target) return null;
-
-  if (process.platform === 'win32') {
-    return `ryl-${target}.zip`;
-  }
-  return `ryl-${target}.tar.gz`;
-}
-
-function download(url, dest) {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest);
-    https.get(url, (response) => {
-      if (response.statusCode === 302 || response.statusCode === 301) {
-        file.close(() => {
-          fs.unlink(dest, () => {
-            download(response.headers.location, dest).then(resolve).catch(reject);
-          });
-        });
-        return;
-      }
-      if (response.statusCode !== 200) {
-        file.close(() => {
-          fs.unlink(dest, () => {
-            reject(new Error(`Failed to download binary: ${response.statusCode}`));
-          });
-        });
-        return;
-      }
-      response.pipe(file);
-      file.on('finish', () => {
-        file.close();
-        resolve();
-      });
-    }).on('error', (err) => {
-      file.close(() => {
-        fs.unlink(dest, () => reject(err));
-      });
-    });
-  });
-}
-
 async function run() {
-  // 0. Try Environment Variable Override
   if (process.env.RYL_BINARY_PATH) {
     execute(process.env.RYL_BINARY_PATH);
     return;
   }
 
-  // 1. Try Local Bin (for dev/local installs)
-  if (fs.existsSync(localBinPath)) {
+  if (exists(localBinPath)) {
     execute(localBinPath);
     return;
   }
 
-  // 2. Try Cache Bin
-  if (fs.existsSync(cacheBinPath)) {
-    execute(cacheBinPath);
-    return;
+  const platformPackage = resolvePlatformPackage();
+  const platformPackageJson = resolveInstalledPackageJson(platformPackage.packageName);
+  if (!platformPackageJson) {
+    console.error(
+      [
+        `No installed npm platform package matches ${process.platform}/${process.arch}.`,
+        `Expected optional dependency: ${platformPackage.packageName}`,
+        `Try reinstalling ${pkg.name} for this platform.`
+      ].join('\n')
+    );
+    process.exit(1);
   }
 
-  // 3. Install and Execute
-  await install();
-  execute(cacheBinPath);
+  const packageRoot = path.dirname(platformPackageJson);
+  const binaryPath = path.join(packageRoot, 'bin', platformPackage.binaryName);
+  if (!exists(binaryPath)) {
+    console.error(
+      `Installed package ${platformPackage.packageName} is missing binary ${platformPackage.binaryName}.`
+    );
+    process.exit(1);
+  }
+
+  execute(binaryPath);
 }
 
-async function install() {
-  const binaryAsset = getBinaryName();
-  if (!binaryAsset) {
-    console.error(`Unsupported platform/architecture: ${process.platform}/${process.arch}`);
-    process.exit(1);
+function exists(candidatePath) {
+  try {
+    require('fs').accessSync(candidatePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePlatformPackage() {
+  for (const platform of platforms.platforms) {
+    if (platform.os.includes(process.platform) && platform.cpu.includes(process.arch)) {
+      return platform;
+    }
   }
 
-  // Ensure cache directory exists
+  console.error(`Unsupported platform/architecture: ${process.platform}/${process.arch}`);
+  process.exit(1);
+}
+
+function resolveInstalledPackageJson(packageName) {
   try {
-    fs.mkdirSync(rylCacheDir, { recursive: true });
-  } catch (err) {
-    console.error(`Error creating cache directory ${rylCacheDir}: ${err.message}`);
-    process.exit(1);
-  }
-
-  const url = `https://github.com/owenlamont/ryl/releases/download/v${version}/${binaryAsset}`;
-  const archivePath = path.join(rylCacheDir, `${binaryAsset}.tmp`);
-  const extractDir = path.join(rylCacheDir, `extract-${Date.now()}`);
-
-  console.log(`Downloading ryl v${version} for ${process.platform}/${process.arch}...`);
-  console.log(`Installing to: ${cacheBinPath}`);
-
-  try {
-    await download(url, archivePath);
-    fs.mkdirSync(extractDir, { recursive: true });
-
-    if (process.platform === 'win32') {
-      spawnSync('powershell.exe', ['-Command', `Expand-Archive -Path "${archivePath}" -DestinationPath "${extractDir}" -Force`], { stdio: 'inherit' });
-    } else {
-      spawnSync('tar', ['-xzf', archivePath, '-C', extractDir], { stdio: 'inherit' });
-    }
-
-    const extractedBinPath = path.join(extractDir, binName);
-    if (!fs.existsSync(extractedBinPath)) {
-      throw new Error(`Binary not found in archive: ${binName}`);
-    }
-
-    // Atomic move
-    fs.renameSync(extractedBinPath, cacheBinPath);
-
-    // Cleanup
-    fs.unlinkSync(archivePath);
-    fs.rmSync(extractDir, { recursive: true, force: true });
-
-    if (process.platform !== 'win32') {
-      fs.chmodSync(cacheBinPath, 0o755);
-    }
-    console.log('Successfully installed ryl!');
-  } catch (err) {
-    console.error(`Error installing ryl binary: ${err.message}`);
-    // Cleanup on failure
-    if (fs.existsSync(archivePath)) fs.unlinkSync(archivePath);
-    if (fs.existsSync(extractDir)) fs.rmSync(extractDir, { recursive: true, force: true });
-
-    if (process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy) {
-      console.error('Note: You are using a proxy; please ensure your environment is configured correctly for Node.js https.get().');
-    }
-    process.exit(1);
+    return require.resolve(`${packageName}/package.json`);
+  } catch {
+    return null;
   }
 }
 

--- a/bin/ryl.js
+++ b/bin/ryl.js
@@ -26,7 +26,9 @@ async function run() {
       [
         `No installed npm platform package matches ${process.platform}/${process.arch}.`,
         `Expected optional dependency: ${platformPackage.packageName}`,
-        `Try reinstalling ${pkg.name} for this platform.`
+        'This package requires npm optionalDependencies; installs done with',
+        '--omit=optional or npm_config_optional=false are not supported.',
+        `Reinstall ${pkg.name} with optional dependencies enabled.`
       ].join('\n')
     );
     process.exit(1);

--- a/npm-platforms.json
+++ b/npm-platforms.json
@@ -1,0 +1,124 @@
+{
+  "binaryName": "ryl",
+  "metaPackageName": "@owenlamont/ryl",
+  "packageScope": "@owenlamont",
+  "platforms": [
+    {
+      "archiveName": "ryl-aarch64-apple-darwin.tar.gz",
+      "binaryName": "ryl",
+      "cpu": [
+        "arm64"
+      ],
+      "folderName": "ryl-darwin-arm64",
+      "os": [
+        "darwin"
+      ],
+      "packageName": "@owenlamont/ryl-darwin-arm64",
+      "target": "aarch64-apple-darwin"
+    },
+    {
+      "archiveName": "ryl-x86_64-unknown-linux-musl.tar.gz",
+      "binaryName": "ryl",
+      "cpu": [
+        "x64"
+      ],
+      "folderName": "ryl-linux-x64-musl",
+      "os": [
+        "linux"
+      ],
+      "packageName": "@owenlamont/ryl-linux-x64-musl",
+      "target": "x86_64-unknown-linux-musl"
+    },
+    {
+      "archiveName": "ryl-aarch64-unknown-linux-musl.tar.gz",
+      "binaryName": "ryl",
+      "cpu": [
+        "arm64"
+      ],
+      "folderName": "ryl-linux-arm64-musl",
+      "os": [
+        "linux"
+      ],
+      "packageName": "@owenlamont/ryl-linux-arm64-musl",
+      "target": "aarch64-unknown-linux-musl"
+    },
+    {
+      "archiveName": "ryl-armv7-unknown-linux-gnueabihf.tar.gz",
+      "binaryName": "ryl",
+      "cpu": [
+        "arm"
+      ],
+      "folderName": "ryl-linux-armv7-gnu",
+      "os": [
+        "linux"
+      ],
+      "packageName": "@owenlamont/ryl-linux-armv7-gnu",
+      "target": "armv7-unknown-linux-gnueabihf"
+    },
+    {
+      "archiveName": "ryl-i686-unknown-linux-gnu.tar.gz",
+      "binaryName": "ryl",
+      "cpu": [
+        "ia32"
+      ],
+      "folderName": "ryl-linux-ia32-gnu",
+      "os": [
+        "linux"
+      ],
+      "packageName": "@owenlamont/ryl-linux-ia32-gnu",
+      "target": "i686-unknown-linux-gnu"
+    },
+    {
+      "archiveName": "ryl-powerpc64le-unknown-linux-gnu.tar.gz",
+      "binaryName": "ryl",
+      "cpu": [
+        "ppc64"
+      ],
+      "folderName": "ryl-linux-ppc64le-gnu",
+      "os": [
+        "linux"
+      ],
+      "packageName": "@owenlamont/ryl-linux-ppc64le-gnu",
+      "target": "powerpc64le-unknown-linux-gnu"
+    },
+    {
+      "archiveName": "ryl-s390x-unknown-linux-gnu.tar.gz",
+      "binaryName": "ryl",
+      "cpu": [
+        "s390x"
+      ],
+      "folderName": "ryl-linux-s390x-gnu",
+      "os": [
+        "linux"
+      ],
+      "packageName": "@owenlamont/ryl-linux-s390x-gnu",
+      "target": "s390x-unknown-linux-gnu"
+    },
+    {
+      "archiveName": "ryl-x86_64-pc-windows-msvc.zip",
+      "binaryName": "ryl.exe",
+      "cpu": [
+        "x64"
+      ],
+      "folderName": "ryl-win32-x64-msvc",
+      "os": [
+        "win32"
+      ],
+      "packageName": "@owenlamont/ryl-win32-x64-msvc",
+      "target": "x86_64-pc-windows-msvc"
+    },
+    {
+      "archiveName": "ryl-aarch64-pc-windows-msvc.zip",
+      "binaryName": "ryl.exe",
+      "cpu": [
+        "arm64"
+      ],
+      "folderName": "ryl-win32-arm64-msvc",
+      "os": [
+        "win32"
+      ],
+      "packageName": "@owenlamont/ryl-win32-arm64-msvc",
+      "target": "aarch64-pc-windows-msvc"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.4.2"
+  "version": "0.4.3"
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "bin/",
+    "npm-platforms.json",
     "README.md",
     "LICENSE"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.4.2"
+version = "0.4.3"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/scripts/build_npm_packages.py
+++ b/scripts/build_npm_packages.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import tarfile
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+PLATFORMS_PATH = ROOT / "npm-platforms.json"
+PACKAGE_JSON_PATH = ROOT / "package.json"
+README_PATH = ROOT / "README.md"
+LICENSE_PATH = ROOT / "LICENSE"
+LAUNCHER_PATH = ROOT / "bin" / "ryl.js"
+
+
+def load_json(path: Path) -> object:
+    """Load UTF-8 JSON from disk.
+
+    Returns:
+        Parsed JSON data.
+    """
+
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, data: object) -> None:
+    """Write JSON with stable formatting and a trailing newline."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+
+
+def clean_dir(path: Path) -> None:
+    """Replace a directory with an empty version of itself."""
+
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def copy_text_asset(src: Path, dst: Path) -> None:
+    """Copy a shared repo asset into a generated package directory."""
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def extract_archive(
+    archive_path: Path, binary_name: str, destination_path: Path
+) -> None:
+    """Extract one named binary from a zip or tar.gz release asset.
+
+    Raises:
+        ValueError: The archive type is unsupported or does not contain exactly
+            one matching file entry.
+    """
+
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    if archive_path.suffix == ".zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            members = [
+                name
+                for name in archive.namelist()
+                if name.rstrip("/").endswith(binary_name)
+            ]
+            if len(members) != 1:
+                raise ValueError(
+                    "Expected exactly one "
+                    f"'{binary_name}' entry in {archive_path.name}, "
+                    f"found {members!r}"
+                )
+            with (
+                archive.open(members[0]) as source,
+                destination_path.open("wb") as destination,
+            ):
+                shutil.copyfileobj(source, destination)
+        return
+
+    if archive_path.suffixes[-2:] == [".tar", ".gz"]:
+        with tarfile.open(archive_path, "r:gz") as archive:
+            members = [
+                member
+                for member in archive.getmembers()
+                if Path(member.name).name == binary_name
+            ]
+            if len(members) != 1:
+                raise ValueError(
+                    "Expected exactly one "
+                    f"'{binary_name}' entry in {archive_path.name}, "
+                    f"found {[m.name for m in members]!r}"
+                )
+            extracted = archive.extractfile(members[0])
+            if extracted is None:
+                raise ValueError(
+                    f"Archive entry {members[0].name!r} in "
+                    f"{archive_path.name} is not a file"
+                )
+            with extracted, destination_path.open("wb") as destination:
+                shutil.copyfileobj(extracted, destination)
+        return
+
+    raise ValueError(f"Unsupported archive type: {archive_path.name}")
+
+
+def build_meta_package(
+    out_dir: Path,
+    package_data: dict[str, object],
+    platforms_data: dict[str, object],
+    local_test: bool,
+) -> None:
+    """Generate the staged meta-package directory."""
+
+    meta_dir = out_dir / "ryl"
+    clean_dir(meta_dir)
+
+    copy_text_asset(README_PATH, meta_dir / "README.md")
+    copy_text_asset(LICENSE_PATH, meta_dir / "LICENSE")
+    copy_text_asset(LAUNCHER_PATH, meta_dir / "bin" / "ryl.js")
+    copy_text_asset(PLATFORMS_PATH, meta_dir / "npm-platforms.json")
+
+    meta_package = dict(package_data)
+    optional_dependencies: dict[str, str] = {}
+    for platform in platforms_data["platforms"]:
+        if local_test:
+            optional_dependencies[platform["packageName"]] = (
+                f"file:../{platform['folderName']}"
+            )
+        else:
+            optional_dependencies[platform["packageName"]] = str(
+                package_data["version"]
+            )
+    meta_package["optionalDependencies"] = optional_dependencies
+
+    write_json(meta_dir / "package.json", meta_package)
+
+
+def build_platform_packages(
+    out_dir: Path,
+    package_data: dict[str, object],
+    platforms_data: dict[str, object],
+    assets_dir: Path,
+) -> None:
+    """Generate staged package directories for each supported platform.
+
+    Raises:
+        FileNotFoundError: A required release asset is missing.
+    """
+
+    for platform in platforms_data["platforms"]:
+        package_dir = out_dir / platform["folderName"]
+        clean_dir(package_dir)
+
+        archive_path = assets_dir / platform["archiveName"]
+        if not archive_path.exists():
+            raise FileNotFoundError(f"Missing release asset {archive_path}")
+
+        copy_text_asset(README_PATH, package_dir / "README.md")
+        copy_text_asset(LICENSE_PATH, package_dir / "LICENSE")
+        binary_path = package_dir / "bin" / platform["binaryName"]
+        extract_archive(archive_path, platform["binaryName"], binary_path)
+        if platform["binaryName"] == "ryl":
+            binary_path.chmod(0o755)
+
+        platform_package = {
+            "name": platform["packageName"],
+            "version": package_data["version"],
+            "description": package_data["description"],
+            "author": package_data["author"],
+            "license": package_data["license"],
+            "homepage": package_data["homepage"],
+            "bugs": package_data["bugs"],
+            "repository": package_data["repository"],
+            "type": "commonjs",
+            "files": ["bin/", "README.md", "LICENSE"],
+            "os": platform["os"],
+            "cpu": platform["cpu"],
+            "publishConfig": {"access": "public"},
+            "preferUnplugged": True,
+        }
+        write_json(package_dir / "package.json", platform_package)
+
+
+def main() -> None:
+    """Build staged npm packages from GitHub release assets."""
+
+    parser = argparse.ArgumentParser(description="Build npm meta and platform packages")
+    parser.add_argument(
+        "--assets-dir",
+        required=True,
+        help="Directory containing release asset archives",
+    )
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="Directory to write generated npm packages into",
+    )
+    parser.add_argument(
+        "--local-test",
+        action="store_true",
+        help=(
+            "Generate the meta package with file: optionalDependencies "
+            "for local install validation"
+        ),
+    )
+    args = parser.parse_args()
+
+    assets_dir = Path(args.assets_dir).resolve()
+    out_dir = Path(args.out_dir).resolve()
+    package_data = load_json(PACKAGE_JSON_PATH)
+    platforms_data = load_json(PLATFORMS_PATH)
+
+    clean_dir(out_dir)
+    build_platform_packages(out_dir, package_data, platforms_data, assets_dir)
+    build_meta_package(out_dir, package_data, platforms_data, args.local_test)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- switch the npm publish job to Node 24
- add an explicit Node/npm version guard before npm trusted publishing
- fail fast if the runner resolves to an unsupported npm CLI version

## Testing
- prek run --all-files
- ./scripts/coverage-missing.sh
- verified release rerun succeeded for v0.4.2
- verified npm install of @owenlamont/ryl@0.4.2 and `npx ryl --version`

## Update

The scope was increased to build platform specific sub-packages and not use the runtime installation script anymore.
