### PR TITLE
178 more fix rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,17 @@ ryl is a CLI tool for linting yaml files
   `prek run --all-files`).
 - `prek` already runs the key tooling (e.g., trim/fix whitespace, `cargo fmt`,
   `cargo clippy --fix`, `cargo clippy`, `rumdl` for Markdown/docs, etc.), so skip
-  invoking those individually—just run `prek` once after code *or* docs updates.
+  invoking those individually. Re-run `prek run --all-files` until the auto-fixes
+  stabilise and a full pass succeeds without modifying files.
 - Whenever source files are edited ensure the full test suite passes (run
   `./scripts/coverage-missing.sh` (Unix) or
   `pwsh ./scripts/coverage-missing.ps1` (Windows) to regenerate coverage; it reports
   uncovered ranges and confirms when coverage is complete)
+- After lint, tests, and coverage are green, review code size changes with
+  `uv run scripts/source_size.py --compare-to <branch-or-ref>` (typically the branch
+  point or `HEAD`). If the size increase looks large relative to the added
+  functionality, look for opportunities to make the implementation DRYer, reuse shared
+  helpers, or simplify it before committing.
 - For any behaviour or feature changes ensure all documentation is updated
   appropriately.
 
@@ -103,19 +109,36 @@ hunting through scattered tips:
 1. Quick status before pushing: run `./scripts/coverage-missing.sh` (Unix) or
    `pwsh ./scripts/coverage-missing.ps1` (Windows). It reruns the coverage suite and
    prints any uncovered ranges, or explicitly confirms when coverage is complete.
-2. If the script reports files, extend CLI/system tests targeting those ranges until
+2. If the coverage script itself fails, run the relevant test suite manually first,
+   fix the failing tests, then rerun the coverage script.
+3. If the script reports files, extend CLI/system tests targeting those ranges until
    the script produces no output.
-3. For richer artifacts (HTML, LCOV, etc.), follow the cargo-llvm-cov documentation
+4. For richer artifacts (HTML, LCOV, etc.), follow the cargo-llvm-cov documentation
    after running the script. HTML is not easily machine readable though so not
    recommended.
-4. When coverage points to tricky regions, prefer CLI/system tests in `tests/`
+5. When coverage points to tricky regions, prefer CLI/system tests in `tests/`
    that drive `env!("CARGO_BIN_EXE_ryl")` so you exercise the same paths as users.
-5. When you need to observe the exact flow through an uncovered branch, run the
+6. When you need to observe the exact flow through an uncovered branch, run the
    failing test under `rust-lldb` (ships with the toolchain). Start with
    `cargo test --no-run` and then
    `rust-lldb target/debug/deps/<test-binary> -- <filter args>` to set breakpoints
    on the problematic lines.
-6. If cached coverage lingers, clear `target/llvm-cov-target` and rerun.
+7. If cached coverage lingers, clear `target/llvm-cov-target` and rerun.
+
+## Code Size Workflow
+
+After finishing feature work, use this order before committing:
+
+1. Run `prek run --all-files` and rerun it until all automatic fixes have stabilised.
+2. Run `./scripts/coverage-missing.sh` (Unix) or
+   `pwsh ./scripts/coverage-missing.ps1` (Windows) and keep iterating until coverage
+   is back to 100%.
+3. If the coverage command fails for reasons unrelated to uncovered lines, run the
+   affected tests manually, fix them, then rerun the coverage command.
+4. Once lint, tests, and coverage are green, inspect code size with
+   `uv run scripts/source_size.py --compare-to <branch-or-ref>`.
+5. If the growth looks high for the functionality added, look for ways to reduce code
+   size or make the implementation DRYer before committing.
 
 ### Coverage-Friendly Rust Idioms
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ ryl is a CLI tool for linting yaml files
 - `prek` already runs the key tooling (e.g., trim/fix whitespace, `cargo fmt`,
   `cargo clippy --fix`, `cargo clippy`, `rumdl` for Markdown/docs, etc.), so skip
   invoking those individually. Re-run `prek run --all-files` until the auto-fixes
-  stabilise and a full pass succeeds without modifying files.
+  stabilise and a full pass succeeds without modifying files before running coverage.
 - Whenever source files are edited ensure the full test suite passes (run
   `./scripts/coverage-missing.sh` (Unix) or
   `pwsh ./scripts/coverage-missing.ps1` (Windows) to regenerate coverage; it reports
@@ -106,24 +106,26 @@ ryl is a CLI tool for linting yaml files
 The CI enforces zero missed lines and zero missed regions. Use this workflow instead of
 hunting through scattered tips:
 
-1. Quick status before pushing: run `./scripts/coverage-missing.sh` (Unix) or
+1. First run `prek run --all-files` and rerun it until all automatic fixes have
+   stabilised and a full pass succeeds without modifying files.
+2. Quick status before pushing: run `./scripts/coverage-missing.sh` (Unix) or
    `pwsh ./scripts/coverage-missing.ps1` (Windows). It reruns the coverage suite and
    prints any uncovered ranges, or explicitly confirms when coverage is complete.
-2. If the coverage script itself fails, run the relevant test suite manually first,
+3. If the coverage script itself fails, run the relevant test suite manually first,
    fix the failing tests, then rerun the coverage script.
-3. If the script reports files, extend CLI/system tests targeting those ranges until
+4. If the script reports files, extend CLI/system tests targeting those ranges until
    the script produces no output.
-4. For richer artifacts (HTML, LCOV, etc.), follow the cargo-llvm-cov documentation
+5. For richer artifacts (HTML, LCOV, etc.), follow the cargo-llvm-cov documentation
    after running the script. HTML is not easily machine readable though so not
    recommended.
-5. When coverage points to tricky regions, prefer CLI/system tests in `tests/`
+6. When coverage points to tricky regions, prefer CLI/system tests in `tests/`
    that drive `env!("CARGO_BIN_EXE_ryl")` so you exercise the same paths as users.
-6. When you need to observe the exact flow through an uncovered branch, run the
+7. When you need to observe the exact flow through an uncovered branch, run the
    failing test under `rust-lldb` (ships with the toolchain). Start with
    `cargo test --no-run` and then
    `rust-lldb target/debug/deps/<test-binary> -- <filter args>` to set breakpoints
    on the problematic lines.
-7. If cached coverage lingers, clear `target/llvm-cov-target` and rerun.
+8. If cached coverage lingers, clear `target/llvm-cov-target` and rerun.
 
 ## Code Size Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -9,12 +9,12 @@ The following rules are implemented and can be configured in your `.ryl.toml` (o
 | Rule | Description | Fixable |
 | :--- | :--- | :---: |
 | `anchors` | Checks for anchor and alias definitions. | |
-| `braces` | Checks for spaces inside braces. | |
-| `brackets` | Checks for spaces inside brackets. | |
+| `braces` | Checks for spaces inside braces. | ✅ |
+| `brackets` | Checks for spaces inside brackets. | ✅ |
 | `colons` | Checks for spaces around colons. | |
-| `commas` | Checks for spaces around commas. | |
+| `commas` | Checks for spaces around commas. | ✅ |
 | `comments` | Checks for spaces after `#` and before `#`. | ✅ |
-| `comments-indentation` | Checks for indentation of comments. | |
+| `comments-indentation` | Checks for indentation of comments. | ✅ |
 | `document-end` | Checks for the document end marker `...`. | |
 | `document-start` | Checks for the document start marker `---`. | |
 | `empty-lines` | Checks for the number of empty lines. | |
@@ -52,6 +52,10 @@ allow-non-breakable-words = true
 ### Fixable Rules
 
 - `comments`
+- `comments-indentation`
+- `commas`
+- `braces`
+- `brackets`
 - `new-lines`
 - `new-line-at-end-of-file`
 

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.5.0"
+version = "0.6.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,7 +160,11 @@ pub struct FixConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixRule {
+    Braces,
+    Brackets,
+    Commas,
     Comments,
+    CommentsIndentation,
     NewLineAtEndOfFile,
     NewLines,
 }
@@ -169,7 +173,11 @@ impl FixRule {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::Braces => "braces",
+            Self::Brackets => "brackets",
+            Self::Commas => "commas",
             Self::Comments => "comments",
+            Self::CommentsIndentation => "comments-indentation",
             Self::NewLineAtEndOfFile => "new-line-at-end-of-file",
             Self::NewLines => "new-lines",
         }
@@ -177,7 +185,11 @@ impl FixRule {
 
     fn parse(value: &str) -> Option<Self> {
         match value {
+            "braces" => Some(Self::Braces),
+            "brackets" => Some(Self::Brackets),
+            "commas" => Some(Self::Commas),
             "comments" => Some(Self::Comments),
+            "comments-indentation" => Some(Self::CommentsIndentation),
             "new-line-at-end-of-file" => Some(Self::NewLineAtEndOfFile),
             "new-lines" => Some(Self::NewLines),
             _ => None,

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 
 use crate::config::YamlLintConfig;
 use crate::decoder;
-use crate::rules::{comments, new_line_at_end_of_file, new_lines};
+use crate::rules::{
+    braces, brackets, commas, comments, comments_indentation, new_line_at_end_of_file,
+    new_lines,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixSafety {
@@ -15,20 +18,34 @@ struct RuleFix {
     safety: FixSafety,
 }
 
-const SAFE_FIX_RULES: [RuleFix; 3] = [
-    RuleFix {
-        rule: new_lines::ID,
-        safety: FixSafety::Safe,
-    },
-    RuleFix {
-        rule: comments::ID,
-        safety: FixSafety::Safe,
-    },
-    RuleFix {
-        rule: new_line_at_end_of_file::ID,
-        safety: FixSafety::Safe,
-    },
-];
+const NEW_LINES_FIX: RuleFix = RuleFix {
+    rule: new_lines::ID,
+    safety: FixSafety::Safe,
+};
+const COMMENTS_FIX: RuleFix = RuleFix {
+    rule: comments::ID,
+    safety: FixSafety::Safe,
+};
+const COMMENTS_INDENTATION_FIX: RuleFix = RuleFix {
+    rule: comments_indentation::ID,
+    safety: FixSafety::Safe,
+};
+const COMMAS_FIX: RuleFix = RuleFix {
+    rule: commas::ID,
+    safety: FixSafety::Safe,
+};
+const BRACES_FIX: RuleFix = RuleFix {
+    rule: braces::ID,
+    safety: FixSafety::Safe,
+};
+const BRACKETS_FIX: RuleFix = RuleFix {
+    rule: brackets::ID,
+    safety: FixSafety::Safe,
+};
+const FINAL_NEWLINE_FIX: RuleFix = RuleFix {
+    rule: new_line_at_end_of_file::ID,
+    safety: FixSafety::Safe,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FixStats {
@@ -81,31 +98,60 @@ pub fn apply_safe_fixes(
 ) -> String {
     let mut content = input.to_string();
 
-    if rule_enabled(SAFE_FIX_RULES[0], cfg, path, base_dir) {
-        let rule_cfg = new_lines::Config::resolve(cfg);
-        if let Some(updated) =
-            new_lines::fix(&content, rule_cfg, new_lines::platform_newline())
-        {
-            content = updated;
-        }
-    }
-
-    if rule_enabled(SAFE_FIX_RULES[1], cfg, path, base_dir) {
-        let rule_cfg = comments::Config::resolve(cfg);
-        if let Some(updated) = comments::fix(&content, &rule_cfg) {
-            content = updated;
-        }
-    }
-
-    if rule_enabled(SAFE_FIX_RULES[2], cfg, path, base_dir) {
-        let newline = target_newline(&content, cfg, path, base_dir);
-        if let Some(updated) = new_line_at_end_of_file::fix(&content, newline.as_str())
-        {
-            content = updated;
-        }
-    }
+    content = apply_rule_fix(content, NEW_LINES_FIX, cfg, path, base_dir, |buffer| {
+        new_lines::fix(
+            buffer,
+            new_lines::Config::resolve(cfg),
+            new_lines::platform_newline(),
+        )
+    });
+    content = apply_rule_fix(content, COMMENTS_FIX, cfg, path, base_dir, |buffer| {
+        comments::fix(buffer, &comments::Config::resolve(cfg))
+    });
+    content = apply_rule_fix(
+        content,
+        COMMENTS_INDENTATION_FIX,
+        cfg,
+        path,
+        base_dir,
+        |buffer| {
+            comments_indentation::fix(
+                buffer,
+                &comments_indentation::Config::resolve(cfg),
+            )
+        },
+    );
+    content = apply_rule_fix(content, COMMAS_FIX, cfg, path, base_dir, |buffer| {
+        commas::fix(buffer, &commas::Config::resolve(cfg))
+    });
+    content = apply_rule_fix(content, BRACES_FIX, cfg, path, base_dir, |buffer| {
+        braces::fix(buffer, &braces::Config::resolve(cfg))
+    });
+    content = apply_rule_fix(content, BRACKETS_FIX, cfg, path, base_dir, |buffer| {
+        brackets::fix(buffer, &brackets::Config::resolve(cfg))
+    });
+    content =
+        apply_rule_fix(content, FINAL_NEWLINE_FIX, cfg, path, base_dir, |buffer| {
+            let newline = target_newline(buffer, cfg, path, base_dir);
+            new_line_at_end_of_file::fix(buffer, newline.as_str())
+        });
 
     content
+}
+
+fn apply_rule_fix(
+    content: String,
+    rule: RuleFix,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+    fix: impl FnOnce(&str) -> Option<String>,
+) -> String {
+    if !rule_enabled(rule, cfg, path, base_dir) {
+        return content;
+    }
+
+    fix(&content).unwrap_or(content)
 }
 
 fn rule_enabled(

--- a/src/rules/commas.rs
+++ b/src/rules/commas.rs
@@ -1,6 +1,7 @@
 use crate::config::YamlLintConfig;
 use crate::rules::support::punctuation::{
     build_line_starts, collect_scalar_ranges, line_and_column, skip_comment,
+    template_double_curly_end,
 };
 use crate::rules::support::span_utils::span_char_index_to_byte;
 
@@ -130,7 +131,13 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
 
         match ch {
             '[' => contexts.push(FlowKind::Sequence),
-            '{' => contexts.push(FlowKind::Mapping),
+            '{' => {
+                if let Some(next_idx) = template_double_curly_end(&chars, i) {
+                    i = next_idx;
+                    continue;
+                }
+                contexts.push(FlowKind::Mapping);
+            }
             ']' | '}' => {
                 contexts.pop();
             }
@@ -188,7 +195,13 @@ pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
 
         match ch {
             '[' => contexts.push(FlowKind::Sequence),
-            '{' => contexts.push(FlowKind::Mapping),
+            '{' => {
+                if let Some(next_idx) = template_double_curly_end(&chars, i) {
+                    i = next_idx;
+                    continue;
+                }
+                contexts.push(FlowKind::Mapping);
+            }
             ']' | '}' => {
                 contexts.pop();
             }

--- a/src/rules/commas.rs
+++ b/src/rules/commas.rs
@@ -84,7 +84,7 @@ enum FlowKind {
 }
 
 enum BeforeResult {
-    SameLine { spaces: usize },
+    SameLine { spaces: usize, start_idx: usize },
     Ignored,
 }
 
@@ -152,6 +152,62 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     violations
 }
 
+#[must_use]
+pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
+    if buffer.is_empty() {
+        return None;
+    }
+
+    let scalar_ranges = collect_scalar_ranges(buffer);
+    let chars: Vec<(usize, char)> = buffer.char_indices().collect();
+    let buffer_len = buffer.len();
+
+    let mut replacements: Vec<(usize, usize, String)> = Vec::new();
+    let mut contexts: Vec<FlowKind> = Vec::new();
+    let mut i = 0usize;
+    let mut range_idx = 0usize;
+
+    while i < chars.len() {
+        let (byte_idx, ch) = chars[i];
+
+        while range_idx < scalar_ranges.len()
+            && span_char_index_to_byte(&chars, scalar_ranges[range_idx].end, buffer_len)
+                <= byte_idx
+        {
+            range_idx += 1;
+        }
+
+        if let Some(range) = scalar_ranges.get(range_idx) {
+            let start_byte = span_char_index_to_byte(&chars, range.start, buffer_len);
+            let end_byte = span_char_index_to_byte(&chars, range.end, buffer_len);
+            if byte_idx >= start_byte && byte_idx < end_byte {
+                i = range.end;
+                continue;
+            }
+        }
+
+        match ch {
+            '[' => contexts.push(FlowKind::Sequence),
+            '{' => contexts.push(FlowKind::Mapping),
+            ']' | '}' => {
+                contexts.pop();
+            }
+            '#' => {
+                i = skip_comment(&chars, i);
+                continue;
+            }
+            ',' if !contexts.is_empty() => {
+                collect_comma_fixes(cfg, &chars, i, &mut replacements);
+            }
+            _ => {}
+        }
+
+        i += 1;
+    }
+
+    apply_replacements(buffer, replacements)
+}
+
 fn evaluate_comma(
     cfg: &Config,
     violations: &mut Vec<Violation>,
@@ -159,7 +215,8 @@ fn evaluate_comma(
     comma_idx: usize,
     line_starts: &[usize],
 ) {
-    if let BeforeResult::SameLine { spaces } = compute_spaces_before(chars, comma_idx)
+    if let BeforeResult::SameLine { spaces, .. } =
+        compute_spaces_before(chars, comma_idx)
         && cfg.max_spaces_before >= 0
     {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
@@ -205,7 +262,10 @@ fn compute_spaces_before(chars: &[(usize, char)], comma_idx: usize) -> BeforeRes
 
     loop {
         let Some(prev) = idx.checked_sub(1) else {
-            return BeforeResult::SameLine { spaces };
+            return BeforeResult::SameLine {
+                spaces,
+                start_idx: comma_idx,
+            };
         };
 
         let ch = chars[prev].1;
@@ -217,7 +277,10 @@ fn compute_spaces_before(chars: &[(usize, char)], comma_idx: usize) -> BeforeRes
         if matches!(ch, '\n' | '\r') {
             return BeforeResult::Ignored;
         }
-        return BeforeResult::SameLine { spaces };
+        return BeforeResult::SameLine {
+            spaces,
+            start_idx: idx,
+        };
     }
 }
 
@@ -248,7 +311,7 @@ pub fn coverage_compute_spaces_before(buffer: &str, comma_idx: usize) -> Option<
     let chars: Vec<(usize, char)> = buffer.char_indices().collect();
     debug_assert!(comma_idx < chars.len());
     match compute_spaces_before(&chars, comma_idx) {
-        BeforeResult::SameLine { spaces } => Some(spaces),
+        BeforeResult::SameLine { spaces, .. } => Some(spaces),
         BeforeResult::Ignored => None,
     }
 }
@@ -257,6 +320,67 @@ pub fn coverage_compute_spaces_before(buffer: &str, comma_idx: usize) -> Option<
 #[must_use]
 pub fn coverage_skip_zero_length_span() -> usize {
     collect_scalar_ranges("").len()
+}
+
+fn collect_comma_fixes(
+    cfg: &Config,
+    chars: &[(usize, char)],
+    comma_idx: usize,
+    replacements: &mut Vec<(usize, usize, String)>,
+) {
+    if let BeforeResult::SameLine { spaces, start_idx } =
+        compute_spaces_before(chars, comma_idx)
+        && cfg.max_spaces_before >= 0
+    {
+        let target = usize::try_from(cfg.max_spaces_before).unwrap_or(usize::MAX);
+        if spaces > target {
+            replacements.push((
+                chars[start_idx].0,
+                chars[comma_idx].0,
+                " ".repeat(target),
+            ));
+        }
+    }
+
+    if let AfterResult::SameLine { spaces, next_char } =
+        compute_spaces_after(chars, comma_idx)
+        && let Some(target) = target_spaces_after(cfg, spaces)
+        && target != spaces
+    {
+        replacements.push((
+            chars[comma_idx].0 + chars[comma_idx].1.len_utf8(),
+            chars[next_char].0,
+            " ".repeat(target),
+        ));
+    }
+}
+
+fn target_spaces_after(cfg: &Config, current: usize) -> Option<usize> {
+    let min_spaces = usize::try_from(cfg.min_spaces_after).ok().unwrap_or(0);
+    let max_spaces = if cfg.max_spaces_after >= 0 {
+        usize::try_from(cfg.max_spaces_after).unwrap_or(usize::MAX)
+    } else {
+        usize::MAX
+    };
+    let target = current.max(min_spaces).min(max_spaces);
+    (target != current).then_some(target)
+}
+
+fn apply_replacements(
+    buffer: &str,
+    mut replacements: Vec<(usize, usize, String)>,
+) -> Option<String> {
+    if replacements.is_empty() {
+        return None;
+    }
+
+    replacements.sort_by(|left, right| right.0.cmp(&left.0));
+
+    let mut output = buffer.to_string();
+    for (start, end, replacement) in replacements {
+        output.replace_range(start..end, &replacement);
+    }
+    Some(output)
 }
 
 #[doc(hidden)]

--- a/src/rules/comments.rs
+++ b/src/rules/comments.rs
@@ -1,6 +1,6 @@
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::{
-    block_scalar_marker_index, leading_whitespace_width,
+    block_scalar_marker_index, leading_whitespace_width, split_lines_preserve_endings,
     strip_trailing_comment_preserving_quotes,
 };
 
@@ -325,37 +325,4 @@ fn fix_comment_line(
     }
 
     line
-}
-
-fn split_lines_preserve_endings(
-    buffer: &str,
-) -> impl Iterator<Item = (usize, &str, &str)> {
-    let mut start = 0usize;
-    let mut line_idx = 0usize;
-    std::iter::from_fn(move || {
-        if start == buffer.len() {
-            return None;
-        }
-
-        let bytes = buffer.as_bytes();
-        let mut idx = start;
-        while idx < bytes.len() && bytes[idx] != b'\n' {
-            idx += 1;
-        }
-
-        let (line, ending, next_start) = if idx < bytes.len() {
-            if idx > start && bytes[idx - 1] == b'\r' {
-                (&buffer[start..idx - 1], &buffer[idx - 1..=idx], idx + 1)
-            } else {
-                (&buffer[start..idx], &buffer[idx..=idx], idx + 1)
-            }
-        } else {
-            (&buffer[start..], "", bytes.len())
-        };
-
-        let current = (line_idx, line, ending);
-        line_idx += 1;
-        start = next_start;
-        Some(current)
-    })
 }

--- a/src/rules/comments_indentation.rs
+++ b/src/rules/comments_indentation.rs
@@ -1,6 +1,6 @@
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::{
-    block_scalar_marker_index, leading_whitespace_width,
+    block_scalar_marker_index, leading_whitespace_width, split_lines_preserve_endings,
     strip_trailing_comment_preserving_quotes,
 };
 
@@ -80,6 +80,71 @@ pub fn check(buffer: &str, _cfg: &Config) -> Vec<Violation> {
     }
 
     diagnostics
+}
+
+#[must_use]
+pub fn fix(buffer: &str, _cfg: &Config) -> Option<String> {
+    if buffer.is_empty() {
+        return None;
+    }
+
+    let mut block_tracker = BlockScalarTracker::default();
+    let mut lines: Vec<LineInfo> = Vec::new();
+
+    for raw_line in buffer.lines() {
+        let indent = leading_whitespace_width(raw_line);
+        let content = &raw_line[indent..];
+
+        let consumed = block_tracker.consume_line(indent, content);
+        let kind = if consumed {
+            LineKind::BlockScalarContent
+        } else {
+            classify_line_kind(content)
+        };
+
+        lines.push(LineInfo { indent, kind });
+        block_tracker.observe_indicator(indent, content);
+    }
+
+    let prev_content_indents = compute_prev_content_indents(&lines);
+    let next_content_indents = compute_next_content_indents(&lines);
+
+    let mut changed = false;
+    let mut last_comment_indent: Option<usize> = None;
+    let mut output = String::with_capacity(buffer.len());
+
+    for ((line_idx, raw_line, ending), line) in
+        split_lines_preserve_endings(buffer).zip(lines.iter())
+    {
+        match line.kind {
+            LineKind::Comment => {
+                let prev_indent = prev_content_indents[line_idx].unwrap_or(0);
+                let next_indent = next_content_indents[line_idx].unwrap_or(0);
+                let reference_indent =
+                    last_comment_indent.unwrap_or_else(|| prev_indent.max(next_indent));
+                let target_indent =
+                    if line.indent != reference_indent && line.indent != next_indent {
+                        changed = true;
+                        reference_indent
+                    } else {
+                        line.indent
+                    };
+                last_comment_indent = Some(target_indent);
+                output.push_str(&" ".repeat(target_indent));
+                output.push_str(raw_line.trim_start_matches([' ', '\t']));
+            }
+            LineKind::Other | LineKind::DirectiveComment => {
+                last_comment_indent = None;
+                output.push_str(raw_line);
+            }
+            LineKind::Empty | LineKind::BlockScalarContent => {
+                output.push_str(raw_line);
+            }
+        }
+        output.push_str(ending);
+    }
+
+    changed.then_some(output)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/rules/comments_indentation.rs
+++ b/src/rules/comments_indentation.rs
@@ -92,8 +92,9 @@ pub fn fix(buffer: &str, _cfg: &Config) -> Option<String> {
     let mut lines: Vec<LineInfo> = Vec::new();
 
     for raw_line in buffer.lines() {
-        let indent = leading_whitespace_width(raw_line);
-        let content = &raw_line[indent..];
+        let line = raw_line.trim_end_matches('\r');
+        let indent = leading_whitespace_width(line);
+        let content = &line[indent..];
 
         let consumed = block_tracker.consume_line(indent, content);
         let kind = if consumed {

--- a/src/rules/support/flow_collection.rs
+++ b/src/rules/support/flow_collection.rs
@@ -4,7 +4,7 @@ use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::punctuation::{
-    build_line_starts, line_and_column, skip_comment,
+    build_line_starts, line_and_column, skip_comment, template_double_curly_end,
 };
 use crate::rules::support::span_utils::ranges_to_char_indices;
 
@@ -735,23 +735,6 @@ fn next_significant_index(chars: &[(usize, char)], open_idx: usize) -> Option<us
         }
     }
     None
-}
-
-fn template_double_curly_end(chars: &[(usize, char)], idx: usize) -> Option<usize> {
-    if idx + 1 >= chars.len() || chars[idx].1 != '{' || chars[idx + 1].1 != '{' {
-        return None;
-    }
-    let mut cursor = idx + 2;
-    while cursor + 1 < chars.len() {
-        if chars[cursor].1 == '}' && chars[cursor + 1].1 == '}' {
-            let inner_contains_mapping =
-                chars[idx + 2..cursor].iter().any(|(_, ch)| *ch == ':');
-            return (!inner_contains_mapping).then_some(cursor + 2);
-        }
-        cursor += 1;
-    }
-    let inner_contains_mapping = chars[idx + 2..].iter().any(|(_, ch)| *ch == ':');
-    (!inner_contains_mapping).then_some(chars.len())
 }
 
 fn target_spacing(current: usize, min: i64, max: i64) -> usize {

--- a/src/rules/support/flow_collection.rs
+++ b/src/rules/support/flow_collection.rs
@@ -47,6 +47,15 @@ macro_rules! define_rule {
             )
         }
 
+        #[must_use]
+        pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
+            $crate::rules::support::flow_collection::fix(
+                buffer,
+                cfg.inner(),
+                &DESCRIPTOR,
+            )
+        }
+
         impl Config {
             #[must_use]
             pub fn resolve(cfg: &$crate::config::YamlLintConfig) -> Self {
@@ -379,6 +388,85 @@ pub fn check(
     violations
 }
 
+#[must_use]
+pub fn fix(
+    buffer: &str,
+    cfg: &Config,
+    desc: &FlowCollectionDescriptor,
+) -> Option<String> {
+    if buffer.is_empty() || cfg.forbid() != Forbid::None {
+        return None;
+    }
+
+    let mut parser = Parser::new_from_str(buffer);
+    let mut collector = ScalarRangeCollector::new();
+    let _ = parser.load(&mut collector, true);
+    let scalar_ranges = collector.into_sorted();
+
+    let chars: Vec<(usize, char)> = buffer.char_indices().collect();
+    let buffer_len = buffer.len();
+    let scalar_ranges = ranges_to_char_indices(scalar_ranges, &chars, buffer_len);
+
+    let mut range_idx = 0usize;
+    let mut idx = 0usize;
+    let mut stack: Vec<CollectionState> = Vec::new();
+    let mut replacements: Vec<(usize, usize, String)> = Vec::new();
+
+    while idx < chars.len() {
+        while range_idx < scalar_ranges.len() && scalar_ranges[range_idx].end <= idx {
+            range_idx += 1;
+        }
+
+        if let Some(range) = scalar_ranges.get(range_idx)
+            && idx >= range.start
+            && idx < range.end
+        {
+            if idx == range.start
+                && let Some(state) = stack.last_mut()
+            {
+                state.is_empty = false;
+            }
+            idx = range.end;
+            continue;
+        }
+
+        let ch = chars[idx].1;
+        if desc.open == '{'
+            && let Some(next_idx) = template_double_curly_end(&chars, idx)
+        {
+            idx = next_idx;
+            continue;
+        }
+
+        if ch == desc.open {
+            if let Some(state) = stack.last_mut() {
+                state.is_empty = false;
+            }
+            let state = fix_open(cfg, desc, &chars, idx, &mut replacements);
+            stack.push(state);
+        } else if ch == desc.close {
+            fix_close(cfg, &chars, idx, &mut stack, &mut replacements);
+        } else {
+            match ch {
+                '#' => {
+                    idx = skip_comment(&chars, idx);
+                    continue;
+                }
+                ',' | ' ' | '\t' | '\n' | '\r' => {}
+                _ => {
+                    if let Some(state) = stack.last_mut() {
+                        state.is_empty = false;
+                    }
+                }
+            }
+        }
+
+        idx += 1;
+    }
+
+    apply_replacements(buffer, replacements)
+}
+
 fn handle_open(
     cfg: &Config,
     desc: &FlowCollectionDescriptor,
@@ -459,6 +547,40 @@ fn handle_open(
     stack.push(state);
 }
 
+fn fix_open(
+    cfg: &Config,
+    desc: &FlowCollectionDescriptor,
+    chars: &[(usize, char)],
+    idx: usize,
+    replacements: &mut Vec<(usize, usize, String)>,
+) -> CollectionState {
+    let next_significant = next_significant_index(chars, idx);
+    let mut state = CollectionState {
+        is_empty: matches!(next_significant.map(|j| chars[j].1), Some(close) if close == desc.close),
+    };
+
+    if let AfterResult::SameLine { spaces, next_idx } =
+        compute_spaces_after_open(chars, idx)
+    {
+        let target = if state.is_empty && chars[next_idx].1 == desc.close {
+            target_spacing(spaces, cfg.effective_min_empty(), cfg.effective_max_empty())
+        } else {
+            state.is_empty = false;
+            target_spacing(spaces, cfg.min_spaces_inside(), cfg.max_spaces_inside())
+        };
+
+        if target != spaces {
+            replacements.push((
+                chars[idx].0 + chars[idx].1.len_utf8(),
+                chars[next_idx].0,
+                " ".repeat(target),
+            ));
+        }
+    }
+
+    state
+}
+
 fn handle_close(
     cfg: &Config,
     desc: &FlowCollectionDescriptor,
@@ -476,7 +598,7 @@ fn handle_close(
         return;
     }
 
-    if let Some(spaces) = compute_spaces_before_close(chars, idx) {
+    if let Some((spaces, _start_idx)) = compute_spaces_before_close(chars, idx) {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
         let close_byte = chars[idx].0;
         let (line, close_column) = line_and_column(line_starts, close_byte);
@@ -496,6 +618,32 @@ fn handle_close(
             });
         }
     }
+}
+
+fn fix_close(
+    cfg: &Config,
+    chars: &[(usize, char)],
+    idx: usize,
+    stack: &mut Vec<CollectionState>,
+    replacements: &mut Vec<(usize, usize, String)>,
+) {
+    let Some(state) = stack.pop() else {
+        return;
+    };
+
+    if state.is_empty {
+        return;
+    }
+
+    let Some((spaces, start_idx)) = compute_spaces_before_close(chars, idx) else {
+        return;
+    };
+    let target =
+        target_spacing(spaces, cfg.min_spaces_inside(), cfg.max_spaces_inside());
+    if target == spaces {
+        return;
+    }
+    replacements.push((chars[start_idx].0, chars[idx].0, " ".repeat(target)));
 }
 
 fn record_after_spacing(
@@ -549,7 +697,7 @@ fn compute_spaces_after_open(chars: &[(usize, char)], open_idx: usize) -> AfterR
 fn compute_spaces_before_close(
     chars: &[(usize, char)],
     close_idx: usize,
-) -> Option<usize> {
+) -> Option<(usize, usize)> {
     let mut spaces = 0usize;
     let mut idx = close_idx;
     loop {
@@ -559,7 +707,7 @@ fn compute_spaces_before_close(
         match chars[idx].1 {
             ' ' | '\t' => spaces += 1,
             '\n' | '\r' | '#' => return None,
-            _ => return Some(spaces),
+            _ => return Some((spaces, idx + 1)),
         }
     }
 }
@@ -604,4 +752,27 @@ fn template_double_curly_end(chars: &[(usize, char)], idx: usize) -> Option<usiz
     }
     let inner_contains_mapping = chars[idx + 2..].iter().any(|(_, ch)| *ch == ':');
     (!inner_contains_mapping).then_some(chars.len())
+}
+
+fn target_spacing(current: usize, min: i64, max: i64) -> usize {
+    let min_spaces = usize::try_from(min).ok().unwrap_or(0);
+    let max_spaces = usize::try_from(max).ok().unwrap_or(usize::MAX);
+    current.max(min_spaces).min(max_spaces)
+}
+
+fn apply_replacements(
+    buffer: &str,
+    mut replacements: Vec<(usize, usize, String)>,
+) -> Option<String> {
+    if replacements.is_empty() {
+        return None;
+    }
+
+    replacements.sort_by(|left, right| right.0.cmp(&left.0));
+
+    let mut output = buffer.to_string();
+    for (start, end, replacement) in replacements {
+        output.replace_range(start..end, &replacement);
+    }
+    Some(output)
 }

--- a/src/rules/support/line_syntax.rs
+++ b/src/rules/support/line_syntax.rs
@@ -54,3 +54,36 @@ pub(crate) fn block_scalar_marker_index(content: &str) -> Option<usize> {
         None
     }
 }
+
+pub(crate) fn split_lines_preserve_endings(
+    buffer: &str,
+) -> impl Iterator<Item = (usize, &str, &str)> {
+    let mut start = 0usize;
+    let mut line_idx = 0usize;
+    std::iter::from_fn(move || {
+        if start == buffer.len() {
+            return None;
+        }
+
+        let bytes = buffer.as_bytes();
+        let mut idx = start;
+        while idx < bytes.len() && bytes[idx] != b'\n' {
+            idx += 1;
+        }
+
+        let (line, ending, next_start) = if idx < bytes.len() {
+            if idx > start && bytes[idx - 1] == b'\r' {
+                (&buffer[start..idx - 1], &buffer[idx - 1..=idx], idx + 1)
+            } else {
+                (&buffer[start..idx], &buffer[idx..=idx], idx + 1)
+            }
+        } else {
+            (&buffer[start..], "", bytes.len())
+        };
+
+        let current = (line_idx, line, ending);
+        line_idx += 1;
+        start = next_start;
+        Some(current)
+    })
+}

--- a/src/rules/support/punctuation.rs
+++ b/src/rules/support/punctuation.rs
@@ -75,6 +75,26 @@ pub(crate) fn line_and_column(
     (left + 1, byte_idx - line_start + 1)
 }
 
+pub(crate) fn template_double_curly_end(
+    chars: &[(usize, char)],
+    idx: usize,
+) -> Option<usize> {
+    if idx + 1 >= chars.len() || chars[idx].1 != '{' || chars[idx + 1].1 != '{' {
+        return None;
+    }
+    let mut cursor = idx + 2;
+    while cursor + 1 < chars.len() {
+        if chars[cursor].1 == '}' && chars[cursor + 1].1 == '}' {
+            let inner_contains_mapping =
+                chars[idx + 2..cursor].iter().any(|(_, ch)| *ch == ':');
+            return (!inner_contains_mapping).then_some(cursor + 2);
+        }
+        cursor += 1;
+    }
+    let inner_contains_mapping = chars[idx + 2..].iter().any(|(_, ch)| *ch == ':');
+    (!inner_contains_mapping).then_some(chars.len())
+}
+
 struct ScalarRangeCollector {
     ranges: Vec<Range<usize>>,
 }

--- a/tests/cli_commas_rule.rs
+++ b/tests/cli_commas_rule.rs
@@ -102,3 +102,51 @@ fn relaxed_spacing_allows_compact_flow() {
     assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
     assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
 }
+
+#[test]
+fn double_curly_template_is_ignored() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("template.yaml");
+    fs::write(&file, "---\nvalue: {{ foo(1,2) }}\n").unwrap();
+    let config = dir.path().join("config.yml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  commas: enable\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "template commas should be ignored: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+}
+
+#[test]
+fn fix_leaves_double_curly_template_unchanged() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("template.yaml");
+    fs::write(&file, "value: {{ foo(1,2) }}\n").unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ndocument-start = 'disable'\ncommas = 'enable'\nnew-line-at-end-of-file = 'disable'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("--fix").arg(&file));
+    assert_eq!(
+        code, 0,
+        "template fix should be a no-op: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "value: {{ foo(1,2) }}\n"
+    );
+}

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -227,3 +227,36 @@ fn fix_applies_new_safe_spacing_rules() {
         "root:\n  mapping: {key: [1, 2]}\n  empty: [ ]\n  # wrong\n  next: value\n"
     );
 }
+
+#[test]
+fn fix_comments_indentation_handles_crlf_blank_lines_without_newline_normalization() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(
+        &file,
+        "root:\r\n  # first\r\n\r\n # second\r\n  value: 1\r\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ndocument-start = 'disable'\nnew-lines = 'disable'\nnew-line-at-end-of-file = 'disable'\ncomments-indentation = 'enable'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("--fix").arg(&file));
+
+    assert_eq!(
+        code, 0,
+        "comments-indentation fix should succeed on CRLF input: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("Found 1 problem (1 fixed, 0 remaining)."),
+        "expected one fixed CRLF comments-indentation problem: {stderr}"
+    );
+    assert!(stdout.is_empty(), "expected no stdout: {stdout}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "root:\r\n  # first\r\n\r\n  # second\r\n  value: 1\r\n"
+    );
+}

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -194,3 +194,36 @@ fn fix_missing_file_reports_read_error() {
     );
     assert!(stdout.is_empty(), "expected no stdout: {stdout}");
 }
+
+#[test]
+fn fix_applies_new_safe_spacing_rules() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(
+        &file,
+        "root:\n  mapping: {  key: [1 ,2]   }\n  empty: []\n # wrong\n  next: value\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ndocument-start = 'disable'\nnew-line-at-end-of-file = 'disable'\ncomments-indentation = 'enable'\ncommas = 'enable'\nbraces = 'enable'\n[rules.brackets]\nmin-spaces-inside-empty = 1\nmax-spaces-inside-empty = 1\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("--fix").arg(&file));
+
+    assert_eq!(
+        code, 0,
+        "new spacing fixes should succeed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("Found 6 problems (6 fixed, 0 remaining)."),
+        "expected all-new-fixes summary in stderr: {stderr}"
+    );
+    assert!(stdout.is_empty(), "expected no stdout: {stdout}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "root:\n  mapping: {key: [1, 2]}\n  empty: [ ]\n  # wrong\n  next: value\n"
+    );
+}

--- a/tests/config_fix.rs
+++ b/tests/config_fix.rs
@@ -52,13 +52,51 @@ fn toml_config_parses_fix_policy() {
 }
 
 #[test]
+fn toml_config_parses_new_safe_fix_rules() {
+    let cfg = PathBuf::from("/repo/.ryl.toml");
+    let env = common::fake_env::FakeEnv::new().with_file(
+        cfg.clone(),
+        "[fix]\nfixable = ['braces', 'brackets', 'commas', 'comments-indentation']\nunfixable = ['braces']\n",
+    );
+
+    let ctx = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("toml config should parse new fix rules");
+
+    assert_eq!(
+        ctx.config.fix().fixable(),
+        [
+            FixRuleSelector::Rule(FixRule::Braces),
+            FixRuleSelector::Rule(FixRule::Brackets),
+            FixRuleSelector::Rule(FixRule::Commas),
+            FixRuleSelector::Rule(FixRule::CommentsIndentation),
+        ]
+    );
+    assert_eq!(ctx.config.fix().unfixable(), [FixRule::Braces]);
+    assert!(!ctx.config.fix().allows_rule("braces"));
+    assert!(ctx.config.fix().allows_rule("brackets"));
+    assert!(ctx.config.fix().allows_rule("commas"));
+    assert!(ctx.config.fix().allows_rule("comments-indentation"));
+}
+
+#[test]
 fn default_fix_policy_allows_all_rules() {
     let root = tempfile::tempdir().unwrap();
     let file = root.path().join("input.yaml");
     std::fs::write(&file, "key: value\n").unwrap();
 
     let ctx = discover_config(&[file], &Overrides::default()).expect("default config");
+    assert!(ctx.config.fix().allows_rule("braces"));
+    assert!(ctx.config.fix().allows_rule("brackets"));
+    assert!(ctx.config.fix().allows_rule("commas"));
     assert!(ctx.config.fix().allows_rule("comments"));
+    assert!(ctx.config.fix().allows_rule("comments-indentation"));
     assert!(ctx.config.fix().allows_rule("new-lines"));
     assert!(!ctx.config.fix().allows_rule("indentation"));
     assert_eq!(ctx.config.fix().fixable(), [FixRuleSelector::All]);

--- a/tests/config_to_toml.rs
+++ b/tests/config_to_toml.rs
@@ -115,7 +115,7 @@ fn to_toml_includes_fix_policy() {
     let cfg_path = td.path().join(".ryl.toml");
     fs::write(
         &cfg_path,
-        "[fix]\nfixable = ['ALL', 'comments', 'new-lines']\nunfixable = ['new-line-at-end-of-file']\n",
+        "[fix]\nfixable = ['ALL', 'braces', 'brackets', 'commas', 'comments', 'comments-indentation', 'new-lines']\nunfixable = ['braces', 'new-line-at-end-of-file']\n",
     )
     .unwrap();
 
@@ -132,8 +132,13 @@ fn to_toml_includes_fix_policy() {
     assert!(toml.contains("[fix]"));
     assert!(toml.contains("fixable = ["));
     assert!(toml.contains("\"ALL\""));
+    assert!(toml.contains("\"braces\""));
+    assert!(toml.contains("\"brackets\""));
+    assert!(toml.contains("\"commas\""));
     assert!(toml.contains("\"comments\""));
+    assert!(toml.contains("\"comments-indentation\""));
     assert!(toml.contains("\"new-lines\""));
     assert!(toml.contains("unfixable = ["));
+    assert!(toml.contains("\"braces\""));
     assert!(toml.contains("\"new-line-at-end-of-file\""));
 }

--- a/tests/fix_engine.rs
+++ b/tests/fix_engine.rs
@@ -168,3 +168,35 @@ fn apply_safe_fixes_to_files_updates_each_entry() {
     assert_eq!(fs::read_to_string(&second).unwrap(), "alpha: beta\n");
     assert_eq!(stats.changed_files, 2);
 }
+
+#[test]
+fn apply_safe_fixes_runs_comments_indentation_and_commas() {
+    let cfg = config(
+        "rules:\n  comments-indentation: enable\n  commas: enable\n  new-line-at-end-of-file: disable\n",
+    );
+
+    let fixed = apply_safe_fixes(
+        "items: [1 ,2]\n # wrong\n  next: value\n",
+        &cfg,
+        std::path::Path::new("input.yaml"),
+        std::path::Path::new("."),
+    );
+
+    assert_eq!(fixed, "items: [1, 2]\n  # wrong\n  next: value\n");
+}
+
+#[test]
+fn apply_safe_fixes_runs_flow_collection_spacing_fixes() {
+    let cfg = config(
+        "rules:\n  braces:\n    min-spaces-inside-empty: 1\n    max-spaces-inside-empty: 1\n  brackets:\n    min-spaces-inside-empty: 1\n    max-spaces-inside-empty: 1\n  new-line-at-end-of-file: disable\n",
+    );
+
+    let fixed = apply_safe_fixes(
+        "mapping: {  key: value   }\nsequence: []\n",
+        &cfg,
+        std::path::Path::new("input.yaml"),
+        std::path::Path::new("."),
+    );
+
+    assert_eq!(fixed, "mapping: {key: value}\nsequence: [ ]\n");
+}

--- a/tests/flow_collection_rule_behavior.rs
+++ b/tests/flow_collection_rule_behavior.rs
@@ -284,3 +284,66 @@ fn brackets_rule_suite() {
         }],
     );
 }
+
+#[test]
+fn braces_fix_normalizes_spacing() {
+    let cfg = BracesConfig::new_for_tests(Forbid::None, 0, 0, 1, 2);
+    let fixed = braces::fix("object: {  key: 1   }\nempty: {}\n", &cfg);
+    assert_eq!(fixed, Some("object: {key: 1}\nempty: { }\n".to_string()));
+}
+
+#[test]
+fn braces_fix_skips_forbid_configs() {
+    let cfg = BracesConfig::new_for_tests(Forbid::All, 0, 0, -1, -1);
+    let fixed = braces::fix("object: { key: 1 }\n", &cfg);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn brackets_fix_normalizes_spacing() {
+    let cfg = BracketsConfig::new_for_tests(Forbid::None, 0, 0, 1, 2);
+    let fixed = brackets::fix("object: [  1, 2   ]\nempty: []\n", &cfg);
+    assert_eq!(fixed, Some("object: [1, 2]\nempty: [ ]\n".to_string()));
+}
+
+#[test]
+fn brackets_fix_ignores_comments_and_newlines() {
+    let cfg = BracketsConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    let fixed = brackets::fix("object: [1, # comment\n  2]\n", &cfg);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn braces_fix_skips_template_double_curly_sequences() {
+    let cfg = BracesConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    let fixed = braces::fix("value: {{ github.token }}\n", &cfg);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn braces_fix_handles_nested_flow_collections() {
+    let cfg = BracesConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    let fixed = braces::fix("outer: { inner: {  key: 1 } }\n", &cfg);
+    assert_eq!(fixed, Some("outer: {inner: {key: 1}}\n".to_string()));
+}
+
+#[test]
+fn brackets_fix_handles_crlf_and_unmatched_closing() {
+    let cfg = BracketsConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    assert_eq!(brackets::fix("object: [1,\r\n  2]\r\n", &cfg), None);
+    assert_eq!(brackets::fix("]\n", &cfg), None);
+}
+
+#[test]
+fn braces_fix_returns_none_for_clean_multiline_collection() {
+    let cfg = BracesConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    let fixed = braces::fix("object: {key: 1,\r\n  other: 2}\r\n", &cfg);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn brackets_fix_returns_none_for_multiline_collection() {
+    let cfg = BracketsConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    let fixed = brackets::fix("seq: [\n  1,\n  2\n]\n", &cfg);
+    assert_eq!(fixed, None);
+}

--- a/tests/rule_commas.rs
+++ b/tests/rule_commas.rs
@@ -238,3 +238,20 @@ fn fix_returns_none_for_empty_input() {
     let fixed = commas::fix("", &cfg);
     assert_eq!(fixed, None);
 }
+
+#[test]
+fn ignores_commas_inside_double_curly_templates() {
+    let cfg = defaults();
+    let diagnostics = commas::check("value: {{ foo(1,2) }}\n", &cfg);
+    assert!(
+        diagnostics.is_empty(),
+        "unexpected diagnostics inside template: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn fix_ignores_commas_inside_double_curly_templates() {
+    let cfg = defaults();
+    let fixed = commas::fix("value: {{ foo(1,2) }}\n", &cfg);
+    assert_eq!(fixed, None);
+}

--- a/tests/rule_commas.rs
+++ b/tests/rule_commas.rs
@@ -203,3 +203,38 @@ fn bare_carriage_return_before_comma_is_ignored() {
         "unexpected diagnostics: {diagnostics:?}"
     );
 }
+
+#[test]
+fn fix_normalizes_spacing_around_commas() {
+    let cfg = defaults();
+    let fixed = commas::fix("[1 ,2,  3]\n", &cfg);
+    assert_eq!(fixed, Some("[1, 2, 3]\n".to_string()));
+}
+
+#[test]
+fn fix_handles_flow_mapping_entries() {
+    let cfg = defaults();
+    let fixed = commas::fix("{foo: 1 ,bar: 2}\n", &cfg);
+    assert_eq!(fixed, Some("{foo: 1, bar: 2}\n".to_string()));
+}
+
+#[test]
+fn fix_ignores_commas_inside_scalars_and_comments() {
+    let cfg = defaults();
+    let fixed = commas::fix("[\"café, menu\", # comment\n  3]\n", &cfg);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn fix_respects_relaxed_spacing_config() {
+    let cfg = Config::new_for_tests(-1, 0, -1);
+    let fixed = commas::fix("[1   ,2]\n", &cfg);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn fix_returns_none_for_empty_input() {
+    let cfg = defaults();
+    let fixed = commas::fix("", &cfg);
+    assert_eq!(fixed, None);
+}

--- a/tests/rule_comments_indentation.rs
+++ b/tests/rule_comments_indentation.rs
@@ -162,3 +162,13 @@ fn fix_returns_none_for_empty_input() {
     let fixed = comments_indentation::fix("", &Config);
     assert_eq!(fixed, None);
 }
+
+#[test]
+fn fix_preserves_comment_alignment_state_across_crlf_blank_lines() {
+    let input = "root:\r\n  # first\r\n\r\n # second\r\n  value: 1\r\n";
+    let fixed = comments_indentation::fix(input, &Config);
+    assert_eq!(
+        fixed,
+        Some("root:\r\n  # first\r\n\r\n  # second\r\n  value: 1\r\n".to_string())
+    );
+}

--- a/tests/rule_comments_indentation.rs
+++ b/tests/rule_comments_indentation.rs
@@ -125,3 +125,40 @@ fn empty_block_scalar_resets_state() {
         "empty block scalars should not cause diagnostics: {hits:?}"
     );
 }
+
+#[test]
+fn fix_aligns_misindented_comment() {
+    let input = "obj:\n # wrong\n  value: 1\n";
+    let fixed = comments_indentation::fix(input, &Config);
+    assert_eq!(fixed, Some("obj:\n  # wrong\n  value: 1\n".to_string()));
+}
+
+#[test]
+fn fix_aligns_comment_block_to_content_indent() {
+    let input = "obj1:\n  a: 1\n# heading\n  # misplaced\nobj2: no\n";
+    let fixed = comments_indentation::fix(input, &Config);
+    assert_eq!(
+        fixed,
+        Some("obj1:\n  a: 1\n# heading\n# misplaced\nobj2: no\n".to_string())
+    );
+}
+
+#[test]
+fn fix_ignores_block_scalar_regions() {
+    let input = "rule:\n  - pattern: |\n      body\n    # example\n  - other: value\n";
+    let fixed = comments_indentation::fix(input, &Config);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn fix_returns_none_when_already_aligned() {
+    let input = "obj:\n  # ok\n  value: 1\n";
+    let fixed = comments_indentation::fix(input, &Config);
+    assert_eq!(fixed, None);
+}
+
+#[test]
+fn fix_returns_none_for_empty_input() {
+    let fixed = comments_indentation::fix("", &Config);
+    assert_eq!(fixed, None);
+}


### PR DESCRIPTION
 ## Summary

  This PR adds the next batch of safe `ryl --fix` implementations:

  - `comments-indentation`
  - `commas`
  - `braces` spacing-only
  - `brackets` spacing-only

  It also bumps the project version to `0.6.0`.

  ## Notes

  - The new flow-collection fixes are intentionally limited to spacing inside existing delimiters.
  - `forbid` configurations are not auto-fixed in this PR.
  - `[fix].fixable` / `[fix].unfixable` now support the new rule names.
  - Fix-engine wiring was cleaned up to use named rule constants instead of positional indexing.

  ## Validation

  - `prek run --all-files`
  - `./scripts/coverage-missing.sh`

  Coverage remains at zero uncovered regions.