### PR TITLE
Add --fix support for quoted-strings rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,12 +157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -793,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -853,27 +847,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -907,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -919,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.2"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
+checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1250,7 +1249,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1275,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.2"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
+checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -1321,9 +1320,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -1373,6 +1372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1422,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -1467,7 +1475,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -1659,6 +1667,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,7 +1772,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1756,6 +1789,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2050,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2063,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2073,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2083,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2096,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -2139,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2195,20 +2239,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2222,40 +2257,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2265,21 +2279,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2295,21 +2297,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2319,21 +2309,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -28,7 +28,7 @@ The following rules are implemented and can be configured in your `.ryl.toml` (o
 | `new-line-at-end-of-file` | Checks for a single newline at the end of the file. | ✅ |
 | `new-lines` | Checks for consistent line endings (LF vs CRLF). | ✅ |
 | `octal-values` | Checks for octal value formats. | |
-| `quoted-strings` | Checks for quoted string styles. | |
+| `quoted-strings` | Checks for quoted string styles. | ✅ |
 | `trailing-spaces` | Checks for trailing whitespace. | |
 | `truthy` | Checks for truthy values (e.g., `true`, `false`). | |
 
@@ -62,6 +62,7 @@ allow-non-breakable-words = true
 - `brackets`
 - `new-lines`
 - `new-line-at-end-of-file`
+- `quoted-strings`
 
 ### Configuring Fixes (TOML only)
 

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.8.0"
+  "version": "0.9.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.8.0"
+version = "0.9.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -9,7 +9,8 @@
         "comments",
         "comments-indentation",
         "new-line-at-end-of-file",
-        "new-lines"
+        "new-lines",
+        "quoted-strings"
       ],
       "type": "string"
     },
@@ -48,7 +49,8 @@
         "comments",
         "comments-indentation",
         "new-line-at-end-of-file",
-        "new-lines"
+        "new-lines",
+        "quoted-strings"
       ],
       "type": "string"
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,6 +268,7 @@ pub enum FixRule {
     CommentsIndentation,
     NewLineAtEndOfFile,
     NewLines,
+    QuotedStrings,
 }
 
 impl FixRule {
@@ -280,6 +281,7 @@ impl FixRule {
             "comments-indentation" => Some(Self::CommentsIndentation),
             "new-line-at-end-of-file" => Some(Self::NewLineAtEndOfFile),
             "new-lines" => Some(Self::NewLines),
+            "quoted-strings" => Some(Self::QuotedStrings),
             _ => None,
         }
     }
@@ -845,6 +847,9 @@ fn normalized_fix_selector(selector: FixRuleSelector) -> TomlFixableRuleSelector
             TomlFixableRuleSelector::NewLineAtEndOfFile
         }
         FixRuleSelector::Rule(FixRule::NewLines) => TomlFixableRuleSelector::NewLines,
+        FixRuleSelector::Rule(FixRule::QuotedStrings) => {
+            TomlFixableRuleSelector::QuotedStrings
+        }
     }
 }
 
@@ -857,6 +862,7 @@ fn normalized_fix_rule(rule: FixRule) -> TomlFixRuleName {
         FixRule::CommentsIndentation => TomlFixRuleName::CommentsIndentation,
         FixRule::NewLineAtEndOfFile => TomlFixRuleName::NewLineAtEndOfFile,
         FixRule::NewLines => TomlFixRuleName::NewLines,
+        FixRule::QuotedStrings => TomlFixRuleName::QuotedStrings,
     }
 }
 
@@ -892,6 +898,9 @@ fn typed_fix_selector(selector: TomlFixableRuleSelector) -> FixRuleSelector {
             FixRuleSelector::Rule(FixRule::NewLineAtEndOfFile)
         }
         TomlFixableRuleSelector::NewLines => FixRuleSelector::Rule(FixRule::NewLines),
+        TomlFixableRuleSelector::QuotedStrings => {
+            FixRuleSelector::Rule(FixRule::QuotedStrings)
+        }
     }
 }
 
@@ -904,6 +913,7 @@ fn typed_fix_rule(rule: TomlFixRuleName) -> FixRule {
         TomlFixRuleName::CommentsIndentation => FixRule::CommentsIndentation,
         TomlFixRuleName::NewLineAtEndOfFile => FixRule::NewLineAtEndOfFile,
         TomlFixRuleName::NewLines => FixRule::NewLines,
+        TomlFixRuleName::QuotedStrings => FixRule::QuotedStrings,
     }
 }
 

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -154,6 +154,8 @@ pub enum FixableRuleSelector {
     NewLineAtEndOfFile,
     #[serde(rename = "new-lines")]
     NewLines,
+    #[serde(rename = "quoted-strings")]
+    QuotedStrings,
 }
 
 /// A fixable rule name accepted by `fix.unfixable`.
@@ -173,6 +175,8 @@ pub enum FixRuleName {
     NewLineAtEndOfFile,
     #[serde(rename = "new-lines")]
     NewLines,
+    #[serde(rename = "quoted-strings")]
+    QuotedStrings,
 }
 
 /// A built-in lint rule name.

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -4,7 +4,7 @@ use crate::config::YamlLintConfig;
 use crate::decoder;
 use crate::rules::{
     braces, brackets, commas, comments, comments_indentation, new_line_at_end_of_file,
-    new_lines,
+    new_lines, quoted_strings,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +44,10 @@ const BRACKETS_FIX: RuleFix = RuleFix {
 };
 const FINAL_NEWLINE_FIX: RuleFix = RuleFix {
     rule: new_line_at_end_of_file::ID,
+    safety: FixSafety::Safe,
+};
+const QUOTED_STRINGS_FIX: RuleFix = RuleFix {
+    rule: quoted_strings::ID,
     safety: FixSafety::Safe,
 };
 
@@ -134,6 +138,10 @@ pub fn apply_safe_fixes(
         apply_rule_fix(content, FINAL_NEWLINE_FIX, cfg, path, base_dir, |buffer| {
             let newline = target_newline(buffer, cfg, path, base_dir);
             new_line_at_end_of_file::fix(buffer, newline.as_str())
+        });
+    content =
+        apply_rule_fix(content, QUOTED_STRINGS_FIX, cfg, path, base_dir, |buffer| {
+            quoted_strings::fix(buffer, &quoted_strings::Config::resolve(cfg))
         });
 
     content

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -684,6 +684,61 @@ pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
     fixer.finish()
 }
 
+fn initial_consistent_quote_style(cfg: &Config, buffer: &str) -> Option<QuoteStyle> {
+    if !matches!(cfg.quote_type, QuoteType::Consistent) {
+        return None;
+    }
+
+    let mut parser = Parser::new_from_str(buffer);
+    let mut finder = ConsistentQuoteStyleFinder::new(cfg, buffer);
+    let _ = parser.load(&mut finder, true);
+    finder.finish()
+}
+
+struct ConsistentQuoteStyleFinder<'cfg> {
+    state: FixState<'cfg>,
+}
+
+impl<'cfg> ConsistentQuoteStyleFinder<'cfg> {
+    fn new(cfg: &'cfg Config, buffer: &'cfg str) -> Self {
+        Self {
+            state: FixState::new(cfg, buffer),
+        }
+    }
+
+    fn finish(self) -> Option<QuoteStyle> {
+        self.state.consistent_quote_style
+    }
+}
+
+impl SpannedEventReceiver<'_> for ConsistentQuoteStyleFinder<'_> {
+    fn on_event(&mut self, event: Event<'_>, span: Span) {
+        match event {
+            Event::StreamStart => self.state.reset_stream(),
+            Event::DocumentStart(_) => self.state.document_start(),
+            Event::DocumentEnd => self.state.document_end(),
+            Event::SequenceStart(_, _) => {
+                let flow = is_flow_sequence(self.state.buffer, span);
+                self.state.enter_sequence(flow);
+            }
+            Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
+            Event::MappingStart(_, _) => {
+                let flow = is_flow_mapping(self.state.buffer, span);
+                self.state.enter_mapping(flow);
+            }
+            Event::Scalar(value, style, _, tag) => {
+                self.state.collect_consistent_quote_style(
+                    style,
+                    value.as_ref(),
+                    tag.as_deref(),
+                    span,
+                );
+            }
+            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+        }
+    }
+}
+
 struct QuotedStringsFixer<'cfg> {
     state: FixState<'cfg>,
     replacements: Vec<Replacement>,
@@ -692,7 +747,11 @@ struct QuotedStringsFixer<'cfg> {
 impl<'cfg> QuotedStringsFixer<'cfg> {
     fn new(cfg: &'cfg Config, buffer: &'cfg str) -> Self {
         Self {
-            state: FixState::new(cfg, buffer),
+            state: FixState::with_consistent_quote_style(
+                cfg,
+                buffer,
+                initial_consistent_quote_style(cfg, buffer),
+            ),
             replacements: Vec::new(),
         }
     }
@@ -743,22 +802,32 @@ struct FixState<'cfg> {
     config: &'cfg Config,
     buffer: &'cfg str,
     walker: Walker<(), bool>,
+    seeded_consistent_quote_style: Option<QuoteStyle>,
     consistent_quote_style: Option<QuoteStyle>,
 }
 
 impl<'cfg> FixState<'cfg> {
     const fn new(config: &'cfg Config, buffer: &'cfg str) -> Self {
+        Self::with_consistent_quote_style(config, buffer, None)
+    }
+
+    const fn with_consistent_quote_style(
+        config: &'cfg Config,
+        buffer: &'cfg str,
+        consistent_quote_style: Option<QuoteStyle>,
+    ) -> Self {
         Self {
             config,
             buffer,
             walker: Walker::new(),
-            consistent_quote_style: None,
+            seeded_consistent_quote_style: consistent_quote_style,
+            consistent_quote_style,
         }
     }
 
     fn reset_stream(&mut self) {
         self.walker.reset();
-        self.consistent_quote_style = None;
+        self.consistent_quote_style = self.seeded_consistent_quote_style;
     }
 
     fn document_start(&mut self) {
@@ -805,6 +874,35 @@ impl<'cfg> FixState<'cfg> {
 
         self.walker.finish_node(context);
         replacement
+    }
+
+    fn collect_consistent_quote_style(
+        &mut self,
+        style: ScalarStyle,
+        value: &str,
+        tag: Option<&Tag>,
+        span: Span,
+    ) {
+        let context = self.walker.begin_node();
+        let active_key = context.active();
+        let resolves_to_string = value_resolves_to_string(value);
+
+        if self.should_skip_scalar(style, tag, active_key, resolves_to_string) {
+            self.walker.finish_node(context);
+            return;
+        }
+
+        if self.consistent_quote_style.is_none()
+            && let Some(style_kind) = quote_style(style)
+            && !self.escaped_double_quote_exception(
+                style_kind,
+                self.has_escaping_in_double_quotes(style, span),
+            )
+        {
+            self.consistent_quote_style = Some(style_kind);
+        }
+
+        self.walker.finish_node(context);
     }
 
     fn should_skip_scalar(
@@ -1061,7 +1159,7 @@ impl<'cfg> FixState<'cfg> {
 }
 
 fn value_needs_double_quotes_for_content(value: &str) -> bool {
-    value.contains('\n') || value.contains('\r')
+    value.contains('\n') || value.contains('\r') || contains_non_printable(value)
 }
 
 fn replacement_for_target(
@@ -1092,16 +1190,18 @@ fn quote_value(value: &str, style: QuoteStyle) -> String {
             result
         }
         QuoteStyle::Double => {
-            let mut result = String::with_capacity(value.len().saturating_add(2));
-            result.push('"');
-            for ch in value.chars() {
-                match ch {
-                    '\\' => result.push_str("\\\\"),
-                    '"' => result.push_str("\\\""),
-                    '\t' => result.push_str("\\t"),
-                    _ => result.push(ch),
-                }
-            }
+            let mut result = value.replace('\\', "\\\\");
+            result = result.replace('"', "\\\"");
+            result = result.replace('\0', "\\0");
+            result = result.replace('\u{7}', "\\a");
+            result = result.replace('\u{8}', "\\b");
+            result = result.replace('\t', "\\t");
+            result = result.replace('\n', "\\n");
+            result = result.replace('\u{b}', "\\v");
+            result = result.replace('\u{c}', "\\f");
+            result = result.replace('\r', "\\r");
+            result = result.replace('\u{1b}', "\\e");
+            result.insert(0, '"');
             result.push('"');
             result
         }

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -599,6 +599,9 @@ fn quotes_are_needed(
     }
 
     if matches!(style, ScalarStyle::DoubleQuoted) {
+        if value.contains('\t') {
+            return true;
+        }
         if contains_non_printable(value) {
             return true;
         }

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -283,7 +283,7 @@ impl<'cfg> QuotedStringsState<'cfg> {
         let active_key = context.active();
         let resolves_to_string = value_resolves_to_string(value);
 
-        if self.should_skip_scalar(style, tag, active_key, resolves_to_string) {
+        if should_skip_scalar(self.config, style, tag, active_key, resolves_to_string) {
             self.walker.finish_node(context);
             return;
         }
@@ -301,30 +301,6 @@ impl<'cfg> QuotedStringsState<'cfg> {
         self.walker.any_metadata(|flow| *flow)
     }
 
-    fn should_skip_scalar(
-        &self,
-        style: ScalarStyle,
-        tag: Option<&Tag>,
-        active_key: bool,
-        resolves_to_string: bool,
-    ) -> bool {
-        if matches!(style, ScalarStyle::Literal | ScalarStyle::Folded) {
-            return true;
-        }
-
-        if active_key && !self.config.check_keys {
-            return true;
-        }
-
-        if let Some(tag) = tag
-            && is_core_tag(tag)
-        {
-            return true;
-        }
-
-        matches!(style, ScalarStyle::Plain) && !resolves_to_string
-    }
-
     fn evaluate_scalar(
         &mut self,
         style: ScalarStyle,
@@ -334,7 +310,14 @@ impl<'cfg> QuotedStringsState<'cfg> {
         span: Span,
     ) -> Option<Violation> {
         let node_label = if active_key { "key" } else { "value" };
-        let facts = self.scalar_quote_facts(style, value, span);
+        let facts = scalar_quote_facts(
+            self.config,
+            self.buffer,
+            self.in_flow(),
+            style,
+            value,
+            span,
+        );
 
         let message = match self.config.required {
             RequiredMode::Always => self.required_always_message(node_label, facts),
@@ -348,45 +331,6 @@ impl<'cfg> QuotedStringsState<'cfg> {
         }?;
 
         Some(build_violation(span, message))
-    }
-
-    fn scalar_quote_facts(
-        &self,
-        style: ScalarStyle,
-        value: &str,
-        span: Span,
-    ) -> ScalarQuoteFacts {
-        ScalarQuoteFacts {
-            style: quote_style(style),
-            has_quoted_quotes: Flag::new(quoted_scalar_contains_opposite_quote(
-                style, value,
-            )),
-            has_double_quote_escape: Flag::new(
-                self.has_escaping_in_double_quotes(style, span),
-            ),
-            extra_required: Flag::new(
-                self.config
-                    .extra_required
-                    .iter()
-                    .any(|re| re.is_match(value)),
-            ),
-            extra_allowed: Flag::new(
-                self.config
-                    .extra_allowed
-                    .iter()
-                    .any(|re| re.is_match(value)),
-            ),
-            quotes_needed: Flag::new(
-                matches!(style, ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted)
-                    && quotes_are_needed(
-                        style,
-                        value,
-                        self.in_flow(),
-                        self.buffer,
-                        span,
-                    ),
-            ),
-        }
     }
 
     fn required_always_message(
@@ -467,7 +411,8 @@ impl<'cfg> QuotedStringsState<'cfg> {
         style_kind: QuoteStyle,
         facts: ScalarQuoteFacts,
     ) -> Option<String> {
-        let has_escape_exception = self.escaped_double_quote_exception(
+        let has_escape_exception = escaped_double_quote_exception(
+            self.config,
             style_kind,
             facts.has_double_quote_escape.get(),
         );
@@ -497,47 +442,15 @@ impl<'cfg> QuotedStringsState<'cfg> {
         has_quoted_quotes: bool,
         has_double_quote_escape: bool,
     ) -> bool {
-        !(self.escaped_double_quote_exception(style_kind, has_double_quote_escape)
-            || self.configured_quote_type_matches(style_kind)
-            || (self.config.allow_quoted_quotes && has_quoted_quotes))
-    }
-
-    fn escaped_double_quote_exception(
-        &self,
-        style_kind: QuoteStyle,
-        has_double_quote_escape: bool,
-    ) -> bool {
-        if !self.config.allow_double_quotes_for_escaping {
-            return false;
-        }
-        if !matches!(style_kind, QuoteStyle::Double) {
-            return false;
-        }
-        has_double_quote_escape
-    }
-
-    fn configured_quote_type_matches(&mut self, style_kind: QuoteStyle) -> bool {
-        match self.config.quote_type {
-            QuoteType::Any => true,
-            QuoteType::Single => matches!(style_kind, QuoteStyle::Single),
-            QuoteType::Double => matches!(style_kind, QuoteStyle::Double),
-            QuoteType::Consistent => {
-                let expected = self.consistent_quote_style.get_or_insert(style_kind);
-                *expected == style_kind
-            }
-        }
-    }
-
-    fn has_escaping_in_double_quotes(&self, style: ScalarStyle, span: Span) -> bool {
-        if !matches!(style, ScalarStyle::DoubleQuoted) {
-            return false;
-        }
-
-        let slice_start = span.start.index().saturating_add(1).min(self.buffer.len());
-        let mut slice_end = span.end.index().saturating_sub(1);
-        slice_end = slice_end.min(self.buffer.len());
-        slice_end = slice_end.max(slice_start);
-        self.buffer[slice_start..slice_end].contains('\\')
+        !(escaped_double_quote_exception(
+            self.config,
+            style_kind,
+            has_double_quote_escape,
+        ) || configured_quote_type_matches(
+            self.config,
+            &mut self.consistent_quote_style,
+            style_kind,
+        ) || (self.config.allow_quoted_quotes && has_quoted_quotes))
     }
 }
 
@@ -577,6 +490,97 @@ fn value_resolves_to_string(value: &str) -> bool {
         Yaml::value_from_str(value),
         Yaml::Value(saphyr::Scalar::String(_))
     )
+}
+
+fn should_skip_scalar(
+    config: &Config,
+    style: ScalarStyle,
+    tag: Option<&Tag>,
+    active_key: bool,
+    resolves_to_string: bool,
+) -> bool {
+    if matches!(style, ScalarStyle::Literal | ScalarStyle::Folded) {
+        return true;
+    }
+
+    if active_key && !config.check_keys {
+        return true;
+    }
+
+    if let Some(tag) = tag
+        && is_core_tag(tag)
+    {
+        return true;
+    }
+
+    matches!(style, ScalarStyle::Plain) && !resolves_to_string
+}
+
+fn scalar_quote_facts(
+    config: &Config,
+    buffer: &str,
+    in_flow: bool,
+    style: ScalarStyle,
+    value: &str,
+    span: Span,
+) -> ScalarQuoteFacts {
+    ScalarQuoteFacts {
+        style: quote_style(style),
+        has_quoted_quotes: Flag::new(quoted_scalar_contains_opposite_quote(
+            style, value,
+        )),
+        has_double_quote_escape: Flag::new(has_escaping_in_double_quotes(
+            buffer, style, span,
+        )),
+        extra_required: Flag::new(
+            config.extra_required.iter().any(|re| re.is_match(value)),
+        ),
+        extra_allowed: Flag::new(
+            config.extra_allowed.iter().any(|re| re.is_match(value)),
+        ),
+        quotes_needed: Flag::new(
+            matches!(style, ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted)
+                && quotes_are_needed(style, value, in_flow, buffer, span),
+        ),
+    }
+}
+
+fn escaped_double_quote_exception(
+    config: &Config,
+    style_kind: QuoteStyle,
+    has_double_quote_escape: bool,
+) -> bool {
+    config.allow_double_quotes_for_escaping
+        && matches!(style_kind, QuoteStyle::Double)
+        && has_double_quote_escape
+}
+
+fn configured_quote_type_matches(
+    config: &Config,
+    consistent_quote_style: &mut Option<QuoteStyle>,
+    style_kind: QuoteStyle,
+) -> bool {
+    match config.quote_type {
+        QuoteType::Any => true,
+        QuoteType::Single => matches!(style_kind, QuoteStyle::Single),
+        QuoteType::Double => matches!(style_kind, QuoteStyle::Double),
+        QuoteType::Consistent => {
+            let expected = consistent_quote_style.get_or_insert(style_kind);
+            *expected == style_kind
+        }
+    }
+}
+
+fn has_escaping_in_double_quotes(buffer: &str, style: ScalarStyle, span: Span) -> bool {
+    if !matches!(style, ScalarStyle::DoubleQuoted) {
+        return false;
+    }
+
+    let slice_start = span.start.index().saturating_add(1).min(buffer.len());
+    let mut slice_end = span.end.index().saturating_sub(1);
+    slice_end = slice_end.min(buffer.len());
+    slice_end = slice_end.max(slice_start);
+    buffer[slice_start..slice_end].contains('\\')
 }
 
 fn quotes_are_needed(
@@ -865,7 +869,7 @@ impl<'cfg> FixState<'cfg> {
         let active_key = context.active();
         let resolves_to_string = value_resolves_to_string(value);
 
-        if self.should_skip_scalar(style, tag, active_key, resolves_to_string) {
+        if should_skip_scalar(self.config, style, tag, active_key, resolves_to_string) {
             self.walker.finish_node(context);
             return None;
         }
@@ -887,82 +891,23 @@ impl<'cfg> FixState<'cfg> {
         let active_key = context.active();
         let resolves_to_string = value_resolves_to_string(value);
 
-        if self.should_skip_scalar(style, tag, active_key, resolves_to_string) {
+        if should_skip_scalar(self.config, style, tag, active_key, resolves_to_string) {
             self.walker.finish_node(context);
             return;
         }
 
         if self.consistent_quote_style.is_none()
             && let Some(style_kind) = quote_style(style)
-            && !self.escaped_double_quote_exception(
+            && !escaped_double_quote_exception(
+                self.config,
                 style_kind,
-                self.has_escaping_in_double_quotes(style, span),
+                has_escaping_in_double_quotes(self.buffer, style, span),
             )
         {
             self.consistent_quote_style = Some(style_kind);
         }
 
         self.walker.finish_node(context);
-    }
-
-    fn should_skip_scalar(
-        &self,
-        style: ScalarStyle,
-        tag: Option<&Tag>,
-        active_key: bool,
-        resolves_to_string: bool,
-    ) -> bool {
-        if matches!(style, ScalarStyle::Literal | ScalarStyle::Folded) {
-            return true;
-        }
-        if active_key && !self.config.check_keys {
-            return true;
-        }
-        if let Some(tag) = tag
-            && is_core_tag(tag)
-        {
-            return true;
-        }
-        matches!(style, ScalarStyle::Plain) && !resolves_to_string
-    }
-
-    fn scalar_quote_facts(
-        &self,
-        style: ScalarStyle,
-        value: &str,
-        span: Span,
-    ) -> ScalarQuoteFacts {
-        ScalarQuoteFacts {
-            style: quote_style(style),
-            has_quoted_quotes: Flag::new(quoted_scalar_contains_opposite_quote(
-                style, value,
-            )),
-            has_double_quote_escape: Flag::new(
-                self.has_escaping_in_double_quotes(style, span),
-            ),
-            extra_required: Flag::new(
-                self.config
-                    .extra_required
-                    .iter()
-                    .any(|re| re.is_match(value)),
-            ),
-            extra_allowed: Flag::new(
-                self.config
-                    .extra_allowed
-                    .iter()
-                    .any(|re| re.is_match(value)),
-            ),
-            quotes_needed: Flag::new(
-                matches!(style, ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted)
-                    && quotes_are_needed(
-                        style,
-                        value,
-                        self.in_flow(),
-                        self.buffer,
-                        span,
-                    ),
-            ),
-        }
     }
 
     fn compute_fix(
@@ -972,7 +917,14 @@ impl<'cfg> FixState<'cfg> {
         resolves_to_string: bool,
         span: Span,
     ) -> Option<Replacement> {
-        let facts = self.scalar_quote_facts(style, value, span);
+        let facts = scalar_quote_facts(
+            self.config,
+            self.buffer,
+            self.in_flow(),
+            style,
+            value,
+            span,
+        );
         let start = span.start.index();
         let end = span.end.index();
 
@@ -1079,7 +1031,8 @@ impl<'cfg> FixState<'cfg> {
         style_kind: QuoteStyle,
         facts: ScalarQuoteFacts,
     ) -> bool {
-        let has_escape_exception = self.escaped_double_quote_exception(
+        let has_escape_exception = escaped_double_quote_exception(
+            self.config,
             style_kind,
             facts.has_double_quote_escape.get(),
         );
@@ -1112,49 +1065,15 @@ impl<'cfg> FixState<'cfg> {
         style_kind: QuoteStyle,
         facts: ScalarQuoteFacts,
     ) -> bool {
-        !(self.escaped_double_quote_exception(
+        !(escaped_double_quote_exception(
+            self.config,
             style_kind,
             facts.has_double_quote_escape.get(),
-        ) || self.configured_quote_type_matches(style_kind)
-            || (self.config.allow_quoted_quotes && facts.has_quoted_quotes.get()))
-    }
-
-    fn escaped_double_quote_exception(
-        &self,
-        style_kind: QuoteStyle,
-        has_double_quote_escape: bool,
-    ) -> bool {
-        if !self.config.allow_double_quotes_for_escaping {
-            return false;
-        }
-        if !matches!(style_kind, QuoteStyle::Double) {
-            return false;
-        }
-        has_double_quote_escape
-    }
-
-    fn configured_quote_type_matches(&mut self, style_kind: QuoteStyle) -> bool {
-        match self.config.quote_type {
-            QuoteType::Any => true,
-            QuoteType::Single => matches!(style_kind, QuoteStyle::Single),
-            QuoteType::Double => matches!(style_kind, QuoteStyle::Double),
-            QuoteType::Consistent => {
-                let expected = self.consistent_quote_style.get_or_insert(style_kind);
-                *expected == style_kind
-            }
-        }
-    }
-
-    fn has_escaping_in_double_quotes(&self, style: ScalarStyle, span: Span) -> bool {
-        if !matches!(style, ScalarStyle::DoubleQuoted) {
-            return false;
-        }
-
-        let slice_start = span.start.index().saturating_add(1).min(self.buffer.len());
-        let mut slice_end = span.end.index().saturating_sub(1);
-        slice_end = slice_end.min(self.buffer.len());
-        slice_end = slice_end.max(slice_start);
-        self.buffer[slice_start..slice_end].contains('\\')
+        ) || configured_quote_type_matches(
+            self.config,
+            &mut self.consistent_quote_style,
+            style_kind,
+        ) || (self.config.allow_quoted_quotes && facts.has_quoted_quotes.get()))
     }
 }
 
@@ -1174,6 +1093,26 @@ fn replacement_for_target(
     Some((start, end, quote_value(value, target)))
 }
 
+const DOUBLE_QUOTE_ESCAPES: &[(char, &str)] = &[
+    ('\\', "\\\\"),
+    ('"', "\\\""),
+    ('\0', "\\0"),
+    ('\u{7}', "\\a"),
+    ('\u{8}', "\\b"),
+    ('\t', "\\t"),
+    ('\n', "\\n"),
+    ('\u{b}', "\\v"),
+    ('\u{c}', "\\f"),
+    ('\r', "\\r"),
+    ('\u{1b}', "\\e"),
+];
+
+fn double_quote_escape(ch: char) -> Option<&'static str> {
+    DOUBLE_QUOTE_ESCAPES
+        .iter()
+        .find_map(|(candidate, escape)| (*candidate == ch).then_some(*escape))
+}
+
 fn quote_value(value: &str, style: QuoteStyle) -> String {
     match style {
         QuoteStyle::Single => {
@@ -1190,18 +1129,15 @@ fn quote_value(value: &str, style: QuoteStyle) -> String {
             result
         }
         QuoteStyle::Double => {
-            let mut result = value.replace('\\', "\\\\");
-            result = result.replace('"', "\\\"");
-            result = result.replace('\0', "\\0");
-            result = result.replace('\u{7}', "\\a");
-            result = result.replace('\u{8}', "\\b");
-            result = result.replace('\t', "\\t");
-            result = result.replace('\n', "\\n");
-            result = result.replace('\u{b}', "\\v");
-            result = result.replace('\u{c}', "\\f");
-            result = result.replace('\r', "\\r");
-            result = result.replace('\u{1b}', "\\e");
-            result.insert(0, '"');
+            let mut result = String::with_capacity(value.len().saturating_add(2));
+            result.push('"');
+            for ch in value.chars() {
+                if let Some(escape) = double_quote_escape(ch) {
+                    result.push_str(escape);
+                } else {
+                    result.push(ch);
+                }
+            }
             result.push('"');
             result
         }

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -163,6 +163,12 @@ impl Config {
             check_keys,
         }
     }
+
+    #[must_use]
+    pub fn with_allow_double_quotes_for_escaping(mut self, value: bool) -> Self {
+        self.allow_double_quotes_for_escaping = value;
+        self
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -275,10 +281,7 @@ impl<'cfg> QuotedStringsState<'cfg> {
     ) {
         let context = self.walker.begin_node();
         let active_key = context.active();
-        let resolves_to_string = matches!(
-            Yaml::value_from_str(value),
-            Yaml::Value(saphyr::Scalar::String(_))
-        );
+        let resolves_to_string = value_resolves_to_string(value);
 
         if self.should_skip_scalar(style, tag, active_key, resolves_to_string) {
             self.walker.finish_node(context);
@@ -504,9 +507,13 @@ impl<'cfg> QuotedStringsState<'cfg> {
         style_kind: QuoteStyle,
         has_double_quote_escape: bool,
     ) -> bool {
-        self.config.allow_double_quotes_for_escaping
-            && matches!(style_kind, QuoteStyle::Double)
-            && has_double_quote_escape
+        if !self.config.allow_double_quotes_for_escaping {
+            return false;
+        }
+        if !matches!(style_kind, QuoteStyle::Double) {
+            return false;
+        }
+        has_double_quote_escape
     }
 
     fn configured_quote_type_matches(&mut self, style_kind: QuoteStyle) -> bool {
@@ -563,6 +570,13 @@ fn next_non_whitespace_char(text: &str, byte_idx: usize) -> Option<char> {
 
 fn is_core_tag(tag: &Tag) -> bool {
     tag.handle == "tag:yaml.org,2002:"
+}
+
+fn value_resolves_to_string(value: &str) -> bool {
+    matches!(
+        Yaml::value_from_str(value),
+        Yaml::Value(saphyr::Scalar::String(_))
+    )
 }
 
 fn quotes_are_needed(
@@ -658,4 +672,438 @@ fn has_backslash_line_ending(buffer: &str, span: Span) -> bool {
     let has_unix_backslash = content.contains("\\\n");
     let has_windows_backslash = content.contains("\\\r\n");
     has_unix_backslash || has_windows_backslash
+}
+
+type Replacement = (usize, usize, String);
+
+#[must_use]
+pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
+    let mut parser = Parser::new_from_str(buffer);
+    let mut fixer = QuotedStringsFixer::new(cfg, buffer);
+    let _ = parser.load(&mut fixer, true);
+    fixer.finish()
+}
+
+struct QuotedStringsFixer<'cfg> {
+    state: FixState<'cfg>,
+    replacements: Vec<Replacement>,
+}
+
+impl<'cfg> QuotedStringsFixer<'cfg> {
+    fn new(cfg: &'cfg Config, buffer: &'cfg str) -> Self {
+        Self {
+            state: FixState::new(cfg, buffer),
+            replacements: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> Option<String> {
+        let mut replacements = self.replacements;
+        if replacements.is_empty() {
+            return None;
+        }
+        replacements.sort_by(|a, b| b.0.cmp(&a.0));
+        let mut output = self.state.buffer.to_owned();
+        for (start, end, replacement) in replacements {
+            output.replace_range(start..end, &replacement);
+        }
+        Some(output)
+    }
+}
+
+impl SpannedEventReceiver<'_> for QuotedStringsFixer<'_> {
+    fn on_event(&mut self, event: Event<'_>, span: Span) {
+        match event {
+            Event::StreamStart => self.state.reset_stream(),
+            Event::DocumentStart(_) => self.state.document_start(),
+            Event::DocumentEnd => self.state.document_end(),
+            Event::SequenceStart(_, _) => {
+                let flow = is_flow_sequence(self.state.buffer, span);
+                self.state.enter_sequence(flow);
+            }
+            Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
+            Event::MappingStart(_, _) => {
+                let flow = is_flow_mapping(self.state.buffer, span);
+                self.state.enter_mapping(flow);
+            }
+            Event::Scalar(value, style, _, tag) => {
+                if let Some(r) =
+                    self.state
+                        .fix_scalar(style, value.as_ref(), tag.as_deref(), span)
+                {
+                    self.replacements.push(r);
+                }
+            }
+            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+        }
+    }
+}
+
+struct FixState<'cfg> {
+    config: &'cfg Config,
+    buffer: &'cfg str,
+    walker: Walker<(), bool>,
+    consistent_quote_style: Option<QuoteStyle>,
+}
+
+impl<'cfg> FixState<'cfg> {
+    const fn new(config: &'cfg Config, buffer: &'cfg str) -> Self {
+        Self {
+            config,
+            buffer,
+            walker: Walker::new(),
+            consistent_quote_style: None,
+        }
+    }
+
+    fn reset_stream(&mut self) {
+        self.walker.reset();
+        self.consistent_quote_style = None;
+    }
+
+    fn document_start(&mut self) {
+        self.walker.reset();
+    }
+
+    fn document_end(&mut self) {
+        self.walker.reset();
+    }
+
+    fn enter_mapping(&mut self, flow: bool) {
+        self.walker.enter_mapping((), flow);
+    }
+
+    fn enter_sequence(&mut self, flow: bool) {
+        self.walker.enter_sequence(flow);
+    }
+
+    fn exit_container(&mut self) {
+        self.walker.exit_container();
+    }
+
+    fn in_flow(&self) -> bool {
+        self.walker.any_metadata(|flow| *flow)
+    }
+
+    fn fix_scalar(
+        &mut self,
+        style: ScalarStyle,
+        value: &str,
+        tag: Option<&Tag>,
+        span: Span,
+    ) -> Option<Replacement> {
+        let context = self.walker.begin_node();
+        let active_key = context.active();
+        let resolves_to_string = value_resolves_to_string(value);
+
+        if self.should_skip_scalar(style, tag, active_key, resolves_to_string) {
+            self.walker.finish_node(context);
+            return None;
+        }
+
+        let replacement = self.compute_fix(style, value, resolves_to_string, span);
+
+        self.walker.finish_node(context);
+        replacement
+    }
+
+    fn should_skip_scalar(
+        &self,
+        style: ScalarStyle,
+        tag: Option<&Tag>,
+        active_key: bool,
+        resolves_to_string: bool,
+    ) -> bool {
+        if matches!(style, ScalarStyle::Literal | ScalarStyle::Folded) {
+            return true;
+        }
+        if active_key && !self.config.check_keys {
+            return true;
+        }
+        if let Some(tag) = tag
+            && is_core_tag(tag)
+        {
+            return true;
+        }
+        matches!(style, ScalarStyle::Plain) && !resolves_to_string
+    }
+
+    fn scalar_quote_facts(
+        &self,
+        style: ScalarStyle,
+        value: &str,
+        span: Span,
+    ) -> ScalarQuoteFacts {
+        ScalarQuoteFacts {
+            style: quote_style(style),
+            has_quoted_quotes: Flag::new(quoted_scalar_contains_opposite_quote(
+                style, value,
+            )),
+            has_double_quote_escape: Flag::new(
+                self.has_escaping_in_double_quotes(style, span),
+            ),
+            extra_required: Flag::new(
+                self.config
+                    .extra_required
+                    .iter()
+                    .any(|re| re.is_match(value)),
+            ),
+            extra_allowed: Flag::new(
+                self.config
+                    .extra_allowed
+                    .iter()
+                    .any(|re| re.is_match(value)),
+            ),
+            quotes_needed: Flag::new(
+                matches!(style, ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted)
+                    && quotes_are_needed(
+                        style,
+                        value,
+                        self.in_flow(),
+                        self.buffer,
+                        span,
+                    ),
+            ),
+        }
+    }
+
+    fn compute_fix(
+        &mut self,
+        style: ScalarStyle,
+        value: &str,
+        resolves_to_string: bool,
+        span: Span,
+    ) -> Option<Replacement> {
+        let facts = self.scalar_quote_facts(style, value, span);
+        let start = span.start.index();
+        let end = span.end.index();
+
+        match self.config.required {
+            RequiredMode::Always => self.fix_required_always(value, facts, start, end),
+            RequiredMode::Never => self.fix_required_never(value, facts, start, end),
+            RequiredMode::OnlyWhenNeeded => {
+                self.fix_only_when_needed(value, resolves_to_string, facts, start, end)
+            }
+        }
+    }
+
+    fn fix_required_always(
+        &mut self,
+        value: &str,
+        facts: ScalarQuoteFacts,
+        start: usize,
+        end: usize,
+    ) -> Option<Replacement> {
+        match facts.style {
+            None => {
+                let target = self.default_quote_style();
+                replacement_for_target(value, start, end, target)
+            }
+            Some(style_kind) => {
+                if self.mismatched_quote(style_kind, facts) {
+                    let target = self.target_quote_style(style_kind);
+                    replacement_for_target(value, start, end, target)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn fix_required_never(
+        &mut self,
+        value: &str,
+        facts: ScalarQuoteFacts,
+        start: usize,
+        end: usize,
+    ) -> Option<Replacement> {
+        match facts.style {
+            None => {
+                if facts.extra_required.get() {
+                    let target = self.default_quote_style();
+                    replacement_for_target(value, start, end, target)
+                } else {
+                    None
+                }
+            }
+            Some(style_kind) => {
+                if self.mismatched_quote(style_kind, facts) {
+                    let target = self.target_quote_style(style_kind);
+                    replacement_for_target(value, start, end, target)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn fix_only_when_needed(
+        &mut self,
+        value: &str,
+        resolves_to_string: bool,
+        facts: ScalarQuoteFacts,
+        start: usize,
+        end: usize,
+    ) -> Option<Replacement> {
+        match facts.style {
+            None => {
+                if facts.extra_required.get() {
+                    let target = self.default_quote_style();
+                    replacement_for_target(value, start, end, target)
+                } else {
+                    None
+                }
+            }
+            Some(style_kind) => {
+                if resolves_to_string && !value.is_empty() && !facts.quotes_needed.get()
+                {
+                    if self.redundant_quote_allowed(style_kind, facts) {
+                        if self.mismatched_quote(style_kind, facts) {
+                            let target = self.target_quote_style(style_kind);
+                            return replacement_for_target(value, start, end, target);
+                        }
+                        return None;
+                    }
+                    return Some((start, end, value.to_owned()));
+                }
+                if self.mismatched_quote(style_kind, facts) {
+                    let target = self.target_quote_style(style_kind);
+                    replacement_for_target(value, start, end, target)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn redundant_quote_allowed(
+        &self,
+        style_kind: QuoteStyle,
+        facts: ScalarQuoteFacts,
+    ) -> bool {
+        let has_escape_exception = self.escaped_double_quote_exception(
+            style_kind,
+            facts.has_double_quote_escape.get(),
+        );
+        facts.extra_required.get() || facts.extra_allowed.get() || has_escape_exception
+    }
+
+    fn default_quote_style(&mut self) -> QuoteStyle {
+        match self.config.quote_type {
+            QuoteType::Double => QuoteStyle::Double,
+            QuoteType::Consistent => *self
+                .consistent_quote_style
+                .get_or_insert(QuoteStyle::Single),
+            QuoteType::Single | QuoteType::Any => QuoteStyle::Single,
+        }
+    }
+
+    fn target_quote_style(&mut self, current: QuoteStyle) -> QuoteStyle {
+        match self.config.quote_type {
+            QuoteType::Single | QuoteType::Any => QuoteStyle::Single,
+            QuoteType::Double => QuoteStyle::Double,
+            QuoteType::Consistent => {
+                let expected = self.consistent_quote_style.get_or_insert(current);
+                *expected
+            }
+        }
+    }
+
+    fn mismatched_quote(
+        &mut self,
+        style_kind: QuoteStyle,
+        facts: ScalarQuoteFacts,
+    ) -> bool {
+        !(self.escaped_double_quote_exception(
+            style_kind,
+            facts.has_double_quote_escape.get(),
+        ) || self.configured_quote_type_matches(style_kind)
+            || (self.config.allow_quoted_quotes && facts.has_quoted_quotes.get()))
+    }
+
+    fn escaped_double_quote_exception(
+        &self,
+        style_kind: QuoteStyle,
+        has_double_quote_escape: bool,
+    ) -> bool {
+        if !self.config.allow_double_quotes_for_escaping {
+            return false;
+        }
+        if !matches!(style_kind, QuoteStyle::Double) {
+            return false;
+        }
+        has_double_quote_escape
+    }
+
+    fn configured_quote_type_matches(&mut self, style_kind: QuoteStyle) -> bool {
+        match self.config.quote_type {
+            QuoteType::Any => true,
+            QuoteType::Single => matches!(style_kind, QuoteStyle::Single),
+            QuoteType::Double => matches!(style_kind, QuoteStyle::Double),
+            QuoteType::Consistent => {
+                let expected = self.consistent_quote_style.get_or_insert(style_kind);
+                *expected == style_kind
+            }
+        }
+    }
+
+    fn has_escaping_in_double_quotes(&self, style: ScalarStyle, span: Span) -> bool {
+        if !matches!(style, ScalarStyle::DoubleQuoted) {
+            return false;
+        }
+
+        let slice_start = span.start.index().saturating_add(1).min(self.buffer.len());
+        let mut slice_end = span.end.index().saturating_sub(1);
+        slice_end = slice_end.min(self.buffer.len());
+        slice_end = slice_end.max(slice_start);
+        self.buffer[slice_start..slice_end].contains('\\')
+    }
+}
+
+fn value_needs_double_quotes_for_content(value: &str) -> bool {
+    value.contains('\n') || value.contains('\r')
+}
+
+fn replacement_for_target(
+    value: &str,
+    start: usize,
+    end: usize,
+    target: QuoteStyle,
+) -> Option<Replacement> {
+    if target == QuoteStyle::Single && value_needs_double_quotes_for_content(value) {
+        return None;
+    }
+    Some((start, end, quote_value(value, target)))
+}
+
+fn quote_value(value: &str, style: QuoteStyle) -> String {
+    match style {
+        QuoteStyle::Single => {
+            let mut result = String::with_capacity(value.len().saturating_add(2));
+            result.push('\'');
+            for ch in value.chars() {
+                if ch == '\'' {
+                    result.push_str("''");
+                } else {
+                    result.push(ch);
+                }
+            }
+            result.push('\'');
+            result
+        }
+        QuoteStyle::Double => {
+            let mut result = String::with_capacity(value.len().saturating_add(2));
+            result.push('"');
+            for ch in value.chars() {
+                match ch {
+                    '\\' => result.push_str("\\\\"),
+                    '"' => result.push_str("\\\""),
+                    '\t' => result.push_str("\\t"),
+                    _ => result.push(ch),
+                }
+            }
+            result.push('"');
+            result
+        }
+    }
 }

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -78,6 +78,54 @@ fn toml_allows_escaped_double_quotes_as_single_quote_exception() {
 }
 
 #[test]
+fn fix_preserves_escaped_double_quotes_in_toml_config() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(&file, "key: \"line\\nbreak\"\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\nallow-double-quotes-for-escaping = true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, _stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(&config)
+        .arg("--fix")
+        .arg(&file));
+    assert_eq!(code, 0);
+    let fixed = fs::read_to_string(&file).unwrap();
+    assert_eq!(fixed, "key: \"line\\nbreak\"\n");
+}
+
+#[test]
+fn fix_removes_redundant_quotes_with_cli_fix_flag() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(&file, "key: \"value\"\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, _stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(&config)
+        .arg("--fix")
+        .arg(&file));
+    assert_eq!(code, 0);
+    let fixed = fs::read_to_string(&file).unwrap();
+    assert_eq!(fixed, "key: value\n");
+}
+
+#[test]
 fn escaped_double_quote_exception_does_not_set_consistent_style() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("data.yaml");

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -102,6 +102,33 @@ fn fix_preserves_escaped_double_quotes_in_toml_config() {
 }
 
 #[test]
+fn fix_preserves_escaped_tabs_that_would_be_invalid_plain_scalars() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(&file, "key: \"a\\tb\"\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nrequired = 'only-when-needed'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(&config)
+        .arg("--fix")
+        .arg(&file));
+    assert_eq!(
+        code, 0,
+        "escaped tab should stay valid after fix: stdout={stdout} stderr={stderr}"
+    );
+    let fixed = fs::read_to_string(&file).unwrap();
+    assert_eq!(fixed, "key: \"a\\tb\"\n");
+}
+
+#[test]
 fn fix_removes_redundant_quotes_with_cli_fix_flag() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("data.yaml");

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -159,3 +159,34 @@ fn escaped_double_quote_exception_does_not_set_consistent_style() {
         "escaped exception and single quote baseline should pass: {output}"
     );
 }
+
+#[test]
+fn fix_consistent_ignores_escaped_exception_when_seeding_style() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(
+        &file,
+        "escaped: \"line\\nbreak\"\nplain: value\nquoted: 'two'\n",
+    )
+    .unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nquote-type = 'consistent'\nallow-double-quotes-for-escaping = true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, _stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(&config)
+        .arg("--fix")
+        .arg(&file));
+    assert_eq!(code, 0);
+    let fixed = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        fixed,
+        "escaped: \"line\\nbreak\"\nplain: 'value'\nquoted: 'two'\n"
+    );
+}

--- a/tests/config_fix.rs
+++ b/tests/config_fix.rs
@@ -323,3 +323,48 @@ fn yaml_extends_default_keeps_default_fix_policy() {
     assert_eq!(cfg.fix().fixable(), [FixRuleSelector::All]);
     assert!(cfg.fix().unfixable().is_empty());
 }
+
+#[test]
+fn toml_config_allows_quoted_strings_in_fixable() {
+    let cfg = PathBuf::from("/repo/.ryl.toml");
+    let env = common::fake_env::FakeEnv::new()
+        .with_file(cfg.clone(), "[fix]\nfixable = ['quoted-strings']\n");
+
+    let ctx = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("toml config should allow quoted-strings in fixable");
+
+    assert_eq!(
+        ctx.config.fix().fixable(),
+        [FixRuleSelector::Rule(FixRule::QuotedStrings)]
+    );
+    assert!(ctx.config.fix().allows_rule("quoted-strings"));
+}
+
+#[test]
+fn to_toml_string_round_trips_quoted_strings_fix_config() {
+    let cfg = PathBuf::from("/repo/.ryl.toml");
+    let env = common::fake_env::FakeEnv::new().with_file(
+        cfg.clone(),
+        "[fix]\nfixable = ['quoted-strings']\nunfixable = ['quoted-strings', 'comments']\n\n[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+    );
+
+    let ctx = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("toml config should parse");
+
+    let toml_output = ctx.config.to_toml_string();
+    assert!(toml_output.contains("quoted-strings"));
+}

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -1,6 +1,7 @@
 use std::{fs, process::Command};
 
 use jsonschema::validator_for;
+use ryl::config_schema::FixableRuleSelector::QuotedStrings as SelQuotedStrings;
 use ryl::config_schema::{
     NormalizedConfig, normalize_toml_config, normalized_config_to_toml_value,
     parse_toml_config_str, schema_value, toml_config_to_value, validate_toml_config,
@@ -965,4 +966,23 @@ fn typed_toml_validation_accepts_valid_extra_allowed_regex() {
 
     validate_toml_config(&parsed)
         .expect("typed validation should allow valid extra-allowed regexes");
+}
+
+#[test]
+fn normalize_toml_config_preserves_quoted_strings_in_fixable() {
+    let parsed = parse_toml_config_str(
+        "[fix]\nfixable = [\"quoted-strings\"]\n\n[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+        false,
+    )
+    .expect("typed TOML parse should succeed")
+    .expect("project TOML should produce config");
+
+    let normalized = normalize_toml_config(&parsed);
+    let fix = normalized.fix.expect("fix should normalize");
+    assert_eq!(fix.fixable.len(), 1);
+    assert!(
+        matches!(fix.fixable[0], SelQuotedStrings),
+        "expected QuotedStrings, got {:?}",
+        fix.fixable[0]
+    );
 }

--- a/tests/fix_engine.rs
+++ b/tests/fix_engine.rs
@@ -200,3 +200,70 @@ fn apply_safe_fixes_runs_flow_collection_spacing_fixes() {
 
     assert_eq!(fixed, "mapping: {key: value}\nsequence: [ ]\n");
 }
+
+#[test]
+fn apply_safe_fixes_runs_quoted_strings_fix() {
+    let cfg = config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+
+    let fixed = apply_safe_fixes(
+        "foo: \"bar\"\n",
+        &cfg,
+        std::path::Path::new("input.yaml"),
+        std::path::Path::new("."),
+    );
+
+    assert_eq!(fixed, "foo: bar\n");
+}
+
+#[test]
+fn apply_safe_fixes_skips_quoted_strings_when_unfixable() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(&file, "foo: \"bar\"\n").unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[fix]\nunfixable = [\"quoted-strings\"]\n\n[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+    )
+    .unwrap();
+
+    let ctx = discover_config(std::slice::from_ref(&file), &Overrides::default())
+        .expect("config discovers");
+
+    let fixed = apply_safe_fixes("foo: \"bar\"\n", &ctx.config, &file, &ctx.base_dir);
+
+    assert_eq!(fixed, "foo: \"bar\"\n");
+}
+
+#[test]
+fn fix_config_allows_quoted_strings_when_listed_in_fixable() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(&file, "foo: bar\n").unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[fix]\nfixable = [\"quoted-strings\"]\n\n[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+    )
+    .unwrap();
+
+    let ctx = discover_config(std::slice::from_ref(&file), &Overrides::default())
+        .expect("config discovers");
+    assert!(ctx.config.fix().allows_rule("quoted-strings"));
+}
+
+#[test]
+fn fix_config_disallows_quoted_strings_when_not_listed() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(&file, "foo: bar\n").unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[fix]\nfixable = [\"comments\"]\n\n[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+    )
+    .unwrap();
+
+    let ctx = discover_config(std::slice::from_ref(&file), &Overrides::default())
+        .expect("config discovers");
+    assert!(!ctx.config.fix().allows_rule("quoted-strings"));
+}

--- a/tests/rule_quoted_strings.rs
+++ b/tests/rule_quoted_strings.rs
@@ -334,3 +334,366 @@ fn inner_double_quotes_are_preserved() {
     let hits = quoted_strings::check(yaml, &cfg);
     assert!(hits.is_empty(), "embedded quotes should keep outer quoting");
 }
+
+#[test]
+fn fix_only_when_needed_removes_redundant_double_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: \"bar\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: bar\n"));
+}
+
+#[test]
+fn fix_only_when_needed_removes_redundant_single_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: 'bar'\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: bar\n"));
+}
+
+#[test]
+fn fix_only_when_needed_converts_double_to_single_when_needed() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: \"{value}\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: '{value}'\n"));
+}
+
+#[test]
+fn fix_only_when_needed_keeps_single_quotes_when_needed_and_correct() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: '{value}'\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_only_when_needed_preserves_quotes_on_values_needing_escaping() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: \"a\\nb\"\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_required_always_adds_single_quotes_to_plain() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n",
+    );
+    let result = quoted_strings::fix("foo: bar\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: 'bar'\n"));
+}
+
+#[test]
+fn fix_required_always_converts_double_to_single() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n",
+    );
+    let result = quoted_strings::fix("foo: \"bar\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: 'bar'\n"));
+}
+
+#[test]
+fn fix_required_always_keeps_correct_single_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n",
+    );
+    let result = quoted_strings::fix("foo: 'bar'\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_required_always_adds_double_quotes_to_plain_when_configured() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",
+    );
+    let result = quoted_strings::fix("foo: bar\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: \"bar\"\n"));
+}
+
+#[test]
+fn fix_required_always_converts_single_to_double() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",
+    );
+    let result = quoted_strings::fix("foo: 'bar'\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: \"bar\"\n"));
+}
+
+#[test]
+fn fix_converts_double_to_single_escaping_inner_single_quote() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n",
+    );
+    let result = quoted_strings::fix("foo: \"it's\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: 'it''s'\n"));
+}
+
+#[test]
+fn fix_removes_quotes_from_value_with_inner_single_quote_when_not_needed() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: 'it''s'\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: it's\n"));
+}
+
+#[test]
+fn fix_consistent_converts_to_first_seen_style() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: consistent\n",
+    );
+    let result = quoted_strings::fix("first: 'one'\nsecond: \"two\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("first: 'one'\nsecond: 'two'\n"));
+}
+
+#[test]
+fn fix_returns_none_when_no_changes_needed() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: bar\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_handles_multiple_scalars_in_one_pass() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("a: \"hello\"\nb: 'world'\nc: \"{flow}\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("a: hello\nb: world\nc: '{flow}'\n"));
+}
+
+#[test]
+fn fix_required_never_does_not_remove_matching_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: false\n",
+    );
+    let result = quoted_strings::fix("foo: 'bar'\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_extra_allowed_permits_quotes_but_still_enforces_quote_type() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n    extra-allowed: ['^http']\n",
+    );
+    let result = quoted_strings::fix("foo: \"http://example.com\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: 'http://example.com'\n"));
+}
+
+#[test]
+fn fix_respects_extra_required() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: false\n    extra-required: ['^http']\n",
+    );
+    let result = quoted_strings::fix("- http://example.com\n", &cfg);
+    assert_eq!(result.as_deref(), Some("- 'http://example.com'\n"));
+}
+
+#[test]
+fn fix_extra_allowed_converts_mismatched() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n    extra-allowed: ['^http']\n",
+    );
+    let result = quoted_strings::fix("foo: \"http://example.com\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: 'http://example.com'\n"));
+}
+
+#[test]
+fn fix_only_when_needed_removes_quotes_when_value_is_plain_scalar_equivalent() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: \"http://example.com\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: http://example.com\n"));
+}
+
+#[test]
+fn fix_skips_literal_block_scalar() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: |\n  literal\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_skips_tagged_scalar() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: !!str yes\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_required_never_with_extra_required_adds_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: false\n    extra-required: ['^must']\n",
+    );
+    let result = quoted_strings::fix("- must be quoted\n", &cfg);
+    assert_eq!(result.as_deref(), Some("- 'must be quoted'\n"));
+}
+
+#[test]
+fn fix_required_never_converts_mismatched_quote_type() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: false\n",
+    );
+    let result = quoted_strings::fix("foo: \"bar\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: 'bar'\n"));
+}
+
+#[test]
+fn fix_only_when_needed_extra_required_adds_quotes_to_plain() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n    extra-required: ['foo']\n",
+    );
+    let result = quoted_strings::fix("- foo\n", &cfg);
+    assert_eq!(result.as_deref(), Some("- 'foo'\n"));
+}
+
+#[test]
+fn fix_only_when_needed_extra_allowed_no_mismatch_leaves_alone() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: any\n    required: only-when-needed\n    extra-allowed: ['^safe']\n",
+    );
+    let result = quoted_strings::fix("foo: \"safe-value\"\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_required_always_adds_double_quotes_with_quote_type_double() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",
+    );
+    let result = quoted_strings::fix("foo: bar\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: \"bar\"\n"));
+}
+
+#[test]
+fn fix_converts_single_to_double_escaping_inner_double_quote() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",
+    );
+    let result = quoted_strings::fix("foo: 'he said \"hi\"'\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: \"he said \\\"hi\\\"\"\n"));
+}
+
+#[test]
+fn fix_converts_single_to_double_escaping_backslash() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",
+    );
+    let result = quoted_strings::fix("foo: 'path\\to'\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: \"path\\\\to\"\n"));
+}
+
+#[test]
+fn fix_allow_quoted_quotes_skips_mismatch() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    allow-quoted-quotes: true\n",
+    );
+    let result = quoted_strings::fix("foo: \"he's\"\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_with_document_separator_still_fixes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("---\nfoo: \"bar\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("---\nfoo: bar\n"));
+}
+
+#[test]
+fn fix_consistent_adds_quotes_to_plain_when_required_always() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: consistent\n",
+    );
+    let result = quoted_strings::fix("foo: bar\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: 'bar'\n"));
+}
+
+#[test]
+fn fix_only_when_needed_consistent_extra_required_adds_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: consistent\n    required: only-when-needed\n    extra-required: ['must']\n",
+    );
+    let result = quoted_strings::fix("- must\n", &cfg);
+    assert_eq!(result.as_deref(), Some("- 'must'\n"));
+}
+
+#[test]
+fn fix_converts_single_to_double_with_tab_escaping() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",
+    );
+    let result = quoted_strings::fix("foo: 'a\tb'\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: \"a\\tb\"\n"));
+}
+
+#[test]
+fn fix_required_never_extra_required_adds_single_quotes_to_sequence_item() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: false\n    extra-required: ['^must']\n",
+    );
+    let result = quoted_strings::fix("- must\n", &cfg);
+    assert_eq!(result.as_deref(), Some("- 'must'\n"));
+}
+
+#[test]
+fn fix_required_never_plain_no_extra_returns_none() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: false\n",
+    );
+    let result = quoted_strings::fix("foo: bar\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_only_when_needed_plain_no_extra_returns_none() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: bar\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_preserves_escaped_double_quotes_when_option_set() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    )
+    .with_allow_double_quotes_for_escaping(true);
+    let result = quoted_strings::fix("foo: \"a\\nb\"\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_converts_unescaped_double_quotes_when_escaping_option_set() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    )
+    .with_allow_double_quotes_for_escaping(true);
+    let result = quoted_strings::fix("foo: \"bar\"\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: bar\n"));
+}
+
+#[test]
+fn fix_escaping_exception_does_not_shield_single_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",
+    )
+    .with_allow_double_quotes_for_escaping(true);
+    let result = quoted_strings::fix("foo: 'bar'\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: \"bar\"\n"));
+}

--- a/tests/rule_quoted_strings.rs
+++ b/tests/rule_quoted_strings.rs
@@ -453,6 +453,18 @@ fn fix_consistent_converts_to_first_seen_style() {
 }
 
 #[test]
+fn fix_consistent_uses_later_existing_style_for_earlier_plain_scalar() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: consistent\n",
+    );
+    let result = quoted_strings::fix("plain: value\nquoted: \"two\"\n", &cfg);
+    assert_eq!(
+        result.as_deref(),
+        Some("plain: \"value\"\nquoted: \"two\"\n")
+    );
+}
+
+#[test]
 fn fix_returns_none_when_no_changes_needed() {
     let cfg = build_config(
         "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
@@ -639,6 +651,15 @@ fn fix_converts_single_to_double_with_tab_escaping() {
     );
     let result = quoted_strings::fix("foo: 'a\tb'\n", &cfg);
     assert_eq!(result.as_deref(), Some("foo: \"a\\tb\"\n"));
+}
+
+#[test]
+fn fix_does_not_convert_non_printable_escape_to_single_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: false\n",
+    );
+    let result = quoted_strings::fix("foo: \"\\a\"\n", &cfg);
+    assert_eq!(result.as_deref(), None);
 }
 
 #[test]


### PR DESCRIPTION
Implements auto-fix for the quoted-strings rule covering:
- Remove unnecessary quotes when value is a valid plain scalar
- Convert mismatched quote types (single/double/consistent)
- Add quotes to plain scalars when configured (required: always, extra-required patterns)
- Respect escaping exception (allow-double-quotes-for-escaping)
- Handle single-quote escaping ('') and double-quote escaping (", \, \t) during conversions
- Correctly skip values with newlines that can't round-trip through single quotes