### PR TITLE
Fix quoted-string autofix edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryl"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "clap",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.9.0"
+version = "0.9.1"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -576,8 +576,9 @@ fn has_escaping_in_double_quotes(buffer: &str, style: ScalarStyle, span: Span) -
         return false;
     }
 
-    let slice_start = span.start.index().saturating_add(1).min(buffer.len());
-    let mut slice_end = span.end.index().saturating_sub(1);
+    let (scalar_start, scalar_end) = scalar_source_bounds(buffer, style, span);
+    let slice_start = scalar_start.saturating_add(1).min(buffer.len());
+    let mut slice_end = scalar_end.saturating_sub(1);
     slice_end = slice_end.min(buffer.len());
     slice_end = slice_end.max(slice_start);
     buffer[slice_start..slice_end].contains('\\')
@@ -595,6 +596,10 @@ fn quotes_are_needed(
             .chars()
             .any(|c| matches!(c, ',' | '[' | ']' | '{' | '}'))
     {
+        return true;
+    }
+
+    if contains_plain_indicator_token(value) {
         return true;
     }
 
@@ -639,6 +644,16 @@ impl<'a> PlainScalarChecker<'a> {
     }
 }
 
+fn contains_plain_indicator_token(value: &str) -> bool {
+    value.split_whitespace().any(|token| {
+        token.len() == 1 && token.chars().next().is_some_and(is_plain_indicator_token)
+    })
+}
+
+const fn is_plain_indicator_token(ch: char) -> bool {
+    matches!(ch, '!' | '&' | '*' | '|' | '>' | '?' | '@' | '%' | '`')
+}
+
 impl SpannedEventReceiver<'_> for PlainScalarChecker<'_> {
     fn on_event(&mut self, event: Event<'_>, _span: Span) {
         if let Event::Scalar(value, style, _, _) = event {
@@ -671,14 +686,74 @@ fn has_backslash_line_ending(buffer: &str, span: Span) -> bool {
         return false;
     }
 
-    let slice_start = span.start.index().saturating_add(1).min(buffer.len());
-    let mut slice_end = span.end.index().saturating_sub(1);
+    let (scalar_start, scalar_end) =
+        scalar_source_bounds(buffer, ScalarStyle::DoubleQuoted, span);
+    let slice_start = scalar_start.saturating_add(1).min(buffer.len());
+    let mut slice_end = scalar_end.saturating_sub(1);
     slice_end = slice_end.min(buffer.len());
     slice_end = slice_end.max(slice_start);
     let content = &buffer[slice_start..slice_end];
     let has_unix_backslash = content.contains("\\\n");
     let has_windows_backslash = content.contains("\\\r\n");
     has_unix_backslash || has_windows_backslash
+}
+
+fn scalar_source_bounds(
+    buffer: &str,
+    style: ScalarStyle,
+    span: Span,
+) -> (usize, usize) {
+    let start = span.start.index().min(buffer.len());
+    let span_end = span.end.index().min(buffer.len());
+    let end = match style {
+        ScalarStyle::SingleQuoted => quoted_scalar_end(buffer, start, b'\''),
+        ScalarStyle::DoubleQuoted => double_quoted_scalar_end(buffer, start),
+        ScalarStyle::Plain | ScalarStyle::Literal | ScalarStyle::Folded => span_end,
+    };
+    (start, end.max(start))
+}
+
+fn quoted_scalar_end(buffer: &str, start: usize, quote: u8) -> usize {
+    let bytes = buffer.as_bytes();
+    let mut cursor = start.saturating_add(1);
+    let mut closing_quote = None;
+    while cursor < bytes.len() {
+        if bytes[cursor] != quote {
+            cursor += 1;
+            continue;
+        }
+
+        if quote == b'\'' && bytes.get(cursor.saturating_add(1)) == Some(&quote) {
+            cursor += 2;
+            continue;
+        }
+
+        closing_quote = Some(cursor + 1);
+        break;
+    }
+
+    closing_quote.expect("quoted scalar event should include a closing quote")
+}
+
+fn double_quoted_scalar_end(buffer: &str, start: usize) -> usize {
+    let bytes = buffer.as_bytes();
+    let mut cursor = start.saturating_add(1);
+    let mut escaped = false;
+    let mut closing_quote = None;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            _ if escaped => escaped = false,
+            b'\\' => escaped = true,
+            b'"' => {
+                closing_quote = Some(cursor + 1);
+                break;
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+
+    closing_quote.expect("double-quoted scalar event should include a closing quote")
 }
 
 type Replacement = (usize, usize, String);
@@ -928,8 +1003,7 @@ impl<'cfg> FixState<'cfg> {
             value,
             span,
         );
-        let start = span.start.index();
-        let end = span.end.index();
+        let (start, end) = scalar_source_bounds(self.buffer, style, span);
 
         match self.config.required {
             RequiredMode::Always => self.fix_required_always(value, facts, start, end),

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -153,6 +153,80 @@ fn fix_removes_redundant_quotes_with_cli_fix_flag() {
 }
 
 #[test]
+fn fix_preserves_inline_comments_when_removing_quotes() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(&file, "cron: \"daily\" # Some schedule\n").unwrap();
+
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, _stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(&config)
+        .arg("--fix")
+        .arg(&file));
+    assert_eq!(code, 0);
+    let fixed = fs::read_to_string(&file).unwrap();
+    assert_eq!(fixed, "cron: daily # Some schedule\n");
+}
+
+#[test]
+fn fix_keeps_quotes_for_plain_scalar_edge_cases() {
+    let dir = tempdir().unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.quoted-strings]\nquote-type = 'single'\nrequired = 'only-when-needed'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let cases = [
+        ("cron", "cron: '30 21 * * 0'\n"),
+        ("wildcard-token", "value: 'foo * bar'\n"),
+        ("anchor-token", "value: 'foo & bar'\n"),
+        ("tag-token", "value: 'foo ! bar'\n"),
+        ("literal-token", "value: 'foo | bar'\n"),
+        ("folded-token", "value: 'foo > bar'\n"),
+        ("mapping-key-token", "value: 'foo ? bar'\n"),
+        ("reserved-at", "value: 'foo @ bar'\n"),
+        ("reserved-percent", "value: 'foo % bar'\n"),
+        ("reserved-backtick", "value: 'foo ` bar'\n"),
+        ("comment", "value: 'foo # bar'\n"),
+        ("mapping", "value: 'foo: bar'\n"),
+        ("flow-sequence", "value: '[1, 2]'\n"),
+        ("flow-mapping", "value: '{a: 1}'\n"),
+    ];
+
+    for (label, input) in cases {
+        let file = dir.path().join(format!("{label}.yaml"));
+        fs::write(&file, input).unwrap();
+
+        let (code, stdout, stderr) =
+            run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+        assert_eq!(
+            code, 0,
+            "quoted scalar should remain valid for {label}: stdout={stdout} stderr={stderr}"
+        );
+
+        let (code, _stdout, _stderr) = run(Command::new(exe)
+            .arg("-c")
+            .arg(&config)
+            .arg("--fix")
+            .arg(&file));
+        assert_eq!(code, 0, "fix should succeed for {label}");
+        let fixed = fs::read_to_string(&file).unwrap();
+        assert_eq!(fixed, input, "fix should preserve quotes for {label}");
+    }
+}
+
+#[test]
 fn escaped_double_quote_exception_does_not_set_consistent_style() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("data.yaml");

--- a/tests/rule_quoted_strings.rs
+++ b/tests/rule_quoted_strings.rs
@@ -710,6 +710,83 @@ fn fix_converts_unescaped_double_quotes_when_escaping_option_set() {
 }
 
 #[test]
+fn fix_only_when_needed_keeps_quotes_for_indicator_tokens() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let cases = [
+        "cron: '30 21 * * 0'\n",
+        "value: 'foo * bar'\n",
+        "value: 'foo & bar'\n",
+        "value: 'foo ! bar'\n",
+        "value: 'foo | bar'\n",
+        "value: 'foo > bar'\n",
+        "value: 'foo ? bar'\n",
+        "value: 'foo @ bar'\n",
+        "value: 'foo % bar'\n",
+        "value: 'foo ` bar'\n",
+    ];
+
+    for yaml in cases {
+        let result = quoted_strings::fix(yaml, &cfg);
+        assert_eq!(result.as_deref(), None, "quotes should stay for {yaml:?}");
+    }
+}
+
+#[test]
+fn only_when_needed_does_not_flag_indicator_token_content_as_redundant() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let cases = [
+        "cron: '30 21 * * 0'\n",
+        "value: 'foo & bar'\n",
+        "value: 'foo ! bar'\n",
+        "value: 'foo | bar'\n",
+        "value: 'foo > bar'\n",
+        "value: 'foo ? bar'\n",
+        "value: 'foo @ bar'\n",
+        "value: 'foo % bar'\n",
+        "value: 'foo ` bar'\n",
+    ];
+
+    for yaml in cases {
+        let hits = quoted_strings::check(yaml, &cfg);
+        assert!(
+            hits.is_empty(),
+            "indicator token content should remain quoted: {yaml:?} => {hits:?}"
+        );
+    }
+}
+
+#[test]
+fn fix_only_when_needed_preserves_inline_comments_when_unquoting() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: single\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: \"bar\" # trailing comment\n", &cfg);
+    assert_eq!(result.as_deref(), Some("foo: bar # trailing comment\n"));
+}
+
+#[test]
+fn fix_only_when_needed_ignores_unterminated_single_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: 'unterminated\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
+fn fix_only_when_needed_ignores_unterminated_double_quotes() {
+    let cfg = build_config(
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: only-when-needed\n",
+    );
+    let result = quoted_strings::fix("foo: \"unterminated\n", &cfg);
+    assert_eq!(result.as_deref(), None);
+}
+
+#[test]
 fn fix_escaping_exception_does_not_shield_single_quotes() {
     let cfg = build_config(
         "rules:\n  document-start: disable\n  quoted-strings:\n    quote-type: double\n",


### PR DESCRIPTION
Disabled quote removal from strings when strings contain characters of semantic significance in YAML and also preserve trailing comments when removing quotes.