### PR TITLE
191 feat per-file-ignores

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,8 @@ jobs:
           path: dist
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          save-cache: false
       - name: Install wheel and run CLI
         run: |
           set -euxo pipefail
@@ -241,6 +243,8 @@ jobs:
           path: dist
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          save-cache: false
       - name: Install wheel and run CLI
         shell: bash
         run: |
@@ -289,6 +293,8 @@ jobs:
           path: dist
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          save-cache: false
       - name: Install wheel and run CLI
         run: |
           set -euxo pipefail

--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -5,6 +5,10 @@ generated/**
 """
 locale = "en_US.UTF-8"
 
+[per-file-ignores]
+"**/values.yaml" = ["document-start"]
+"**/kustomization.yaml" = ["document-start"]
+
 [fix]
 fixable = ["ALL"]
 unfixable = ["comments"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,11 +1467,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "dirs-next",
  "encoding_rs",
+ "globset",
  "ignore",
  "jsonschema",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.0", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "suggestions"] }
+globset = "0.4.18"
 ignore = "0.4.25"
 rayon = "1.11.0"
 schemars = { version = "1.2.1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ locale = "en_US.UTF-8"
 [per-file-ignores]
 "**/values.yaml" = ["document-start"]
 "**/kustomization.yaml" = ["document-start"]
+# `!` negates the pattern, so this ignores truthy outside Kubernetes manifests.
+"!k8s/**.yaml" = ["truthy"]
 
 [rules]
 document-start = "disable"

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ Example benchmark figure (5x5 matrix, 5 runs per point):
   for a full list of supported rules and their fixable status.
 - TOML and YAML are not merged during discovery. If a TOML project config is
   found, YAML project config discovery is skipped (and `ryl` prints a warning).
-- Native fix policy is TOML-only. YAML config remains yamllint-compatible and
-  does not support `fix` settings.
+- Native fix policy and per-file ignores are TOML-only. YAML config remains
+  yamllint-compatible and does not support ryl-native settings.
 - Per-file behavior: unless a global config is set via `--config-data`,
   `--config-file`, or `YAMLLINT_CONFIG_FILE`, each file discovers its nearest
   project config. Ignores apply to directory scans and explicit files (parity).
@@ -230,6 +230,10 @@ Example TOML config (`.ryl.toml`):
 yaml-files = ["*.yaml", "*.yml"]
 ignore = ["vendor/**", "generated/**"]
 locale = "en_US.UTF-8"
+
+[per-file-ignores]
+"**/values.yaml" = ["document-start"]
+"**/kustomization.yaml" = ["document-start"]
 
 [rules]
 document-start = "disable"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.7.0"
+  "version": "0.8.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.7.0"
+version = "0.8.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -1767,7 +1767,7 @@
           "type": "null"
         }
       ],
-      "description": "Native fix policy, available only in TOML config."
+      "description": "Native fix policy."
     },
     "ignore": {
       "anyOf": [
@@ -1805,7 +1805,7 @@
         },
         "type": "array"
       },
-      "description": "Per-file rule ignores, available only in TOML config.",
+      "description": "Per-file rule ignores.",
       "type": [
         "object",
         "null"

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -391,6 +391,35 @@
       ],
       "type": "string"
     },
+    "RuleName": {
+      "description": "A built-in lint rule name.",
+      "enum": [
+        "anchors",
+        "braces",
+        "brackets",
+        "colons",
+        "commas",
+        "comments",
+        "comments-indentation",
+        "document-end",
+        "document-start",
+        "empty-lines",
+        "empty-values",
+        "float-values",
+        "hyphens",
+        "indentation",
+        "key-duplicates",
+        "key-ordering",
+        "line-length",
+        "new-line-at-end-of-file",
+        "new-lines",
+        "octal-values",
+        "quoted-strings",
+        "trailing-spaces",
+        "truthy"
+      ],
+      "type": "string"
+    },
     "RuleOptionsForAnchorsOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1766,6 +1795,19 @@
       "description": "Locale identifier used by diagnostics.",
       "type": [
         "string",
+        "null"
+      ]
+    },
+    "per-file-ignores": {
+      "additionalProperties": {
+        "items": {
+          "$ref": "#/$defs/RuleName"
+        },
+        "type": "array"
+      },
+      "description": "Per-file rule ignores, available only in TOML config.",
+      "type": [
+        "object",
         "null"
       ]
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use globset::{Glob, GlobMatcher};
+use globset::{Glob, GlobMatcher, escape as glob_escape};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use saphyr::{LoadableYamlNode, ScalarOwned, YamlOwned};
 
@@ -156,11 +156,7 @@ impl PerFileIgnore {
         let (negated, pattern) = pattern
             .strip_prefix('!')
             .map_or((false, pattern), |stripped| (true, stripped));
-        let absolute_pattern = if Path::new(pattern).is_absolute() {
-            PathBuf::from(pattern)
-        } else {
-            base_dir.join(pattern)
-        };
+        let absolute_pattern = absolute_glob_pattern(pattern, base_dir);
         let basename_matcher = Glob::new(pattern)
             .map_err(|err| {
                 format!(
@@ -168,12 +164,8 @@ impl PerFileIgnore {
                 )
             })?
             .compile_matcher();
-        let absolute_matcher = Glob::new(&absolute_pattern.to_string_lossy())
-            .map_err(|err| {
-                format!(
-                    "invalid config: per-file-ignores pattern '{pattern}' is invalid: {err}"
-                )
-            })?
+        let absolute_matcher = Glob::new(&absolute_pattern)
+            .expect("absolute per-file ignore pattern should compile after validation")
             .compile_matcher();
         Ok(Self {
             basename_matcher,
@@ -199,6 +191,21 @@ impl PerFileIgnore {
         } else {
             filename_matches || path_matches
         }
+    }
+}
+
+fn absolute_glob_pattern(pattern: &str, base_dir: &Path) -> String {
+    if Path::new(pattern).is_absolute() {
+        pattern.to_owned()
+    } else {
+        let mut pattern_with_base = glob_escape(&base_dir.to_string_lossy());
+        if !pattern_with_base.is_empty()
+            && !pattern_with_base.ends_with(std::path::MAIN_SEPARATOR)
+        {
+            pattern_with_base.push(std::path::MAIN_SEPARATOR);
+        }
+        pattern_with_base.push_str(pattern);
+        pattern_with_base
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,10 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use globset::{Glob, GlobMatcher};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use saphyr::{LoadableYamlNode, ScalarOwned, YamlOwned};
 
@@ -116,6 +118,8 @@ pub struct YamlLintConfig {
     ignore_from_files: Vec<String>,
     #[allow(clippy::struct_field_names)]
     ignore_matcher: Option<Gitignore>,
+    per_file_ignores: BTreeMap<String, Vec<String>>,
+    per_file_ignore_matchers: Vec<PerFileIgnore>,
     rule_names: Vec<String>,
     rules: std::collections::BTreeMap<String, RuleConfig>,
     yaml_file_patterns: Vec<String>,
@@ -137,6 +141,65 @@ struct RuleFilter {
 struct RuleConfig {
     value: YamlOwned,
     filter: Option<RuleFilter>,
+}
+
+#[derive(Debug, Clone)]
+struct PerFileIgnore {
+    basename_matcher: GlobMatcher,
+    absolute_matcher: GlobMatcher,
+    negated: bool,
+    rules: Vec<String>,
+}
+
+impl PerFileIgnore {
+    fn new(pattern: &str, rules: Vec<String>, base_dir: &Path) -> Result<Self, String> {
+        let (negated, pattern) = pattern
+            .strip_prefix('!')
+            .map_or((false, pattern), |stripped| (true, stripped));
+        let absolute_pattern = if Path::new(pattern).is_absolute() {
+            PathBuf::from(pattern)
+        } else {
+            base_dir.join(pattern)
+        };
+        let basename_matcher = Glob::new(pattern)
+            .map_err(|err| {
+                format!(
+                    "invalid config: per-file-ignores pattern '{pattern}' is invalid: {err}"
+                )
+            })?
+            .compile_matcher();
+        let absolute_matcher = Glob::new(&absolute_pattern.to_string_lossy())
+            .map_err(|err| {
+                format!(
+                    "invalid config: per-file-ignores pattern '{pattern}' is invalid: {err}"
+                )
+            })?
+            .compile_matcher();
+        Ok(Self {
+            basename_matcher,
+            absolute_matcher,
+            negated,
+            rules,
+        })
+    }
+
+    fn matches(&self, path: &Path, base_dir: &Path) -> bool {
+        let filename_matches = path.file_name().is_some_and(|file_name| {
+            self.basename_matcher.is_match(Path::new(file_name))
+        });
+        let absolute_path = if path.is_absolute() {
+            Cow::Borrowed(path)
+        } else {
+            Cow::Owned(base_dir.join(path))
+        };
+        let path_matches = self.absolute_matcher.is_match(absolute_path.as_ref());
+
+        if self.negated {
+            !filename_matches && !path_matches
+        } else {
+            filename_matches || path_matches
+        }
+    }
 }
 
 impl RuleConfig {
@@ -268,6 +331,8 @@ impl Default for YamlLintConfig {
             ignore_patterns: Vec::new(),
             ignore_from_files: Vec::new(),
             ignore_matcher: None,
+            per_file_ignores: BTreeMap::new(),
+            per_file_ignore_matchers: Vec::new(),
             rule_names: Vec::new(),
             rules: std::collections::BTreeMap::new(),
             yaml_file_patterns: DEFAULT_YAML_FILE_PATTERNS
@@ -416,6 +481,11 @@ impl YamlLintConfig {
         self.rules
             .get(rule)
             .is_some_and(|config| config.is_ignored(path, base_dir))
+            || self
+                .per_file_ignore_matchers
+                .iter()
+                .filter(|entry| entry.matches(path, base_dir))
+                .any(|entry| entry.rules.iter().any(|candidate| candidate == rule))
     }
 
     #[must_use]
@@ -490,6 +560,8 @@ impl YamlLintConfig {
         if !other.yaml_file_patterns.is_empty() {
             self.yaml_file_patterns = other.yaml_file_patterns;
         }
+        self.per_file_ignores = other.per_file_ignores;
+        self.per_file_ignore_matchers = other.per_file_ignore_matchers;
         self.locale = self.locale.take().or(other.locale);
     }
 
@@ -508,6 +580,10 @@ impl YamlLintConfig {
         if let Some(yaml_files) = normalized.yaml_file_patterns {
             self.yaml_file_patterns.clear();
             self.yaml_file_patterns = yaml_files;
+        }
+
+        if !normalized.per_file_ignores.is_empty() {
+            self.per_file_ignores = normalized.per_file_ignores;
         }
 
         if let Some(locale) = normalized.locale {
@@ -545,6 +621,8 @@ impl YamlLintConfig {
             self.ignore_patterns.extend(extra_patterns);
         }
         self.ignore_matcher = matcher;
+        self.per_file_ignore_matchers =
+            build_per_file_ignores(&self.per_file_ignores, base_dir)?;
 
         self.build_yaml_matcher(base_dir);
 
@@ -644,6 +722,16 @@ fn build_ignore_matcher(
             .expect("ignore matcher build should not fail after validation")
     });
     Ok((matcher, extra_patterns))
+}
+
+fn build_per_file_ignores(
+    per_file_ignores: &BTreeMap<String, Vec<String>>,
+    base_dir: &Path,
+) -> Result<Vec<PerFileIgnore>, String> {
+    per_file_ignores
+        .iter()
+        .map(|(pattern, rules)| PerFileIgnore::new(pattern, rules.clone(), base_dir))
+        .collect()
 }
 
 fn path_matches_ignore(matcher: &Gitignore, path: &Path, base_dir: &Path) -> bool {
@@ -772,6 +860,7 @@ fn normalized_config_from_runtime(config: &YamlLintConfig) -> NormalizedConfig {
             .then(|| config.ignore_patterns.clone()),
         ignore_from_files: (!config.ignore_from_files.is_empty())
             .then(|| config.ignore_from_files.clone()),
+        per_file_ignores: config.per_file_ignores.clone(),
         yaml_file_patterns: Some(config.yaml_file_patterns.clone()),
         locale: config.locale.clone(),
         fix: normalized_fix_config(&config.fix),

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -29,6 +29,9 @@ pub struct TomlConfig {
     pub locale: Option<String>,
     /// Native fix policy, available only in TOML config.
     pub fix: Option<FixTable>,
+    /// Per-file rule ignores, available only in TOML config.
+    #[serde(rename = "per-file-ignores")]
+    pub per_file_ignores: Option<BTreeMap<String, Vec<RuleName>>>,
     /// Rule configuration table.
     pub rules: Option<RulesTable>,
     #[serde(flatten, default)]
@@ -170,6 +173,88 @@ pub enum FixRuleName {
     NewLineAtEndOfFile,
     #[serde(rename = "new-lines")]
     NewLines,
+}
+
+/// A built-in lint rule name.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
+pub enum RuleName {
+    #[serde(rename = "anchors")]
+    Anchors,
+    #[serde(rename = "braces")]
+    Braces,
+    #[serde(rename = "brackets")]
+    Brackets,
+    #[serde(rename = "colons")]
+    Colons,
+    #[serde(rename = "commas")]
+    Commas,
+    #[serde(rename = "comments")]
+    Comments,
+    #[serde(rename = "comments-indentation")]
+    CommentsIndentation,
+    #[serde(rename = "document-end")]
+    DocumentEnd,
+    #[serde(rename = "document-start")]
+    DocumentStart,
+    #[serde(rename = "empty-lines")]
+    EmptyLines,
+    #[serde(rename = "empty-values")]
+    EmptyValues,
+    #[serde(rename = "float-values")]
+    FloatValues,
+    #[serde(rename = "hyphens")]
+    Hyphens,
+    #[serde(rename = "indentation")]
+    Indentation,
+    #[serde(rename = "key-duplicates")]
+    KeyDuplicates,
+    #[serde(rename = "key-ordering")]
+    KeyOrdering,
+    #[serde(rename = "line-length")]
+    LineLength,
+    #[serde(rename = "new-line-at-end-of-file")]
+    NewLineAtEndOfFile,
+    #[serde(rename = "new-lines")]
+    NewLines,
+    #[serde(rename = "octal-values")]
+    OctalValues,
+    #[serde(rename = "quoted-strings")]
+    QuotedStrings,
+    #[serde(rename = "trailing-spaces")]
+    TrailingSpaces,
+    #[serde(rename = "truthy")]
+    Truthy,
+}
+
+impl RuleName {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Anchors => "anchors",
+            Self::Braces => "braces",
+            Self::Brackets => "brackets",
+            Self::Colons => "colons",
+            Self::Commas => "commas",
+            Self::Comments => "comments",
+            Self::CommentsIndentation => "comments-indentation",
+            Self::DocumentEnd => "document-end",
+            Self::DocumentStart => "document-start",
+            Self::EmptyLines => "empty-lines",
+            Self::EmptyValues => "empty-values",
+            Self::FloatValues => "float-values",
+            Self::Hyphens => "hyphens",
+            Self::Indentation => "indentation",
+            Self::KeyDuplicates => "key-duplicates",
+            Self::KeyOrdering => "key-ordering",
+            Self::LineLength => "line-length",
+            Self::NewLineAtEndOfFile => "new-line-at-end-of-file",
+            Self::NewLines => "new-lines",
+            Self::OctalValues => "octal-values",
+            Self::QuotedStrings => "quoted-strings",
+            Self::TrailingSpaces => "trailing-spaces",
+            Self::Truthy => "truthy",
+        }
+    }
 }
 
 /// Built-in rule table for TOML config.
@@ -620,6 +705,7 @@ pub struct NormalizedFixConfig {
 pub struct NormalizedConfig {
     pub ignore_patterns: Option<Vec<String>>,
     pub ignore_from_files: Option<Vec<String>>,
+    pub per_file_ignores: BTreeMap<String, Vec<String>>,
     pub yaml_file_patterns: Option<Vec<String>>,
     pub locale: Option<String>,
     pub fix: Option<NormalizedFixConfig>,

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -27,9 +27,9 @@ pub struct TomlConfig {
     pub ignore_from_file: Option<StringOrVec>,
     /// Locale identifier used by diagnostics.
     pub locale: Option<String>,
-    /// Native fix policy, available only in TOML config.
+    /// Native fix policy.
     pub fix: Option<FixTable>,
-    /// Per-file rule ignores, available only in TOML config.
+    /// Per-file rule ignores.
     #[serde(rename = "per-file-ignores")]
     pub per_file_ignores: Option<BTreeMap<String, Vec<RuleName>>>,
     /// Rule configuration table.

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -2,7 +2,7 @@ use saphyr::{LoadableYamlNode, MappingOwned, ScalarOwned, YamlOwned};
 use serde::Serialize;
 
 use super::{
-    FixTable, NormalizedConfig, NormalizedFixConfig, RulesTable, StringOrVec,
+    FixTable, NormalizedConfig, NormalizedFixConfig, RuleName, RulesTable, StringOrVec,
     TomlConfig, YamlConfig,
 };
 
@@ -31,6 +31,20 @@ fn normalize_fix_table(fix: &FixTable) -> NormalizedFixConfig {
             .unwrap_or_else(|| vec![super::FixableRuleSelector::All]),
         unfixable: fix.unfixable.clone().unwrap_or_default(),
     }
+}
+
+fn normalize_per_file_ignores(
+    ignores: &std::collections::BTreeMap<String, Vec<RuleName>>,
+) -> std::collections::BTreeMap<String, Vec<String>> {
+    ignores
+        .iter()
+        .map(|(pattern, rules)| {
+            (
+                pattern.clone(),
+                rules.iter().map(|rule| rule.as_str().to_string()).collect(),
+            )
+        })
+        .collect()
 }
 
 #[must_use]
@@ -117,6 +131,10 @@ pub fn normalize_toml_config(config: &TomlConfig) -> NormalizedConfig {
             .as_ref()
             .map(ignore_patterns_from_string_or_vec),
         ignore_from_files: config.ignore_from_file.as_ref().map(string_or_vec_items),
+        per_file_ignores: config
+            .per_file_ignores
+            .as_ref()
+            .map_or_else(std::collections::BTreeMap::new, normalize_per_file_ignores),
         yaml_file_patterns: config.yaml_files.clone(),
         locale: config.locale.clone(),
         fix: config.fix.as_ref().map(normalize_fix_table),
@@ -131,6 +149,7 @@ pub fn normalize_yaml_config(config: &YamlConfig) -> NormalizedConfig {
     NormalizedConfig {
         ignore_patterns: config.ignore.as_ref().map(string_or_vec_items),
         ignore_from_files: config.ignore_from_file.as_ref().map(string_or_vec_items),
+        per_file_ignores: std::collections::BTreeMap::new(),
         yaml_file_patterns: config.yaml_files.clone(),
         locale: config.locale.clone(),
         fix: None,
@@ -224,6 +243,11 @@ pub fn toml_config_to_value(config: &TomlConfig) -> toml::Value {
     );
     insert_serialized(&mut table, "locale", config.locale.as_ref());
     insert_serialized(&mut table, "fix", config.fix.as_ref());
+    insert_serialized(
+        &mut table,
+        "per-file-ignores",
+        config.per_file_ignores.as_ref(),
+    );
     if let Some(rules) = config.rules.as_ref() {
         table.insert("rules".to_string(), rules_table_to_value(rules));
     }
@@ -290,6 +314,13 @@ pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value
         table.insert("fix".to_string(), normalized_fix_to_toml_value(fix));
     }
 
+    if !config.per_file_ignores.is_empty() {
+        table.insert(
+            "per-file-ignores".to_string(),
+            normalized_per_file_ignores_to_toml_value(&config.per_file_ignores),
+        );
+    }
+
     if !config.rules.is_empty() {
         table.insert(
             "rules".to_string(),
@@ -298,4 +329,25 @@ pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value
     }
 
     toml::Value::Table(table)
+}
+
+fn normalized_per_file_ignores_to_toml_value(
+    per_file_ignores: &std::collections::BTreeMap<String, Vec<String>>,
+) -> toml::Value {
+    toml::Value::Table(
+        per_file_ignores
+            .iter()
+            .map(|(pattern, rules)| {
+                (
+                    pattern.clone(),
+                    toml::Value::Array(
+                        rules
+                            .iter()
+                            .map(|rule| toml::Value::String(rule.clone()))
+                            .collect(),
+                    ),
+                )
+            })
+            .collect(),
+    )
 }

--- a/tests/cli_per_file_ignores.rs
+++ b/tests/cli_per_file_ignores.rs
@@ -1,0 +1,147 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn toml_per_file_ignores_combine_matching_patterns() {
+    let dir = tempdir().unwrap();
+    let values = dir.path().join("values.yaml");
+    let manifest = dir.path().join("manifest.yaml");
+    fs::write(&values, "flag: yes\n").unwrap();
+    fs::write(&manifest, "flag: yes\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        r#"[rules]
+document-start = "enable"
+truthy = "enable"
+
+[per-file-ignores]
+"**/values.yaml" = ["document-start"]
+"*.yaml" = ["truthy"]
+"#,
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(&config)
+        .arg(&values)
+        .arg(&manifest));
+    assert_eq!(
+        code, 1,
+        "expected one error: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("manifest.yaml")
+            && output.contains("missing document start")
+            && output.contains("document-start"),
+        "manifest should keep document-start diagnostic: {output}"
+    );
+    assert!(
+        !output.contains("values.yaml") && !output.contains("truthy value"),
+        "values document-start and all truthy diagnostics should be ignored: {output}"
+    );
+}
+
+#[test]
+fn toml_per_file_ignores_support_ruff_negated_patterns() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    let outside = dir.path().join("outside.yaml");
+    let inside = src.join("inside.yaml");
+    fs::write(&outside, "name: value\n").unwrap();
+    fs::write(&inside, "name: value\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        r#"[rules]
+document-start = "enable"
+
+[per-file-ignores]
+"!src/**.yaml" = ["document-start"]
+"#,
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(dir.path()));
+    assert_eq!(
+        code, 1,
+        "expected one error: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("inside.yaml") && output.contains("document-start"),
+        "src file should not be ignored by negated pattern: {output}"
+    );
+    assert!(
+        !output.contains("outside.yaml"),
+        "outside file should be ignored by negated pattern: {output}"
+    );
+}
+
+#[test]
+fn toml_per_file_ignores_match_absolute_patterns() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("absolute.yaml");
+    fs::write(&file, "name: value\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        format!(
+            "[rules]\ndocument-start = 'enable'\n[per-file-ignores]\n'{}' = ['document-start']\n",
+            file.display()
+        ),
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "absolute per-file ignore should pass: stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
+fn toml_per_file_ignores_match_relative_cli_paths() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("relative.yaml");
+    fs::write(&file, "name: value\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules]\ndocument-start = 'enable'\n[per-file-ignores]\n'relative.yaml' = ['document-start']\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .current_dir(dir.path())
+        .arg("-c")
+        .arg(".ryl.toml")
+        .arg("relative.yaml"));
+    assert_eq!(
+        code, 0,
+        "relative per-file ignore should pass: stdout={stdout} stderr={stderr}"
+    );
+}

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -209,6 +209,9 @@ yaml-files = ["*.yaml", "*.yml"]
 ignore = ["vendor/**", "generated/**"]
 locale = "en_US.UTF-8"
 
+[per-file-ignores]
+"**/values.yaml" = ["document-start"]
+
 [rules]
 document-start = "disable"
 comments-indentation = true
@@ -253,12 +256,85 @@ require-starting-space = "yes"
 
 [fix]
 fixable = "comments"
+
+[per-file-ignores]
+"values.yaml" = ["not-a-rule"]
 "#,
     );
 
     assert!(
         !validator.is_valid(&instance),
         "schema should reject invalid field types"
+    );
+}
+
+#[test]
+fn normalize_toml_config_preserves_all_per_file_ignore_rule_names() {
+    let typed = parse_toml_config_str(
+        r#"
+[per-file-ignores]
+"all.yaml" = [
+    "anchors",
+    "braces",
+    "brackets",
+    "colons",
+    "commas",
+    "comments",
+    "comments-indentation",
+    "document-end",
+    "document-start",
+    "empty-lines",
+    "empty-values",
+    "float-values",
+    "hyphens",
+    "indentation",
+    "key-duplicates",
+    "key-ordering",
+    "line-length",
+    "new-line-at-end-of-file",
+    "new-lines",
+    "octal-values",
+    "quoted-strings",
+    "trailing-spaces",
+    "truthy",
+]
+"#,
+        false,
+    )
+    .unwrap()
+    .unwrap();
+    let normalized = normalize_toml_config(&typed);
+    let rules = normalized
+        .per_file_ignores
+        .get("all.yaml")
+        .expect("per-file rule list should normalize");
+    assert_eq!(
+        rules,
+        &[
+            "anchors",
+            "braces",
+            "brackets",
+            "colons",
+            "commas",
+            "comments",
+            "comments-indentation",
+            "document-end",
+            "document-start",
+            "empty-lines",
+            "empty-values",
+            "float-values",
+            "hyphens",
+            "indentation",
+            "key-duplicates",
+            "key-ordering",
+            "line-length",
+            "new-line-at-end-of-file",
+            "new-lines",
+            "octal-values",
+            "quoted-strings",
+            "trailing-spaces",
+            "truthy",
+        ]
     );
 }
 

--- a/tests/config_to_toml.rs
+++ b/tests/config_to_toml.rs
@@ -44,6 +44,29 @@ fn to_toml_includes_ignore_from_file_when_present() {
 }
 
 #[test]
+fn to_toml_includes_per_file_ignores_when_present() {
+    let td = tempdir().unwrap();
+    let cfg = td.path().join(".ryl.toml");
+    fs::write(
+        &cfg,
+        "[rules]\ndocument-start = 'enable'\n[per-file-ignores]\n'values.yaml' = ['document-start']\n",
+    )
+    .unwrap();
+    let ctx = discover_config(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+    )
+    .unwrap();
+    let toml = ctx.config.to_toml_string();
+    assert!(toml.contains("[per-file-ignores]"));
+    assert!(toml.contains("\"values.yaml\" = ["));
+    assert!(toml.contains("\"document-start\""));
+}
+
+#[test]
 fn to_toml_errors_on_null_values() {
     let err = discover_config(
         &[],

--- a/tests/config_toml_coverage.rs
+++ b/tests/config_toml_coverage.rs
@@ -78,3 +78,47 @@ fn explicit_pyproject_config_file_with_tool_ryl_loads() {
     .expect("explicit pyproject [tool.ryl]");
     assert_eq!(ctx.config.locale(), Some("it_IT.UTF-8"));
 }
+
+#[test]
+fn per_file_ignores_reject_invalid_pattern() {
+    let td = tempdir().unwrap();
+    let cfg = td.path().join(".ryl.toml");
+    fs::write(
+        &cfg,
+        "[rules]\ndocument-start = 'enable'\n[per-file-ignores]\n'[' = ['document-start']\n",
+    )
+    .unwrap();
+
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+    )
+    .unwrap_err();
+    assert!(err.contains("per-file-ignores pattern '[' is invalid"));
+}
+
+#[test]
+fn per_file_ignores_reject_invalid_absolute_pattern() {
+    let td = tempdir().unwrap();
+    let root = td.path().join("[root");
+    fs::create_dir(&root).unwrap();
+    let cfg = root.join(".ryl.toml");
+    fs::write(
+        &cfg,
+        "[rules]\ndocument-start = 'enable'\n[per-file-ignores]\n'file.yaml' = ['document-start']\n",
+    )
+    .unwrap();
+
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+    )
+    .unwrap_err();
+    assert!(err.contains("per-file-ignores pattern 'file.yaml' is invalid"));
+}

--- a/tests/config_toml_coverage.rs
+++ b/tests/config_toml_coverage.rs
@@ -101,24 +101,29 @@ fn per_file_ignores_reject_invalid_pattern() {
 }
 
 #[test]
-fn per_file_ignores_reject_invalid_absolute_pattern() {
+fn per_file_ignores_treat_base_dir_glob_chars_as_literals() {
     let td = tempdir().unwrap();
     let root = td.path().join("[root");
     fs::create_dir(&root).unwrap();
+    let file = root.join("file.yaml");
     let cfg = root.join(".ryl.toml");
+    fs::write(&file, "name: value\n").unwrap();
     fs::write(
         &cfg,
         "[rules]\ndocument-start = 'enable'\n[per-file-ignores]\n'file.yaml' = ['document-start']\n",
     )
     .unwrap();
 
-    let err = discover_config(
-        &[],
+    let ctx = discover_config(
+        std::slice::from_ref(&file),
         &Overrides {
             config_file: Some(cfg),
             config_data: None,
         },
     )
-    .unwrap_err();
-    assert!(err.contains("per-file-ignores pattern 'file.yaml' is invalid"));
+    .expect("per-file ignores with literal metacharacter base directory");
+    assert!(
+        ctx.config
+            .is_rule_ignored("document-start", &file, &ctx.base_dir)
+    );
 }

--- a/tests/fixtures/schemastore/ryl-valid.toml
+++ b/tests/fixtures/schemastore/ryl-valid.toml
@@ -2,6 +2,9 @@
 yaml-files = ["*.yaml", "*.yml"]
 ignore = ["vendor/**"]
 
+[per-file-ignores]
+"**/values.yaml" = ["document-start"]
+
 [rules]
 document-start = "disable"
 


### PR DESCRIPTION
## Summary

Adds native TOML `per-file-ignores` support, following Ruff-style semantics.

Users can now disable specific rules for files matching glob patterns:

```toml
[per-file-ignores]
"**/values.yaml" = ["document-start"]
"**/kustomization.yaml" = ["document-start"]
"!k8s/**.yaml" = ["truthy"]
```

This keeps .yamllint YAML compatibility unchanged while giving native .ryl.toml / [tool.ryl] config a focused way to handle mixed YAML repositories.

## Details

  - Adds TOML-only [per-file-ignores] schema support.
  - Validates per-file ignore rule names against built-in rules.
  - Combines ignored rules when multiple patterns match.
  - Supports Ruff-style negated patterns with !.
  - Preserves existing ignore = [...] behavior for skipping files entirely.
  - Bumps package versions to 0.8.0.
  - Reduces release smoke-test setup-uv cache-save noise by setting save-cache: false.

## Validation

  - prek run --all-files
  - ./scripts/coverage-missing.sh
  - uv run scripts/source_size.py --compare-to HEAD