### PR TITLE
184 quote type single should allow double quoted strings with escape sequences

### DIFF
--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -125,6 +125,7 @@ quote-type = "double"
 required = "only-when-needed"
 extra-required = ["^cmd$"]
 allow-quoted-quotes = true
+allow-double-quotes-for-escaping = false
 check-keys = true
 
 [rules.trailing-spaces]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ ryl is a CLI tool for linting yaml files
 - When mirroring yamllint behaviour, spot-check tricky inputs with the ryl CLI so
   our diagnostics and message text match (e.g., mixed newline styles or config keys of
   type int/bool/null/tagged scalar).
+- Keep YAML configuration strictly aligned with functionality that yamllint currently
+  supports. Put any ryl-only settings, experimental rule options, or ahead-of-upstream
+  behaviour in TOML configuration so future yamllint additions cannot clash with
+  existing YAML semantics.
 
 ## Code Change Requirements
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -37,6 +37,10 @@ The following rules are implemented and can be configured in your `.ryl.toml` (o
 Most rules follow the standard `yamllint` configuration. For detailed options,
 refer to the [yamllint documentation](https://yamllint.readthedocs.io/en/stable/rules.html).
 
+TOML configuration also supports
+`allow-double-quotes-for-escaping = true` for `quoted-strings`; this option is
+not accepted in YAML config until yamllint supports it.
+
 ### Example: `line-length`
 
 ```toml

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -97,7 +97,8 @@
       "enum": [
         "any",
         "single",
-        "double"
+        "double",
+        "consistent"
       ],
       "type": "string"
     },
@@ -355,7 +356,7 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
-    "RuleEntryForQuotedStringsOptions": {
+    "RuleEntryForTomlQuotedStringsOptions": {
       "anyOf": [
         {
           "type": "boolean"
@@ -364,7 +365,7 @@
           "$ref": "#/$defs/RuleSwitch"
         },
         {
-          "$ref": "#/$defs/RuleOptionsForQuotedStringsOptions"
+          "$ref": "#/$defs/RuleOptionsForTomlQuotedStringsOptions"
         }
       ],
       "description": "Common rule entry shape used by TOML config."
@@ -1317,10 +1318,16 @@
       },
       "type": "object"
     },
-    "RuleOptionsForQuotedStringsOptions": {
+    "RuleOptionsForTomlQuotedStringsOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
       "properties": {
+        "allow-double-quotes-for-escaping": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "allow-quoted-quotes": {
           "type": [
             "boolean",
@@ -1670,7 +1677,7 @@
         "quoted-strings": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RuleEntryForQuotedStringsOptions"
+              "$ref": "#/$defs/RuleEntryForTomlQuotedStringsOptions"
             },
             {
               "type": "null"

--- a/ryl.yaml.schema.json
+++ b/ryl.yaml.schema.json
@@ -45,7 +45,8 @@
       "enum": [
         "any",
         "single",
-        "double"
+        "double",
+        "consistent"
       ],
       "type": "string"
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -568,7 +568,6 @@ impl YamlLintConfig {
             self.yaml_file_patterns = other.yaml_file_patterns;
         }
         self.per_file_ignores = other.per_file_ignores;
-        self.per_file_ignore_matchers = other.per_file_ignore_matchers;
         self.locale = self.locale.take().or(other.locale);
     }
 

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -33,7 +33,7 @@ pub struct TomlConfig {
     #[serde(rename = "per-file-ignores")]
     pub per_file_ignores: Option<BTreeMap<String, Vec<RuleName>>>,
     /// Rule configuration table.
-    pub rules: Option<RulesTable>,
+    pub rules: Option<RulesTable<TomlQuotedStringsOptions>>,
     #[serde(flatten, default)]
     #[schemars(skip)]
     extra: BTreeMap<String, toml::Value>,
@@ -259,7 +259,7 @@ impl RuleName {
 
 /// Built-in rule table for TOML config.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
-pub struct RulesTable {
+pub struct RulesTable<Q = QuotedStringsOptions> {
     pub anchors: Option<RuleEntry<AnchorsOptions>>,
     pub braces: Option<RuleEntry<BraceLikeOptions>>,
     pub brackets: Option<RuleEntry<BraceLikeOptions>>,
@@ -293,7 +293,7 @@ pub struct RulesTable {
     #[serde(rename = "octal-values")]
     pub octal_values: Option<RuleEntry<OctalValuesOptions>>,
     #[serde(rename = "quoted-strings")]
-    pub quoted_strings: Option<RuleEntry<QuotedStringsOptions>>,
+    pub quoted_strings: Option<RuleEntry<Q>>,
     #[serde(rename = "trailing-spaces")]
     pub trailing_spaces: Option<RuleEntry<NoOptions>>,
     pub truthy: Option<RuleEntry<TruthyOptions>>,
@@ -522,6 +522,24 @@ pub struct QuotedStringsOptions {
     pub check_keys: Option<bool>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TomlQuotedStringsOptions {
+    #[serde(rename = "quote-type")]
+    pub quote_type: Option<QuoteType>,
+    pub required: Option<QuotedStringsRequired>,
+    #[serde(rename = "extra-required")]
+    pub extra_required: Option<Vec<String>>,
+    #[serde(rename = "extra-allowed")]
+    pub extra_allowed: Option<Vec<String>>,
+    #[serde(rename = "allow-quoted-quotes")]
+    pub allow_quoted_quotes: Option<bool>,
+    #[serde(rename = "allow-double-quotes-for-escaping")]
+    pub allow_double_quotes_for_escaping: Option<bool>,
+    #[serde(rename = "check-keys")]
+    pub check_keys: Option<bool>,
+}
+
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
 pub enum QuoteType {
     #[serde(rename = "any")]
@@ -530,6 +548,8 @@ pub enum QuoteType {
     Single,
     #[serde(rename = "double")]
     Double,
+    #[serde(rename = "consistent")]
+    Consistent,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -676,10 +696,10 @@ pub fn validate_yaml_config(config: &YamlConfig) -> Result<(), String> {
     )
 }
 
-fn validate_common_config(
+fn validate_common_config<Q: validation::QuotedStringsOptionSet>(
     ignore: Option<&StringOrVec>,
     ignore_from_file: Option<&StringOrVec>,
-    rules: Option<&RulesTable>,
+    rules: Option<&RulesTable<Q>>,
 ) -> Result<(), String> {
     if ignore.is_some() && ignore_from_file.is_some() {
         return Err(

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -160,8 +160,8 @@ pub fn normalize_yaml_config(config: &YamlConfig) -> NormalizedConfig {
     }
 }
 
-fn normalized_rules_from_table(
-    rules: &RulesTable,
+fn normalized_rules_from_table<Q: Serialize>(
+    rules: &RulesTable<Q>,
 ) -> std::collections::BTreeMap<String, YamlOwned> {
     rules_table_to_value(rules)
         .as_table()
@@ -186,7 +186,7 @@ fn insert_serialized<T: Serialize>(
     }
 }
 
-fn rules_table_to_value(rules: &RulesTable) -> toml::Value {
+fn rules_table_to_value<Q: Serialize>(rules: &RulesTable<Q>) -> toml::Value {
     let mut table = toml::map::Map::new();
     insert_serialized(&mut table, "anchors", rules.anchors.as_ref());
     insert_serialized(&mut table, "braces", rules.braces.as_ref());

--- a/src/config_schema/validation.rs
+++ b/src/config_schema/validation.rs
@@ -4,9 +4,44 @@ use toml::Value;
 use super::{
     KeyOrderingOptions, QuotedStringsOptions, QuotedStringsRequired,
     QuotedStringsRequiredMode, RuleEntry, RuleOptions, RulesTable,
+    TomlQuotedStringsOptions,
 };
 
-impl RulesTable {
+pub trait QuotedStringsOptionSet {
+    fn required(&self) -> Option<&QuotedStringsRequired>;
+    fn extra_required(&self) -> Option<&[String]>;
+    fn extra_allowed(&self) -> Option<&[String]>;
+}
+
+impl QuotedStringsOptionSet for QuotedStringsOptions {
+    fn required(&self) -> Option<&QuotedStringsRequired> {
+        self.required.as_ref()
+    }
+
+    fn extra_required(&self) -> Option<&[String]> {
+        self.extra_required.as_deref()
+    }
+
+    fn extra_allowed(&self) -> Option<&[String]> {
+        self.extra_allowed.as_deref()
+    }
+}
+
+impl QuotedStringsOptionSet for TomlQuotedStringsOptions {
+    fn required(&self) -> Option<&QuotedStringsRequired> {
+        self.required.as_ref()
+    }
+
+    fn extra_required(&self) -> Option<&[String]> {
+        self.extra_required.as_deref()
+    }
+
+    fn extra_allowed(&self) -> Option<&[String]> {
+        self.extra_allowed.as_deref()
+    }
+}
+
+impl<Q: QuotedStringsOptionSet> RulesTable<Q> {
     pub(super) fn validate(&self) -> Result<(), String> {
         validate_key_ordering_rule(self.key_ordering.as_ref())?;
         validate_quoted_strings_rule(self.quoted_strings.as_ref())?;
@@ -59,16 +94,16 @@ fn validate_key_ordering_rule(
 }
 
 fn validate_quoted_strings_rule(
-    entry: Option<&RuleEntry<QuotedStringsOptions>>,
+    entry: Option<&RuleEntry<impl QuotedStringsOptionSet>>,
 ) -> Result<(), String> {
     let Some(options) = rule_options(entry) else {
         return Ok(());
     };
     let specific = &options.specific;
     validate_quoted_strings_semantics(
-        quoted_strings_required_mode(specific.required.as_ref()),
-        specific.extra_required.as_deref(),
-        specific.extra_allowed.as_deref(),
+        quoted_strings_required_mode(specific.required()),
+        specific.extra_required(),
+        specific.extra_allowed(),
     )
 }
 

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -12,22 +12,52 @@ enum QuoteType {
     Any,
     Single,
     Double,
-}
-
-impl QuoteType {
-    const fn matches(self, style: Option<QuoteStyle>) -> bool {
-        match self {
-            Self::Any => style.is_some(),
-            Self::Single => matches!(style, Some(QuoteStyle::Single)),
-            Self::Double => matches!(style, Some(QuoteStyle::Double)),
-        }
-    }
+    Consistent,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum QuoteStyle {
     Single,
     Double,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScalarQuoteFacts {
+    style: Option<QuoteStyle>,
+    has_quoted_quotes: Flag,
+    has_double_quote_escape: Flag,
+    extra_required: Flag,
+    extra_allowed: Flag,
+    quotes_needed: Flag,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Flag(bool);
+
+impl Flag {
+    const fn new(value: bool) -> Self {
+        Self(value)
+    }
+
+    const fn get(self) -> bool {
+        self.0
+    }
+}
+
+fn quote_style(style: ScalarStyle) -> Option<QuoteStyle> {
+    match style {
+        ScalarStyle::SingleQuoted => Some(QuoteStyle::Single),
+        ScalarStyle::DoubleQuoted => Some(QuoteStyle::Double),
+        ScalarStyle::Plain | ScalarStyle::Literal | ScalarStyle::Folded => None,
+    }
+}
+
+fn quoted_scalar_contains_opposite_quote(style: ScalarStyle, value: &str) -> bool {
+    match style {
+        ScalarStyle::SingleQuoted => value.contains('"'),
+        ScalarStyle::DoubleQuoted => value.contains('\''),
+        _ => false,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,6 +75,7 @@ pub struct Config {
     extra_required: Vec<Regex>,
     extra_allowed: Vec<Regex>,
     allow_quoted_quotes: bool,
+    allow_double_quotes_for_escaping: bool,
     pub check_keys: bool,
 }
 
@@ -62,6 +93,7 @@ impl Config {
         {
             Some("single") => (QuoteType::Single, "single"),
             Some("double") => (QuoteType::Double, "double"),
+            Some("consistent") => (QuoteType::Consistent, "consistent"),
             _ => (QuoteType::Any, "any"),
         };
 
@@ -110,6 +142,11 @@ impl Config {
             .and_then(saphyr::YamlOwned::as_bool)
             .unwrap_or(false);
 
+        let allow_double_quotes_for_escaping = cfg
+            .rule_option(ID, "allow-double-quotes-for-escaping")
+            .and_then(saphyr::YamlOwned::as_bool)
+            .unwrap_or(false);
+
         let check_keys = cfg
             .rule_option(ID, "check-keys")
             .and_then(saphyr::YamlOwned::as_bool)
@@ -122,6 +159,7 @@ impl Config {
             extra_required,
             extra_allowed,
             allow_quoted_quotes,
+            allow_double_quotes_for_escaping,
             check_keys,
         }
     }
@@ -189,6 +227,7 @@ struct QuotedStringsState<'cfg> {
     config: &'cfg Config,
     buffer: &'cfg str,
     walker: Walker<(), bool>,
+    consistent_quote_style: Option<QuoteStyle>,
 }
 
 impl<'cfg> QuotedStringsState<'cfg> {
@@ -197,19 +236,23 @@ impl<'cfg> QuotedStringsState<'cfg> {
             config,
             buffer,
             walker: Walker::new(),
+            consistent_quote_style: None,
         }
     }
 
     fn reset_stream(&mut self) {
         self.walker.reset();
+        self.consistent_quote_style = None;
     }
 
     fn document_start(&mut self) {
         self.walker.reset();
+        self.consistent_quote_style = None;
     }
 
     fn document_end(&mut self) {
         self.walker.reset();
+        self.consistent_quote_style = None;
     }
 
     fn enter_mapping(&mut self, flow: bool) {
@@ -282,7 +325,7 @@ impl<'cfg> QuotedStringsState<'cfg> {
     }
 
     fn evaluate_scalar(
-        &self,
+        &mut self,
         style: ScalarStyle,
         value: &str,
         active_key: bool,
@@ -290,106 +333,206 @@ impl<'cfg> QuotedStringsState<'cfg> {
         span: Span,
     ) -> Option<Violation> {
         let node_label = if active_key { "key" } else { "value" };
-        let quote_style = match style {
-            ScalarStyle::SingleQuoted => Some(QuoteStyle::Single),
-            ScalarStyle::DoubleQuoted => Some(QuoteStyle::Double),
-            ScalarStyle::Plain | ScalarStyle::Literal | ScalarStyle::Folded => None,
-        };
-
-        let has_quoted_quotes = match style {
-            ScalarStyle::SingleQuoted => value.contains('"'),
-            ScalarStyle::DoubleQuoted => value.contains('\''),
-            _ => false,
-        };
-
-        let extra_required = self
-            .config
-            .extra_required
-            .iter()
-            .any(|re| re.is_match(value));
-        let extra_allowed = self
-            .config
-            .extra_allowed
-            .iter()
-            .any(|re| re.is_match(value));
-        let quotes_needed =
-            matches!(style, ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted)
-                && quotes_are_needed(style, value, self.in_flow(), self.buffer, span);
+        let facts = self.scalar_quote_facts(style, value, span);
 
         let message = match self.config.required {
-            RequiredMode::Always => {
-                if quote_style.is_none()
-                    || quote_style.is_some_and(|style_kind| {
-                        self.mismatched_quote(style_kind, has_quoted_quotes)
-                    })
-                {
-                    Some(format!(
-                        "string {node_label} is not quoted with {} quotes",
-                        self.config.quote_type_label
-                    ))
-                } else {
-                    None
-                }
-            }
-            RequiredMode::Never => quote_style.map_or_else(
-                || {
-                    if extra_required {
-                        Some(format!("string {node_label} is not quoted"))
-                    } else {
-                        None
-                    }
-                },
-                |style_kind| {
-                    if self.mismatched_quote(style_kind, has_quoted_quotes) {
-                        Some(format!(
-                            "string {node_label} is not quoted with {} quotes",
-                            self.config.quote_type_label
-                        ))
-                    } else {
-                        None
-                    }
-                },
-            ),
-            RequiredMode::OnlyWhenNeeded => quote_style.map_or_else(
-                || {
-                    if extra_required {
-                        Some(format!("string {node_label} is not quoted"))
-                    } else {
-                        None
-                    }
-                },
-                |style_kind| {
-                    if resolves_to_string && !value.is_empty() && !quotes_needed {
-                        if extra_required || extra_allowed {
-                            None
-                        } else {
-                            Some(format!(
-                                "string {node_label} is redundantly quoted with {} quotes",
-                                self.config.quote_type_label
-                            ))
-                        }
-                    } else if self.mismatched_quote(style_kind, has_quoted_quotes) {
-                        Some(format!(
-                            "string {node_label} is not quoted with {} quotes",
-                            self.config.quote_type_label
-                        ))
-                    } else {
-                        None
-                    }
-                },
+            RequiredMode::Always => self.required_always_message(node_label, facts),
+            RequiredMode::Never => self.required_never_message(node_label, facts),
+            RequiredMode::OnlyWhenNeeded => self.only_when_needed_message(
+                node_label,
+                value,
+                resolves_to_string,
+                facts,
             ),
         }?;
 
         Some(build_violation(span, message))
     }
 
-    const fn mismatched_quote(
+    fn scalar_quote_facts(
         &self,
+        style: ScalarStyle,
+        value: &str,
+        span: Span,
+    ) -> ScalarQuoteFacts {
+        ScalarQuoteFacts {
+            style: quote_style(style),
+            has_quoted_quotes: Flag::new(quoted_scalar_contains_opposite_quote(
+                style, value,
+            )),
+            has_double_quote_escape: Flag::new(
+                self.has_escaping_in_double_quotes(style, span),
+            ),
+            extra_required: Flag::new(
+                self.config
+                    .extra_required
+                    .iter()
+                    .any(|re| re.is_match(value)),
+            ),
+            extra_allowed: Flag::new(
+                self.config
+                    .extra_allowed
+                    .iter()
+                    .any(|re| re.is_match(value)),
+            ),
+            quotes_needed: Flag::new(
+                matches!(style, ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted)
+                    && quotes_are_needed(
+                        style,
+                        value,
+                        self.in_flow(),
+                        self.buffer,
+                        span,
+                    ),
+            ),
+        }
+    }
+
+    fn required_always_message(
+        &mut self,
+        node_label: &str,
+        facts: ScalarQuoteFacts,
+    ) -> Option<String> {
+        if facts.style.is_none()
+            || facts.style.is_some_and(|style_kind| {
+                self.mismatched_quote(
+                    style_kind,
+                    facts.has_quoted_quotes.get(),
+                    facts.has_double_quote_escape.get(),
+                )
+            })
+        {
+            Some(self.not_quoted_with_message(node_label))
+        } else {
+            None
+        }
+    }
+
+    fn required_never_message(
+        &mut self,
+        node_label: &str,
+        facts: ScalarQuoteFacts,
+    ) -> Option<String> {
+        facts.style.map_or_else(
+            || {
+                facts
+                    .extra_required
+                    .get()
+                    .then(|| format!("string {node_label} is not quoted"))
+            },
+            |style_kind| {
+                self.mismatched_quote(
+                    style_kind,
+                    facts.has_quoted_quotes.get(),
+                    facts.has_double_quote_escape.get(),
+                )
+                .then(|| self.not_quoted_with_message(node_label))
+            },
+        )
+    }
+
+    fn only_when_needed_message(
+        &mut self,
+        node_label: &str,
+        value: &str,
+        resolves_to_string: bool,
+        facts: ScalarQuoteFacts,
+    ) -> Option<String> {
+        facts.style.map_or_else(
+            || {
+                facts
+                    .extra_required
+                    .get()
+                    .then(|| format!("string {node_label} is not quoted"))
+            },
+            |style_kind| {
+                if resolves_to_string && !value.is_empty() && !facts.quotes_needed.get()
+                {
+                    return self.redundant_quote_message(node_label, style_kind, facts);
+                }
+                self.mismatched_quote(
+                    style_kind,
+                    facts.has_quoted_quotes.get(),
+                    facts.has_double_quote_escape.get(),
+                )
+                .then(|| self.not_quoted_with_message(node_label))
+            },
+        )
+    }
+
+    fn redundant_quote_message(
+        &self,
+        node_label: &str,
+        style_kind: QuoteStyle,
+        facts: ScalarQuoteFacts,
+    ) -> Option<String> {
+        let has_escape_exception = self.escaped_double_quote_exception(
+            style_kind,
+            facts.has_double_quote_escape.get(),
+        );
+        if facts.extra_required.get()
+            || facts.extra_allowed.get()
+            || has_escape_exception
+        {
+            None
+        } else {
+            Some(format!(
+                "string {node_label} is redundantly quoted with {} quotes",
+                self.config.quote_type_label
+            ))
+        }
+    }
+
+    fn not_quoted_with_message(&self, node_label: &str) -> String {
+        format!(
+            "string {node_label} is not quoted with {} quotes",
+            self.config.quote_type_label
+        )
+    }
+
+    fn mismatched_quote(
+        &mut self,
         style_kind: QuoteStyle,
         has_quoted_quotes: bool,
+        has_double_quote_escape: bool,
     ) -> bool {
-        !(self.config.quote_type.matches(Some(style_kind))
+        !(self.escaped_double_quote_exception(style_kind, has_double_quote_escape)
+            || self.configured_quote_type_matches(style_kind)
             || (self.config.allow_quoted_quotes && has_quoted_quotes))
+    }
+
+    fn escaped_double_quote_exception(
+        &self,
+        style_kind: QuoteStyle,
+        has_double_quote_escape: bool,
+    ) -> bool {
+        self.config.allow_double_quotes_for_escaping
+            && matches!(style_kind, QuoteStyle::Double)
+            && has_double_quote_escape
+    }
+
+    fn configured_quote_type_matches(&mut self, style_kind: QuoteStyle) -> bool {
+        match self.config.quote_type {
+            QuoteType::Any => true,
+            QuoteType::Single => matches!(style_kind, QuoteStyle::Single),
+            QuoteType::Double => matches!(style_kind, QuoteStyle::Double),
+            QuoteType::Consistent => {
+                let expected = self.consistent_quote_style.get_or_insert(style_kind);
+                *expected == style_kind
+            }
+        }
+    }
+
+    fn has_escaping_in_double_quotes(&self, style: ScalarStyle, span: Span) -> bool {
+        if !matches!(style, ScalarStyle::DoubleQuoted) {
+            return false;
+        }
+
+        let slice_start = span.start.index().saturating_add(1).min(self.buffer.len());
+        let mut slice_end = span.end.index().saturating_sub(1);
+        slice_end = slice_end.min(self.buffer.len());
+        slice_end = slice_end.max(slice_start);
+        self.buffer[slice_start..slice_end].contains('\\')
     }
 }
 

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -247,12 +247,10 @@ impl<'cfg> QuotedStringsState<'cfg> {
 
     fn document_start(&mut self) {
         self.walker.reset();
-        self.consistent_quote_style = None;
     }
 
     fn document_end(&mut self) {
         self.walker.reset();
-        self.consistent_quote_style = None;
     }
 
     fn enter_mapping(&mut self, flow: bool) {

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -45,3 +45,69 @@ fn quoted_strings_reports_redundant_quotes() {
         "rule label missing: {output}"
     );
 }
+
+#[test]
+fn toml_allows_escaped_double_quotes_as_single_quote_exception() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(&file, "escaped: \"line\\nbreak\"\nplain: \"text\"\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\nallow-double-quotes-for-escaping = true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 1,
+        "only unescaped double quotes should fail: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert!(
+        output.contains("2:8"),
+        "plain double-quoted scalar should be reported: {output}"
+    );
+    assert!(
+        !output.contains("1:10"),
+        "escaped double-quoted scalar should be allowed: {output}"
+    );
+}
+
+#[test]
+fn escaped_double_quote_exception_does_not_set_consistent_style() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(
+        &file,
+        "escaped: \"line\\nbreak\"\nfirst: 'text'\nsecond: \"text\"\n",
+    )
+    .unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nquote-type = 'consistent'\nrequired = false\nallow-double-quotes-for-escaping = true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 1,
+        "unescaped double quotes should fail after single quote baseline: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert!(
+        output.contains("3:9"),
+        "unescaped double-quoted scalar should be reported: {output}"
+    );
+    assert!(
+        !output.contains("1:10") && !output.contains("2:8"),
+        "escaped exception and single quote baseline should pass: {output}"
+    );
+}

--- a/tests/config_quoted_strings.rs
+++ b/tests/config_quoted_strings.rs
@@ -12,6 +12,14 @@ fn error_when_quote_type_invalid() {
 }
 
 #[test]
+fn quote_type_consistent_is_accepted() {
+    YamlLintConfig::from_yaml_str(
+        "rules:\n  quoted-strings:\n    quote-type: consistent\n",
+    )
+    .expect("consistent quote type should be accepted");
+}
+
+#[test]
 fn error_when_quote_type_not_string() {
     let err =
         YamlLintConfig::from_yaml_str("rules:\n  quoted-strings:\n    quote-type: 1\n")
@@ -72,6 +80,16 @@ fn error_when_extra_allowed_contains_non_string() {
 fn error_when_allow_quoted_quotes_not_bool() {
     let err = YamlLintConfig::from_yaml_str(
         "rules:\n  quoted-strings:\n    allow-quoted-quotes: 1\n",
+    )
+    .unwrap_err();
+    assert!(err.contains("failed to parse config data:"), "{err}");
+    assert!(err.contains("rules.quoted-strings"), "{err}");
+}
+
+#[test]
+fn error_when_allow_double_quotes_for_escaping_is_in_yaml_config() {
+    let err = YamlLintConfig::from_yaml_str(
+        "rules:\n  quoted-strings:\n    allow-double-quotes-for-escaping: true\n",
     )
     .unwrap_err();
     assert!(err.contains("failed to parse config data:"), "{err}");

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -231,6 +231,7 @@ check-multi-line-strings = false
 quote-type = "double"
 required = "only-when-needed"
 extra-required = ["^cmd$"]
+allow-double-quotes-for-escaping = true
 check-keys = true
 
 [fix]
@@ -468,6 +469,24 @@ fn generated_yaml_schema_rejects_invalid_known_field_types() {
 }
 
 #[test]
+fn generated_yaml_schema_rejects_toml_only_quoted_strings_option() {
+    let schema = yaml_schema_value();
+    let validator = validator_for(&schema).expect("generated schema should compile");
+    let instance = json!({
+        "rules": {
+            "quoted-strings": {
+                "allow-double-quotes-for-escaping": true
+            }
+        }
+    });
+
+    assert!(
+        !validator.is_valid(&instance),
+        "YAML schema should reject ryl-only quoted-strings options"
+    );
+}
+
+#[test]
 fn generated_yaml_schema_uses_readable_rule_wrapper_names() {
     assert_readable_rule_wrapper_defs(&yaml_schema_value());
 }
@@ -576,6 +595,19 @@ document-start = "disable"
         .and_then(toml::Value::as_str);
 
     assert_eq!(document_start, Some("disable"));
+}
+
+#[test]
+fn typed_toml_parser_accepts_toml_only_quoted_strings_option() {
+    let parsed = parse_toml_config_str(
+        "[rules.quoted-strings]\nallow-double-quotes-for-escaping = true\n",
+        false,
+    )
+    .expect("typed TOML parse should succeed")
+    .expect("project TOML should produce config");
+
+    validate_toml_config(&parsed)
+        .expect("TOML-only quoted-strings option should validate");
 }
 
 #[test]

--- a/tests/rule_quoted_strings.rs
+++ b/tests/rule_quoted_strings.rs
@@ -65,6 +65,21 @@ fn quote_type_consistent_ignores_plain_scalars_for_style_choice() {
 }
 
 #[test]
+fn quote_type_consistent_keeps_style_across_documents() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: consistent\n",
+    );
+    let hits = quoted_strings::check("---\nfirst: 'one'\n---\nsecond: \"two\"\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].line, 4);
+    assert_eq!(hits[0].column, 9);
+    assert_eq!(
+        hits[0].message,
+        "string value is not quoted with consistent quotes"
+    );
+}
+
+#[test]
 fn non_string_plain_values_are_ignored() {
     let cfg =
         build_config("rules:\n  document-start: disable\n  quoted-strings: enable\n");

--- a/tests/rule_quoted_strings.rs
+++ b/tests/rule_quoted_strings.rs
@@ -34,6 +34,37 @@ fn quote_type_single_requires_single_quotes() {
 }
 
 #[test]
+fn quote_type_consistent_uses_first_quoted_style() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: consistent\n",
+    );
+    let hits = quoted_strings::check("first: 'one'\nsecond: \"two\"\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].line, 2);
+    assert_eq!(hits[0].column, 9);
+    assert_eq!(
+        hits[0].message,
+        "string value is not quoted with consistent quotes"
+    );
+}
+
+#[test]
+fn quote_type_consistent_ignores_plain_scalars_for_style_choice() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: false\n    quote-type: consistent\n",
+    );
+    let hits =
+        quoted_strings::check("plain: value\nfirst: \"one\"\nsecond: 'two'\n", &cfg);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].line, 3);
+    assert_eq!(hits[0].column, 9);
+    assert_eq!(
+        hits[0].message,
+        "string value is not quoted with consistent quotes"
+    );
+}
+
+#[test]
 fn non_string_plain_values_are_ignored() {
     let cfg =
         build_config("rules:\n  document-start: disable\n  quoted-strings: enable\n");

--- a/tests/yamllint_compat_quoted_strings.rs
+++ b/tests/yamllint_compat_quoted_strings.rs
@@ -93,6 +93,13 @@ fn quoted_strings_rule_matches_yamllint() {
     let consistent_file = dir.path().join("consistent-input.yaml");
     fs::write(&consistent_file, "first: 'one'\nsecond: \"two\"\n").unwrap();
 
+    let consistent_multi_doc_file = dir.path().join("consistent-multi-doc.yaml");
+    fs::write(
+        &consistent_multi_doc_file,
+        "---\nfirst: 'one'\n---\nsecond: \"two\"\n",
+    )
+    .unwrap();
+
     let exe = env!("CARGO_BIN_EXE_ryl");
 
     let cases = [
@@ -136,6 +143,12 @@ fn quoted_strings_rule_matches_yamllint() {
             label: "consistent",
             config: &consistent_cfg,
             file: &consistent_file,
+            exit: 1,
+        },
+        Case {
+            label: "consistent-multi-doc",
+            config: &consistent_cfg,
+            file: &consistent_multi_doc_file,
             exit: 1,
         },
     ];

--- a/tests/yamllint_compat_quoted_strings.rs
+++ b/tests/yamllint_compat_quoted_strings.rs
@@ -65,6 +65,13 @@ fn quoted_strings_rule_matches_yamllint() {
     )
     .unwrap();
 
+    let consistent_cfg = dir.path().join("consistent.yaml");
+    fs::write(
+        &consistent_cfg,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: consistent\n",
+    )
+    .unwrap();
+
     let plain_file = dir.path().join("plain.yaml");
     fs::write(&plain_file, "foo: bar\n").unwrap();
 
@@ -82,6 +89,9 @@ fn quoted_strings_rule_matches_yamllint() {
 
     let key_file = dir.path().join("key.yaml");
     fs::write(&key_file, "foo:bar: baz\n").unwrap();
+
+    let consistent_file = dir.path().join("consistent-input.yaml");
+    fs::write(&consistent_file, "first: 'one'\nsecond: \"two\"\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
 
@@ -120,6 +130,12 @@ fn quoted_strings_rule_matches_yamllint() {
             label: "check-keys",
             config: &check_keys_cfg,
             file: &key_file,
+            exit: 1,
+        },
+        Case {
+            label: "consistent",
+            config: &consistent_cfg,
+            file: &consistent_file,
             exit: 1,
         },
     ];


### PR DESCRIPTION
## Summary

 - Add yamllint-compatible `quoted-strings.quote-type = "consistent"` support.
 - Add TOML-only `quoted-strings.allow-double-quotes-for-escaping` for escaped double-quoted scalars.
 - Keep YAML config aligned with current yamllint behavior by rejecting the new ryl-only option there.
 - Refresh TOML/YAML config schemas and add regression coverage.

## Notes

`allow-double-quotes-for-escaping` follows the direction discussed upstream in adrienverge/yamllint#777, but is TOML-only config until yamllint supports it. When used with `quote-type = "consistent"`, escaped double-quoted strings are treated as exceptions and do not establish the consistent quote baseline.

## Validation

 - `prek run --all-files`
 - `./scripts/coverage-missing.sh`
 - `uv run scripts/source_size.py --compare-to HEAD`