### PR TITLE
test: add property-style tests for safe --fix invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,19 +112,33 @@ ryl is a CLI tool for linting yaml files
 `tests/property_safe_fix.rs` runs `proptest`-generated YAML through `apply_safe_fixes`
 and asserts three invariants: idempotence, no remaining safe-fix-rule diagnostics
 after fixing, and parse preservation (input that parses must produce output that
-parses to an equal `YamlOwned` value). A deterministic sibling test pins one
-known-dirty document through the same checks so the property assertions cannot
-silently become a no-op if the generator drifts.
+parses to an equal `YamlOwned` value). Deterministic sibling tests pin known-dirty
+documents and known production-bug patterns (issues #184 and #206) through the same
+checks so the property assertions cannot silently become a no-op if the generator
+drifts.
+
+The suite runs against a matrix of named configs to catch config-specific
+regressions: five YAML configs (`yamllint-default`, `best-practice`, `strict-single`,
+`strict-double`, `consistent`) exercising the surface yamllint exposes, plus one
+TOML-backed config (`best-practice-toml`) loaded from a tempfile via
+`discover_config` so ryl-only options like `allow-double-quotes-for-escaping` are
+also covered.
 
 When you add a new `FixSafety::Safe` rule:
 
-1. Add its rule id to `SAFE_FIX_RULES` and to `SAFE_FIX_CONFIG_YAML` in
-   `tests/property_safe_fix.rs`.
+1. Add its rule id to `SAFE_FIX_RULES` and to `COMMON_SAFE_FIX_RULES_YAML` in
+   `tests/property_safe_fix.rs`. If the new rule introduces meaningful config
+   axes, add a variant to `QUOTED_STRINGS_VARIANTS` (or a peer constant for that
+   rule) so the matrix exercises each regime; ryl-only options must go through
+   the TOML slot rather than YAML.
 2. Extend the AST / renderer in that file so generated documents exercise the
    syntax the new fixer targets. Skipping this leaves the property tests green
    for the wrong reason — the fixer has nothing to do.
 3. Run `cargo test --test property_safe_fix` and resolve any failures before
    landing the rule.
+4. Add a focused CLI-level regression test in `tests/cli_fix.rs` (or the
+   rule-specific file) for any production bug discovered along the way, so the
+   property suite is backed by a deterministic guard.
 
 Failing inputs are persisted at `tests/proptest-regressions/property_safe_fix.txt`
 and replayed first on every run. That file is committed to git so the regression

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,29 @@ ryl is a CLI tool for linting yaml files
   the "zero missed regions" guarantee enforced by CI. Add new coverage via CLI/system
   tests in `tests/` instead.
 
+### Property Tests For Safe Fixes
+
+`tests/property_safe_fix.rs` runs `proptest`-generated YAML through `apply_safe_fixes`
+and asserts three invariants: idempotence, no remaining safe-fix-rule diagnostics
+after fixing, and parse preservation (input that parses must produce output that
+parses to an equal `YamlOwned` value). A deterministic sibling test pins one
+known-dirty document through the same checks so the property assertions cannot
+silently become a no-op if the generator drifts.
+
+When you add a new `FixSafety::Safe` rule:
+
+1. Add its rule id to `SAFE_FIX_RULES` and to `SAFE_FIX_CONFIG_YAML` in
+   `tests/property_safe_fix.rs`.
+2. Extend the AST / renderer in that file so generated documents exercise the
+   syntax the new fixer targets. Skipping this leaves the property tests green
+   for the wrong reason — the fixer has nothing to do.
+3. Run `cargo test --test property_safe_fix` and resolve any failures before
+   landing the rule.
+
+Failing inputs are persisted at `tests/proptest-regressions/property_safe_fix.txt`
+and replayed first on every run. That file is committed to git so the regression
+follows the codebase, not the developer's machine.
+
 ## Coverage Workflow
 
 The CI enforces zero missed lines and zero missed regions. Use this workflow instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1189,31 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1201,6 +1235,44 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -1464,6 +1536,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryl"
 version = "0.9.2"
 dependencies = [
@@ -1473,6 +1557,7 @@ dependencies = [
  "globset",
  "ignore",
  "jsonschema",
+ "proptest",
  "rayon",
  "regex",
  "saphyr",
@@ -1967,6 +2052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2129,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,5 +49,6 @@ toml = { version = "1.1.2", default-features = false, features = ["display", "pa
 
 [dev-dependencies]
 jsonschema = "0.46.2"
+proptest = "1.11.0"
 semver = "1"
 tempfile = "3"

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -7,6 +7,8 @@ use crate::rules::{
     new_lines, quoted_strings,
 };
 
+const RULE_FIX_MAX_ITERATIONS: usize = 8;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixSafety {
     Safe,
@@ -173,8 +175,6 @@ fn apply_rule_fix(
     }
     current
 }
-
-const RULE_FIX_MAX_ITERATIONS: usize = 8;
 
 fn rule_enabled(
     rule: RuleFix,

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -153,14 +153,29 @@ fn apply_rule_fix(
     cfg: &YamlLintConfig,
     path: &Path,
     base_dir: &Path,
-    fix: impl FnOnce(&str) -> Option<String>,
+    fix: impl Fn(&str) -> Option<String>,
 ) -> String {
     if !rule_enabled(rule, cfg, path, base_dir) {
         return content;
     }
 
-    fix(&content).unwrap_or(content)
+    // Run the rule's fix to a fixed point. A single pass is not enough for
+    // rules like quoted-strings where one fix exposes a follow-up diagnostic
+    // (e.g. converting double quotes to single quotes leaves a now-redundant
+    // pair that must be removed); without convergence here, the CLI's single
+    // --fix invocation would leave the output non-idempotent.
+    let mut current = content;
+    for _ in 0..RULE_FIX_MAX_ITERATIONS {
+        let Some(next) = fix(&current) else { break };
+        if next == current {
+            break;
+        }
+        current = next;
+    }
+    current
 }
+
+const RULE_FIX_MAX_ITERATIONS: usize = 8;
 
 fn rule_enabled(
     rule: RuleFix,

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -163,13 +163,12 @@ fn apply_rule_fix(
     // rules like quoted-strings where one fix exposes a follow-up diagnostic
     // (e.g. converting double quotes to single quotes leaves a now-redundant
     // pair that must be removed); without convergence here, the CLI's single
-    // --fix invocation would leave the output non-idempotent.
+    // --fix invocation would leave the output non-idempotent. Well-behaved
+    // fix functions signal completion by returning None, so the loop exits
+    // after at most one extra no-op call per rule.
     let mut current = content;
     for _ in 0..RULE_FIX_MAX_ITERATIONS {
         let Some(next) = fix(&current) else { break };
-        if next == current {
-            break;
-        }
         current = next;
     }
     current

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,4 @@ pub mod migrate;
 pub mod rules;
 
 pub use discover::{gather_yaml_from_dir, is_yaml_path};
-pub use lint::{LintProblem, Severity, lint_file};
+pub use lint::{LintProblem, Severity, lint_file, lint_str};

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -53,23 +53,37 @@ impl<'i> saphyr_parser::EventReceiver<'i> for NullSink {
 /// # Errors
 ///
 /// Returns `Err(String)` when the file cannot be read.
-#[allow(clippy::too_many_lines)]
 pub fn lint_file(
     path: &Path,
     cfg: &YamlLintConfig,
     base_dir: &Path,
 ) -> Result<Vec<LintProblem>, String> {
     let content = decoder::read_file(path)?;
+    Ok(lint_str(&content, path, cfg, base_dir))
+}
 
+/// Lint YAML content held in memory and return diagnostics in yamllint format
+/// order.
+///
+/// `path` is used purely for diagnostic context and per-rule ignore matching;
+/// no filesystem reads are performed.
+#[allow(clippy::too_many_lines)]
+#[must_use]
+pub fn lint_str(
+    content: &str,
+    path: &Path,
+    cfg: &YamlLintConfig,
+    base_dir: &Path,
+) -> Vec<LintProblem> {
     let mut diagnostics: Vec<LintProblem> = Vec::new();
 
-    collect_document_start_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_document_start_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
-    collect_document_end_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_document_end_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
     if let Some(level) = cfg.rule_level(new_line_at_end_of_file::ID)
         && !cfg.is_rule_ignored(new_line_at_end_of_file::ID, path, base_dir)
-        && let Some(hit) = new_line_at_end_of_file::check(&content)
+        && let Some(hit) = new_line_at_end_of_file::check(content)
     {
         diagnostics.push(LintProblem {
             line: hit.line,
@@ -85,7 +99,7 @@ pub fn lint_file(
     {
         let rule_cfg = new_lines::Config::resolve(cfg);
         if let Some(hit) =
-            new_lines::check(&content, rule_cfg, new_lines::platform_newline())
+            new_lines::check(content, rule_cfg, new_lines::platform_newline())
         {
             diagnostics.push(LintProblem {
                 line: hit.line,
@@ -97,24 +111,24 @@ pub fn lint_file(
         }
     }
 
-    collect_empty_lines_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_empty_lines_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
-    collect_commas_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_commas_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
-    collect_colons_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_colons_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
-    collect_braces_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
-    collect_brackets_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_braces_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
+    collect_brackets_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
-    collect_comments_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_comments_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
-    collect_anchors_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_anchors_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
     if let Some(level) = cfg.rule_level(octal_values::ID)
         && !cfg.is_rule_ignored(octal_values::ID, path, base_dir)
     {
         let rule_cfg = octal_values::Config::resolve(cfg);
-        for hit in octal_values::check(&content, &rule_cfg) {
+        for hit in octal_values::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -129,7 +143,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(float_values::ID, path, base_dir)
     {
         let rule_cfg = float_values::Config::resolve(cfg);
-        for hit in float_values::check(&content, &rule_cfg) {
+        for hit in float_values::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -144,7 +158,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(empty_values::ID, path, base_dir)
     {
         let rule_cfg = empty_values::Config::resolve(cfg);
-        for hit in empty_values::check(&content, &rule_cfg) {
+        for hit in empty_values::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -159,7 +173,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(quoted_strings::ID, path, base_dir)
     {
         let rule_cfg = quoted_strings::Config::resolve(cfg);
-        for hit in quoted_strings::check(&content, &rule_cfg) {
+        for hit in quoted_strings::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -174,7 +188,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(truthy::ID, path, base_dir)
     {
         let rule_cfg = truthy::Config::resolve(cfg);
-        for hit in truthy::check(&content, &rule_cfg) {
+        for hit in truthy::check(content, &rule_cfg) {
             let truthy::Violation {
                 line,
                 column,
@@ -194,7 +208,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(key_duplicates::ID, path, base_dir)
     {
         let rule_cfg = key_duplicates::Config::resolve(cfg);
-        for hit in key_duplicates::check(&content, &rule_cfg) {
+        for hit in key_duplicates::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -209,7 +223,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(key_ordering::ID, path, base_dir)
     {
         let rule_cfg = key_ordering::Config::resolve(cfg);
-        for hit in key_ordering::check(&content, &rule_cfg) {
+        for hit in key_ordering::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -224,7 +238,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(hyphens::ID, path, base_dir)
     {
         let rule_cfg = hyphens::Config::resolve(cfg);
-        for hit in hyphens::check(&content, &rule_cfg) {
+        for hit in hyphens::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -237,7 +251,7 @@ pub fn lint_file(
 
     collect_comments_indentation_diagnostics(
         &mut diagnostics,
-        &content,
+        content,
         cfg,
         path,
         base_dir,
@@ -247,7 +261,7 @@ pub fn lint_file(
         && !cfg.is_rule_ignored(indentation::ID, path, base_dir)
     {
         let rule_cfg = indentation::Config::resolve(cfg);
-        for hit in indentation::check(&content, &rule_cfg) {
+        for hit in indentation::check(content, &rule_cfg) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -258,12 +272,12 @@ pub fn lint_file(
         }
     }
 
-    collect_line_length_diagnostics(&mut diagnostics, &content, cfg, path, base_dir);
+    collect_line_length_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
     if let Some(level) = cfg.rule_level(trailing_spaces::ID)
         && !cfg.is_rule_ignored(trailing_spaces::ID, path, base_dir)
     {
-        for hit in trailing_spaces::check(&content) {
+        for hit in trailing_spaces::check(content) {
             diagnostics.push(LintProblem {
                 line: hit.line,
                 column: hit.column,
@@ -274,12 +288,12 @@ pub fn lint_file(
         }
     }
 
-    if let Some(syntax) = syntax_diagnostic(&content) {
+    if let Some(syntax) = syntax_diagnostic(content) {
         diagnostics.clear();
         diagnostics.push(syntax);
     }
 
-    Ok(diagnostics)
+    diagnostics
 }
 
 fn collect_document_end_diagnostics(

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -260,3 +260,57 @@ fn fix_comments_indentation_handles_crlf_blank_lines_without_newline_normalizati
         "root:\r\n  # first\r\n\r\n  # second\r\n  value: 1\r\n"
     );
 }
+
+
+#[test]
+fn fix_under_best_practice_converges_in_one_invocation_for_escape_sequences() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(&file, "key: \"a\\ta\"\n").unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules.quoted-strings]\nquote-type = \"single\"\nrequired = \"only-when-needed\"\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_, _, _) = run(Command::new(exe).arg("--fix").arg(&file));
+    let first_pass = fs::read_to_string(&file).unwrap();
+
+    let (_, _, _) = run(Command::new(exe).arg("--fix").arg(&file));
+    let second_pass = fs::read_to_string(&file).unwrap();
+
+    assert_eq!(
+        first_pass, second_pass,
+        "one --fix invocation should reach the fixed point; first={first_pass:?} second={second_pass:?}"
+    );
+}
+
+#[test]
+fn fix_with_toml_allow_double_quotes_for_escaping_silences_quoted_strings_diagnostic() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(&file, "message: \"line1\\nline2\"\n").unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules.quoted-strings]\nquote-type = \"single\"\nrequired = \"only-when-needed\"\nallow-double-quotes-for-escaping = true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("--fix").arg(&file));
+
+    assert_eq!(
+        code, 0,
+        "fix should succeed without quoted-strings diagnostics: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("quoted-strings") && !stderr.contains("quoted-strings"),
+        "allow-double-quotes-for-escaping should silence quoted-strings diagnostic: stdout={stdout} stderr={stderr}"
+    );
+    let fixed = fs::read_to_string(&file).unwrap();
+    assert!(
+        fixed.contains("\"line1\\nline2\""),
+        "double-quoted escape sequence should be retained verbatim: {fixed:?}"
+    );
+}

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -261,7 +261,6 @@ fn fix_comments_indentation_handles_crlf_blank_lines_without_newline_normalizati
     );
 }
 
-
 #[test]
 fn fix_under_best_practice_converges_in_one_invocation_for_escape_sequences() {
     let dir = tempdir().unwrap();

--- a/tests/property_safe_fix.rs
+++ b/tests/property_safe_fix.rs
@@ -4,6 +4,8 @@ use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
 use ryl::config::YamlLintConfig;
 use ryl::fix::apply_safe_fixes;
+use ryl::lint::{LintProblem, lint_str};
+use saphyr::{LoadableYamlNode, YamlOwned};
 
 const SAFE_FIX_CONFIG_YAML: &str = "rules:
   new-lines: enable
@@ -16,6 +18,17 @@ const SAFE_FIX_CONFIG_YAML: &str = "rules:
   quoted-strings: enable
 ";
 
+const SAFE_FIX_RULES: &[&str] = &[
+    "new-lines",
+    "comments",
+    "comments-indentation",
+    "commas",
+    "braces",
+    "brackets",
+    "new-line-at-end-of-file",
+    "quoted-strings",
+];
+
 fn safe_fix_config() -> YamlLintConfig {
     YamlLintConfig::from_yaml_str(SAFE_FIX_CONFIG_YAML)
         .expect("safe-fix config string is valid")
@@ -27,6 +40,21 @@ fn synthetic_path() -> &'static Path {
 
 fn synthetic_base_dir() -> &'static Path {
     Path::new(".")
+}
+
+fn safe_fix_rule_diagnostics(content: &str, cfg: &YamlLintConfig) -> Vec<LintProblem> {
+    lint_str(content, synthetic_path(), cfg, synthetic_base_dir())
+        .into_iter()
+        .filter(|diag| {
+            diag.rule
+                .map(|rule| SAFE_FIX_RULES.contains(&rule))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+fn parse_for_compare(content: &str) -> Option<Vec<YamlOwned>> {
+    YamlOwned::load_from_str(content).ok()
 }
 
 #[derive(Debug, Clone)]
@@ -294,10 +322,50 @@ proptest! {
             twice
         );
     }
+
+    #[test]
+    fn safe_fix_leaves_no_safe_fix_rule_diagnostics(document in arb_document()) {
+        let input = document.render();
+        let cfg = safe_fix_config();
+        let fixed = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
+        if parse_for_compare(&fixed).is_none() {
+            return Ok(());
+        }
+        let remaining = safe_fix_rule_diagnostics(&fixed, &cfg);
+        prop_assert!(
+            remaining.is_empty(),
+            "safe-fix-rule diagnostics survived fix for input {:?}; fixed {:?}; diagnostics {:?}",
+            input,
+            fixed,
+            remaining
+        );
+    }
+
+    #[test]
+    fn safe_fix_preserves_parsed_value(document in arb_document()) {
+        let input = document.render();
+        let Some(before) = parse_for_compare(&input) else {
+            return Ok(());
+        };
+        let cfg = safe_fix_config();
+        let fixed = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
+        let after = parse_for_compare(&fixed).ok_or_else(|| {
+            TestCaseError::fail(format!(
+                "safe fix broke a previously-parseable document; input {input:?}; fixed {fixed:?}"
+            ))
+        })?;
+        prop_assert_eq!(
+            &before,
+            &after,
+            "safe fix changed parsed YAML value; input {:?}; fixed {:?}",
+            input,
+            fixed
+        );
+    }
 }
 
 #[test]
-fn renderer_emits_dirty_inputs_that_safe_fix_normalizes() {
+fn safe_fix_properties_hold_for_known_dirty_input() {
     let plain = |name: &str| Node::Scalar(Scalar::Plain(name.to_string()));
     let dirty_flow_seq = Document {
         entries: vec![BlockEntry {
@@ -319,14 +387,21 @@ fn renderer_emits_dirty_inputs_that_safe_fix_normalizes() {
         has_final_newline: false,
     };
     let input = dirty_flow_seq.render();
-    let fixed = apply_safe_fixes(
-        &input,
-        &safe_fix_config(),
-        synthetic_path(),
-        synthetic_base_dir(),
-    );
+    let cfg = safe_fix_config();
+    let before = parse_for_compare(&input).expect("known dirty input must parse");
+    let fixed = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
     assert_ne!(
         input, fixed,
         "renderer must emit inputs that exercise safe fixers; input={input:?} fixed={fixed:?}"
     );
+    let after =
+        parse_for_compare(&fixed).expect("safe fix must keep known input parseable");
+    assert_eq!(before, after, "safe fix must preserve parsed value");
+    let remaining = safe_fix_rule_diagnostics(&fixed, &cfg);
+    assert!(
+        remaining.is_empty(),
+        "safe-fix-rule diagnostics must clear after fix on known input: {remaining:?}"
+    );
+    let twice = apply_safe_fixes(&fixed, &cfg, synthetic_path(), synthetic_base_dir());
+    assert_eq!(fixed, twice, "safe fix must be idempotent on known input");
 }

--- a/tests/property_safe_fix.rs
+++ b/tests/property_safe_fix.rs
@@ -539,8 +539,11 @@ fn safe_fix_properties_hold_for_known_dirty_input() {
             input, fixed,
             "renderer must emit inputs that exercise safe fixers under config '{cfg_name}'; input={input:?} fixed={fixed:?}"
         );
-        let after = parse_for_compare(&fixed)
-            .unwrap_or_else(|| panic!("safe fix broke parseable input under config '{cfg_name}': {fixed:?}"));
+        let after = parse_for_compare(&fixed).unwrap_or_else(|| {
+            panic!(
+                "safe fix broke parseable input under config '{cfg_name}': {fixed:?}"
+            )
+        });
         assert_eq!(
             before, after,
             "safe fix must preserve parsed value under config '{cfg_name}'"
@@ -564,8 +567,7 @@ fn best_practice_retains_quotes_around_yaml_metachars() {
     let input = "schedule: '30 21 * * 0'\n";
     let cfg = named_config("best-practice");
     let before = parse_for_compare(input).expect("input parses");
-    let fixed =
-        apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
+    let fixed = apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
     let after = parse_for_compare(&fixed)
         .expect("best-practice fix must keep cron-like input parseable");
     assert_eq!(before, after, "parse must be preserved: {fixed:?}");
@@ -580,8 +582,7 @@ fn best_practice_does_not_break_parse_for_escape_sequences() {
     let input = "message: \"line1\\nline2\"\n";
     let cfg = named_config("best-practice");
     let before = parse_for_compare(input).expect("input parses");
-    let fixed =
-        apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
+    let fixed = apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
     let after = parse_for_compare(&fixed)
         .expect("best-practice fix must keep escape-sequence input parseable");
     assert_eq!(
@@ -595,8 +596,7 @@ fn best_practice_preserves_trailing_comment_when_unquoting() {
     let input = "key: 'value'  # important comment\n";
     let cfg = named_config("best-practice");
     let before = parse_for_compare(input).expect("input parses");
-    let fixed =
-        apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
+    let fixed = apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
     let after = parse_for_compare(&fixed)
         .expect("best-practice fix must keep quoted-with-comment input parseable");
     assert_eq!(before, after, "parse must be preserved: {fixed:?}");

--- a/tests/property_safe_fix.rs
+++ b/tests/property_safe_fix.rs
@@ -1,0 +1,332 @@
+use std::path::Path;
+
+use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+use ryl::config::YamlLintConfig;
+use ryl::fix::apply_safe_fixes;
+
+const SAFE_FIX_CONFIG_YAML: &str = "rules:
+  new-lines: enable
+  comments: enable
+  comments-indentation: enable
+  commas: enable
+  braces: enable
+  brackets: enable
+  new-line-at-end-of-file: enable
+  quoted-strings: enable
+";
+
+fn safe_fix_config() -> YamlLintConfig {
+    YamlLintConfig::from_yaml_str(SAFE_FIX_CONFIG_YAML)
+        .expect("safe-fix config string is valid")
+}
+
+fn synthetic_path() -> &'static Path {
+    Path::new("synthetic.yaml")
+}
+
+fn synthetic_base_dir() -> &'static Path {
+    Path::new(".")
+}
+
+#[derive(Debug, Clone)]
+enum Scalar {
+    Plain(String),
+    SingleQuoted(String),
+    DoubleQuoted(String),
+}
+
+#[derive(Debug, Clone)]
+enum Node {
+    Scalar(Scalar),
+    FlowSeq(Vec<Node>, FlowStyle),
+    FlowMap(Vec<(Scalar, Node)>, FlowStyle),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FlowStyle {
+    inner_padding: u8,
+    spaces_before_comma: u8,
+    spaces_after_comma: u8,
+}
+
+#[derive(Debug, Clone)]
+struct InlineComment {
+    spaces_after_hash: u8,
+    text: String,
+}
+
+#[derive(Debug, Clone)]
+struct BlockEntry {
+    key: String,
+    value: Node,
+    trailing_inline_comment: Option<InlineComment>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum NewlineStyle {
+    Lf,
+    Crlf,
+}
+
+#[derive(Debug, Clone)]
+struct Document {
+    entries: Vec<BlockEntry>,
+    newline: NewlineStyle,
+    has_final_newline: bool,
+}
+
+fn push_spaces(buffer: &mut String, count: u8) {
+    for _ in 0..count {
+        buffer.push(' ');
+    }
+}
+
+impl Scalar {
+    fn render(&self, buffer: &mut String) {
+        match self {
+            Self::Plain(text) => buffer.push_str(text),
+            Self::SingleQuoted(text) => {
+                buffer.push('\'');
+                for ch in text.chars() {
+                    if ch == '\'' {
+                        buffer.push_str("''");
+                    } else {
+                        buffer.push(ch);
+                    }
+                }
+                buffer.push('\'');
+            }
+            Self::DoubleQuoted(text) => {
+                buffer.push('"');
+                for ch in text.chars() {
+                    match ch {
+                        '"' => buffer.push_str("\\\""),
+                        '\\' => buffer.push_str("\\\\"),
+                        _ => buffer.push(ch),
+                    }
+                }
+                buffer.push('"');
+            }
+        }
+    }
+}
+
+impl Node {
+    fn render(&self, buffer: &mut String) {
+        match self {
+            Self::Scalar(scalar) => scalar.render(buffer),
+            Self::FlowSeq(items, style) => {
+                buffer.push('[');
+                push_spaces(buffer, style.inner_padding);
+                for (index, item) in items.iter().enumerate() {
+                    if index > 0 {
+                        push_spaces(buffer, style.spaces_before_comma);
+                        buffer.push(',');
+                        push_spaces(buffer, style.spaces_after_comma);
+                    }
+                    item.render(buffer);
+                }
+                push_spaces(buffer, style.inner_padding);
+                buffer.push(']');
+            }
+            Self::FlowMap(pairs, style) => {
+                buffer.push('{');
+                push_spaces(buffer, style.inner_padding);
+                for (index, (key, value)) in pairs.iter().enumerate() {
+                    if index > 0 {
+                        push_spaces(buffer, style.spaces_before_comma);
+                        buffer.push(',');
+                        push_spaces(buffer, style.spaces_after_comma);
+                    }
+                    key.render(buffer);
+                    buffer.push_str(": ");
+                    value.render(buffer);
+                }
+                push_spaces(buffer, style.inner_padding);
+                buffer.push('}');
+            }
+        }
+    }
+}
+
+impl Document {
+    fn render(&self) -> String {
+        let mut buffer = String::new();
+        let line_terminator = match self.newline {
+            NewlineStyle::Lf => "\n",
+            NewlineStyle::Crlf => "\r\n",
+        };
+        for (index, entry) in self.entries.iter().enumerate() {
+            if index > 0 {
+                buffer.push_str(line_terminator);
+            }
+            buffer.push_str(&entry.key);
+            buffer.push_str(": ");
+            entry.value.render(&mut buffer);
+            if let Some(comment) = &entry.trailing_inline_comment {
+                buffer.push_str("  #");
+                push_spaces(&mut buffer, comment.spaces_after_hash);
+                buffer.push_str(&comment.text);
+            }
+        }
+        if self.has_final_newline {
+            buffer.push_str(line_terminator);
+        }
+        buffer
+    }
+}
+
+fn arb_plain_identifier() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_]{0,6}".prop_map(|value| value)
+}
+
+fn arb_quoted_payload() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![
+            Just('a'),
+            Just('b'),
+            Just('1'),
+            Just(' '),
+            Just('#'),
+            Just(','),
+            Just('{'),
+            Just('}'),
+            Just('['),
+            Just(']'),
+        ],
+        0usize..=6,
+    )
+    .prop_map(|chars| chars.into_iter().collect())
+}
+
+fn arb_scalar() -> impl Strategy<Value = Scalar> {
+    prop_oneof![
+        arb_plain_identifier().prop_map(Scalar::Plain),
+        arb_quoted_payload().prop_map(Scalar::SingleQuoted),
+        arb_quoted_payload().prop_map(Scalar::DoubleQuoted),
+    ]
+}
+
+fn arb_flow_style() -> impl Strategy<Value = FlowStyle> {
+    (0u8..=2, 0u8..=2, 0u8..=2).prop_map(
+        |(inner_padding, spaces_before_comma, spaces_after_comma)| FlowStyle {
+            inner_padding,
+            spaces_before_comma,
+            spaces_after_comma,
+        },
+    )
+}
+
+fn arb_node() -> impl Strategy<Value = Node> {
+    let leaf = arb_scalar().prop_map(Node::Scalar);
+    leaf.prop_recursive(2, 16, 4, |inner| {
+        prop_oneof![
+            (
+                prop::collection::vec(inner.clone(), 0..=4),
+                arb_flow_style()
+            )
+                .prop_map(|(items, style)| Node::FlowSeq(items, style)),
+            (
+                prop::collection::vec((arb_scalar(), inner), 0..=4),
+                arb_flow_style(),
+            )
+                .prop_map(|(pairs, style)| Node::FlowMap(pairs, style)),
+        ]
+    })
+}
+
+fn arb_inline_comment() -> impl Strategy<Value = InlineComment> {
+    (0u8..=2, "[a-z][a-z0-9 ]{0,8}").prop_map(|(spaces_after_hash, text)| {
+        InlineComment {
+            spaces_after_hash,
+            text,
+        }
+    })
+}
+
+fn arb_block_entry() -> impl Strategy<Value = BlockEntry> {
+    (
+        arb_plain_identifier(),
+        arb_node(),
+        prop::option::of(arb_inline_comment()),
+    )
+        .prop_map(|(key, value, trailing_inline_comment)| BlockEntry {
+            key,
+            value,
+            trailing_inline_comment,
+        })
+}
+
+fn arb_document() -> impl Strategy<Value = Document> {
+    (
+        prop::collection::vec(arb_block_entry(), 1..=4),
+        prop_oneof![Just(NewlineStyle::Lf), Just(NewlineStyle::Crlf)],
+        any::<bool>(),
+    )
+        .prop_map(|(entries, newline, has_final_newline)| Document {
+            entries,
+            newline,
+            has_final_newline,
+        })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource(
+            "proptest-regressions",
+        ))),
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn safe_fix_is_idempotent(document in arb_document()) {
+        let input = document.render();
+        let cfg = safe_fix_config();
+        let once = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
+        let twice = apply_safe_fixes(&once, &cfg, synthetic_path(), synthetic_base_dir());
+        prop_assert_eq!(
+            &once,
+            &twice,
+            "applying safe fixes is not idempotent for input {:?}; once -> {:?}; twice -> {:?}",
+            input,
+            once,
+            twice
+        );
+    }
+}
+
+#[test]
+fn renderer_emits_dirty_inputs_that_safe_fix_normalizes() {
+    let plain = |name: &str| Node::Scalar(Scalar::Plain(name.to_string()));
+    let dirty_flow_seq = Document {
+        entries: vec![BlockEntry {
+            key: "items".to_string(),
+            value: Node::FlowSeq(
+                vec![plain("a"), plain("b")],
+                FlowStyle {
+                    inner_padding: 1,
+                    spaces_before_comma: 1,
+                    spaces_after_comma: 2,
+                },
+            ),
+            trailing_inline_comment: Some(InlineComment {
+                spaces_after_hash: 0,
+                text: "trailing".to_string(),
+            }),
+        }],
+        newline: NewlineStyle::Crlf,
+        has_final_newline: false,
+    };
+    let input = dirty_flow_seq.render();
+    let fixed = apply_safe_fixes(
+        &input,
+        &safe_fix_config(),
+        synthetic_path(),
+        synthetic_base_dir(),
+    );
+    assert_ne!(
+        input, fixed,
+        "renderer must emit inputs that exercise safe fixers; input={input:?} fixed={fixed:?}"
+    );
+}

--- a/tests/property_safe_fix.rs
+++ b/tests/property_safe_fix.rs
@@ -81,6 +81,9 @@ allow-double-quotes-for-escaping = true
 struct PreparedConfig {
     name: &'static str,
     cfg: YamlLintConfig,
+    // Holds the tempdir containing the .ryl.toml that `discover_config` was
+    // given; kept alive so the path embedded in `cfg` (used by per-file
+    // ignore matching) stays valid for the lifetime of the LazyLock.
     _backing: Option<TempDir>,
 }
 

--- a/tests/property_safe_fix.rs
+++ b/tests/property_safe_fix.rs
@@ -1,13 +1,16 @@
+use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
-use ryl::config::YamlLintConfig;
+use ryl::config::{Overrides, YamlLintConfig, discover_config};
 use ryl::fix::apply_safe_fixes;
 use ryl::lint::{LintProblem, lint_str};
 use saphyr::{LoadableYamlNode, YamlOwned};
+use tempfile::TempDir;
 
-const SAFE_FIX_CONFIG_YAML: &str = "rules:
+const COMMON_SAFE_FIX_RULES_YAML: &str = "rules:
   new-lines: enable
   comments: enable
   comments-indentation: enable
@@ -15,8 +18,39 @@ const SAFE_FIX_CONFIG_YAML: &str = "rules:
   braces: enable
   brackets: enable
   new-line-at-end-of-file: enable
-  quoted-strings: enable
 ";
+
+const QUOTED_STRINGS_VARIANTS: &[(&str, &str)] = &[
+    ("yamllint-default", "  quoted-strings: enable\n"),
+    (
+        "best-practice",
+        "  quoted-strings:
+    quote-type: single
+    required: only-when-needed
+",
+    ),
+    (
+        "strict-single",
+        "  quoted-strings:
+    quote-type: single
+    required: true
+",
+    ),
+    (
+        "strict-double",
+        "  quoted-strings:
+    quote-type: double
+    required: true
+",
+    ),
+    (
+        "consistent",
+        "  quoted-strings:
+    quote-type: consistent
+    required: true
+",
+    ),
+];
 
 const SAFE_FIX_RULES: &[&str] = &[
     "new-lines",
@@ -29,9 +63,70 @@ const SAFE_FIX_RULES: &[&str] = &[
     "quoted-strings",
 ];
 
-fn safe_fix_config() -> YamlLintConfig {
-    YamlLintConfig::from_yaml_str(SAFE_FIX_CONFIG_YAML)
-        .expect("safe-fix config string is valid")
+const BEST_PRACTICE_TOML: &str = "[rules]
+new-lines = 'enable'
+comments = 'enable'
+comments-indentation = 'enable'
+commas = 'enable'
+braces = 'enable'
+brackets = 'enable'
+new-line-at-end-of-file = 'enable'
+
+[rules.quoted-strings]
+quote-type = 'single'
+required = 'only-when-needed'
+allow-double-quotes-for-escaping = true
+";
+
+struct PreparedConfig {
+    name: &'static str,
+    cfg: YamlLintConfig,
+    _backing: Option<TempDir>,
+}
+
+static SAFE_FIX_CONFIGS: LazyLock<Vec<PreparedConfig>> = LazyLock::new(|| {
+    let mut configs: Vec<PreparedConfig> = QUOTED_STRINGS_VARIANTS
+        .iter()
+        .map(|(name, suffix)| {
+            let yaml = format!("{COMMON_SAFE_FIX_RULES_YAML}{suffix}");
+            let cfg = YamlLintConfig::from_yaml_str(&yaml)
+                .expect("named safe-fix config must parse");
+            PreparedConfig {
+                name,
+                cfg,
+                _backing: None,
+            }
+        })
+        .collect();
+
+    let dir = TempDir::new().expect("create tempdir for TOML config");
+    let toml_path = dir.path().join(".ryl.toml");
+    fs::write(&toml_path, BEST_PRACTICE_TOML).expect("write TOML config");
+    let overrides = Overrides {
+        config_file: Some(toml_path),
+        config_data: None,
+    };
+    let ctx = discover_config(&[], &overrides)
+        .expect("TOML-backed best-practice config must load");
+    configs.push(PreparedConfig {
+        name: "best-practice-toml",
+        cfg: ctx.config,
+        _backing: Some(dir),
+    });
+
+    configs
+});
+
+fn safe_fix_configs() -> &'static [PreparedConfig] {
+    &SAFE_FIX_CONFIGS
+}
+
+fn named_config(name: &str) -> &'static YamlLintConfig {
+    &safe_fix_configs()
+        .iter()
+        .find(|prepared| prepared.name == name)
+        .unwrap_or_else(|| panic!("unknown safe-fix config '{name}'"))
+        .cfg
 }
 
 fn synthetic_path() -> &'static Path {
@@ -131,6 +226,8 @@ impl Scalar {
                     match ch {
                         '"' => buffer.push_str("\\\""),
                         '\\' => buffer.push_str("\\\\"),
+                        '\n' => buffer.push_str("\\n"),
+                        '\t' => buffer.push_str("\\t"),
                         _ => buffer.push(ch),
                     }
                 }
@@ -209,7 +306,7 @@ fn arb_plain_identifier() -> impl Strategy<Value = String> {
     "[a-z][a-z0-9_]{0,6}".prop_map(|value| value)
 }
 
-fn arb_quoted_payload() -> impl Strategy<Value = String> {
+fn arb_single_quoted_payload() -> impl Strategy<Value = String> {
     prop::collection::vec(
         prop_oneof![
             Just('a'),
@@ -222,6 +319,35 @@ fn arb_quoted_payload() -> impl Strategy<Value = String> {
             Just('}'),
             Just('['),
             Just(']'),
+            Just('*'),
+            Just('?'),
+            Just('&'),
+            Just('!'),
+            Just(':'),
+        ],
+        0usize..=6,
+    )
+    .prop_map(|chars| chars.into_iter().collect())
+}
+
+fn arb_double_quoted_payload() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![
+            Just('a'),
+            Just('b'),
+            Just('1'),
+            Just(' '),
+            Just('#'),
+            Just(','),
+            Just('{'),
+            Just('}'),
+            Just('['),
+            Just(']'),
+            Just('*'),
+            Just('?'),
+            Just('&'),
+            Just('!'),
+            Just(':'),
         ],
         0usize..=6,
     )
@@ -231,8 +357,8 @@ fn arb_quoted_payload() -> impl Strategy<Value = String> {
 fn arb_scalar() -> impl Strategy<Value = Scalar> {
     prop_oneof![
         arb_plain_identifier().prop_map(Scalar::Plain),
-        arb_quoted_payload().prop_map(Scalar::SingleQuoted),
-        arb_quoted_payload().prop_map(Scalar::DoubleQuoted),
+        arb_single_quoted_payload().prop_map(Scalar::SingleQuoted),
+        arb_double_quoted_payload().prop_map(Scalar::DoubleQuoted),
     ]
 }
 
@@ -310,35 +436,46 @@ proptest! {
     #[test]
     fn safe_fix_is_idempotent(document in arb_document()) {
         let input = document.render();
-        let cfg = safe_fix_config();
-        let once = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
-        let twice = apply_safe_fixes(&once, &cfg, synthetic_path(), synthetic_base_dir());
-        prop_assert_eq!(
-            &once,
-            &twice,
-            "applying safe fixes is not idempotent for input {:?}; once -> {:?}; twice -> {:?}",
-            input,
-            once,
-            twice
-        );
+        for prepared in safe_fix_configs() {
+            let cfg_name = prepared.name;
+            let cfg = &prepared.cfg;
+            let once =
+                apply_safe_fixes(&input, cfg, synthetic_path(), synthetic_base_dir());
+            let twice =
+                apply_safe_fixes(&once, cfg, synthetic_path(), synthetic_base_dir());
+            prop_assert_eq!(
+                &once,
+                &twice,
+                "applying safe fixes is not idempotent under config '{}' for input {:?}; once -> {:?}; twice -> {:?}",
+                cfg_name,
+                input,
+                once,
+                twice
+            );
+        }
     }
 
     #[test]
     fn safe_fix_leaves_no_safe_fix_rule_diagnostics(document in arb_document()) {
         let input = document.render();
-        let cfg = safe_fix_config();
-        let fixed = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
-        if parse_for_compare(&fixed).is_none() {
-            return Ok(());
+        for prepared in safe_fix_configs() {
+            let cfg_name = prepared.name;
+            let cfg = &prepared.cfg;
+            let fixed =
+                apply_safe_fixes(&input, cfg, synthetic_path(), synthetic_base_dir());
+            if parse_for_compare(&fixed).is_none() {
+                continue;
+            }
+            let remaining = safe_fix_rule_diagnostics(&fixed, cfg);
+            prop_assert!(
+                remaining.is_empty(),
+                "safe-fix-rule diagnostics survived fix under config '{}' for input {:?}; fixed {:?}; diagnostics {:?}",
+                cfg_name,
+                input,
+                fixed,
+                remaining
+            );
         }
-        let remaining = safe_fix_rule_diagnostics(&fixed, &cfg);
-        prop_assert!(
-            remaining.is_empty(),
-            "safe-fix-rule diagnostics survived fix for input {:?}; fixed {:?}; diagnostics {:?}",
-            input,
-            fixed,
-            remaining
-        );
     }
 
     #[test]
@@ -347,20 +484,25 @@ proptest! {
         let Some(before) = parse_for_compare(&input) else {
             return Ok(());
         };
-        let cfg = safe_fix_config();
-        let fixed = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
-        let after = parse_for_compare(&fixed).ok_or_else(|| {
-            TestCaseError::fail(format!(
-                "safe fix broke a previously-parseable document; input {input:?}; fixed {fixed:?}"
-            ))
-        })?;
-        prop_assert_eq!(
-            &before,
-            &after,
-            "safe fix changed parsed YAML value; input {:?}; fixed {:?}",
-            input,
-            fixed
-        );
+        for prepared in safe_fix_configs() {
+            let cfg_name = prepared.name;
+            let cfg = &prepared.cfg;
+            let fixed =
+                apply_safe_fixes(&input, cfg, synthetic_path(), synthetic_base_dir());
+            let after = parse_for_compare(&fixed).ok_or_else(|| {
+                TestCaseError::fail(format!(
+                    "safe fix broke a previously-parseable document under config '{cfg_name}'; input {input:?}; fixed {fixed:?}"
+                ))
+            })?;
+            prop_assert_eq!(
+                &before,
+                &after,
+                "safe fix changed parsed YAML value under config '{}'; input {:?}; fixed {:?}",
+                cfg_name,
+                input,
+                fixed
+            );
+        }
     }
 }
 
@@ -387,21 +529,79 @@ fn safe_fix_properties_hold_for_known_dirty_input() {
         has_final_newline: false,
     };
     let input = dirty_flow_seq.render();
-    let cfg = safe_fix_config();
     let before = parse_for_compare(&input).expect("known dirty input must parse");
-    let fixed = apply_safe_fixes(&input, &cfg, synthetic_path(), synthetic_base_dir());
-    assert_ne!(
-        input, fixed,
-        "renderer must emit inputs that exercise safe fixers; input={input:?} fixed={fixed:?}"
-    );
-    let after =
-        parse_for_compare(&fixed).expect("safe fix must keep known input parseable");
-    assert_eq!(before, after, "safe fix must preserve parsed value");
-    let remaining = safe_fix_rule_diagnostics(&fixed, &cfg);
+    for prepared in safe_fix_configs() {
+        let cfg_name = prepared.name;
+        let cfg = &prepared.cfg;
+        let fixed =
+            apply_safe_fixes(&input, cfg, synthetic_path(), synthetic_base_dir());
+        assert_ne!(
+            input, fixed,
+            "renderer must emit inputs that exercise safe fixers under config '{cfg_name}'; input={input:?} fixed={fixed:?}"
+        );
+        let after = parse_for_compare(&fixed)
+            .unwrap_or_else(|| panic!("safe fix broke parseable input under config '{cfg_name}': {fixed:?}"));
+        assert_eq!(
+            before, after,
+            "safe fix must preserve parsed value under config '{cfg_name}'"
+        );
+        let remaining = safe_fix_rule_diagnostics(&fixed, cfg);
+        assert!(
+            remaining.is_empty(),
+            "safe-fix-rule diagnostics must clear after fix under config '{cfg_name}': {remaining:?}"
+        );
+        let twice =
+            apply_safe_fixes(&fixed, cfg, synthetic_path(), synthetic_base_dir());
+        assert_eq!(
+            fixed, twice,
+            "safe fix must be idempotent under config '{cfg_name}'"
+        );
+    }
+}
+
+#[test]
+fn best_practice_retains_quotes_around_yaml_metachars() {
+    let input = "schedule: '30 21 * * 0'\n";
+    let cfg = named_config("best-practice");
+    let before = parse_for_compare(input).expect("input parses");
+    let fixed =
+        apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
+    let after = parse_for_compare(&fixed)
+        .expect("best-practice fix must keep cron-like input parseable");
+    assert_eq!(before, after, "parse must be preserved: {fixed:?}");
     assert!(
-        remaining.is_empty(),
-        "safe-fix-rule diagnostics must clear after fix on known input: {remaining:?}"
+        fixed.contains("'30 21 * * 0'"),
+        "best-practice must retain quotes around scalars containing YAML metachars (issue #206): {fixed:?}"
     );
-    let twice = apply_safe_fixes(&fixed, &cfg, synthetic_path(), synthetic_base_dir());
-    assert_eq!(fixed, twice, "safe fix must be idempotent on known input");
+}
+
+#[test]
+fn best_practice_does_not_break_parse_for_escape_sequences() {
+    let input = "message: \"line1\\nline2\"\n";
+    let cfg = named_config("best-practice");
+    let before = parse_for_compare(input).expect("input parses");
+    let fixed =
+        apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
+    let after = parse_for_compare(&fixed)
+        .expect("best-practice fix must keep escape-sequence input parseable");
+    assert_eq!(
+        before, after,
+        "safe fix must not change parsed value of escape-bearing scalars (issue #184): {fixed:?}"
+    );
+}
+
+#[test]
+fn best_practice_preserves_trailing_comment_when_unquoting() {
+    let input = "key: 'value'  # important comment\n";
+    let cfg = named_config("best-practice");
+    let before = parse_for_compare(input).expect("input parses");
+    let fixed =
+        apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
+    let after = parse_for_compare(&fixed)
+        .expect("best-practice fix must keep quoted-with-comment input parseable");
+    assert_eq!(before, after, "parse must be preserved: {fixed:?}");
+    assert!(
+        fixed.contains("# important comment"),
+        "trailing comment must survive quote removal (issue #206): {fixed:?}"
+    );
 }

--- a/tests/property_safe_fix.rs
+++ b/tests/property_safe_fix.rs
@@ -301,8 +301,8 @@ fn arb_document() -> impl Strategy<Value = Document> {
 
 proptest! {
     #![proptest_config(ProptestConfig {
-        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource(
-            "proptest-regressions",
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "tests/proptest-regressions/property_safe_fix.txt",
         ))),
         ..ProptestConfig::default()
     })]

--- a/tests/proptest-regressions/property_safe_fix.txt
+++ b/tests/proptest-regressions/property_safe_fix.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 690f9ca4ae48c512ddb6131a3d37426288536602c67aae9a864134f107db3b0c # shrinks to document = Document { entries: [BlockEntry { key: "a", value: Scalar(Plain("a")), trailing_inline_comment: None }], newline: Lf, has_final_newline: false }
+cc a0c6ae6f138b81d6ac7efb5c6ec5b92b87db819bbba90f72f6a9a023896e375d # shrinks to document = Document { entries: [BlockEntry { key: "a", value: Scalar(Plain("a")), trailing_inline_comment: None }], newline: Lf, has_final_newline: false }
+cc 108197f47fe7d08b62ee0f097129defa7c33c5ba062cf003dff5658b142ccf12 # shrinks to document = Document { entries: [BlockEntry { key: "a", value: Scalar(Plain("a")), trailing_inline_comment: None }], newline: Lf, has_final_newline: false }
+cc f3c429d76709f5bf40982e897f85b83e19ea5e818d8e862f2d22cb77fb5c69c8 # shrinks to document = Document { entries: [BlockEntry { key: "a", value: Scalar(DoubleQuoted("a\ta")), trailing_inline_comment: None }], newline: Lf, has_final_newline: false }


### PR DESCRIPTION
Closes #180.

## Summary

Adds a `proptest`-driven test suite that asserts the three invariants
called out in #180 across the eight currently-safe `FixSafety::Safe`
rules:

- **Idempotence** — `apply_safe_fixes(apply_safe_fixes(x)) == apply_safe_fixes(x)`.
- **Cleanliness** — linting the fixed output reports zero diagnostics for any
  of the eight safe-fix rules (guarded against the lint syntax-error
  short-circuit so the property can't silently degrade to a no-op).
- **Parse preservation (strong)** — if the input parses via
  `saphyr::YamlOwned`, the fixed output must also parse and the parsed values
  must be equal. Stronger than the issue's "if both parse" wording.

The properties run against a matrix of six named configs to catch
config-specific regressions:

| Config | Source | Notes |
|---|---|---|
| `yamllint-default` | YAML | bare `quoted-strings: enable` |
| `best-practice` | YAML | `single` + `only-when-needed` |
| `strict-single` | YAML | `single` + `required: true` |
| `strict-double` | YAML | `double` + `required: true` |
| `consistent` | YAML | `consistent` + `required: true` |
| `best-practice-toml` | TOML | adds `allow-double-quotes-for-escaping` (ryl-only) |

Per the project's "YAML configuration strictly aligned with yamllint" rule,
ryl-only options can only be exercised through TOML. The TOML config slot is
loaded via `discover_config` from a tempfile (held alive via `LazyLock`)
specifically so this surface gets covered.

The suite lives in `tests/property_safe_fix.rs` with a small AST (`Scalar`,
`Node`, `BlockEntry`, `Document`), `proptest` strategies, and a renderer
that injects whitespace / newline / comment noise so the fixers actually
have work to do. The generator's quoted-payload alphabet includes the YAML
metachars (`#`, `,`, `{`, `}`, `[`, `]`, `*`, `?`, `&`, `!`, `:`) that
real-world bugs have hidden behind. Three deterministic regression tests
pin the production-bug patterns from issues #184 (escape sequences) and
#206 (cron pattern + trailing-comment preservation).

## What also landed here

While extending the property tests with the config matrix, the new
`best-practice` config surfaced an idempotence bug in `quoted-strings`'s
fixer — under `quote-type: single` + `required: only-when-needed`, the
single fix pass converted double quotes to single, exposing that the
result also qualified for quote removal, but the CLI never re-applied
the fix. Users had to run `--fix` twice.

`src/fix.rs::apply_rule_fix` now runs each rule's fix to a fixed point,
bounded at eight iterations. All current rules converge in ≤3 iterations;
well-behaved fix functions signal completion by returning `None` so the
loop terminates after one extra no-op call.

Two conventional CLI-level regression tests in `tests/cli_fix.rs` guard
both findings:

- `fix_under_best_practice_converges_in_one_invocation_for_escape_sequences`
  pins the idempotence fix.
- `fix_with_toml_allow_double_quotes_for_escaping_silences_quoted_strings_diagnostic`
  documents the TOML-only option's expected behavior.

## Commits

1. `refactor(lint)` — split `lint_file` into a string-based `lint_str` core
   plus a thin disk-reading wrapper. No behavior change.
2. `test(property)` — proptest dev-dep + scaffolding + idempotence smoke.
3. `test(property)` — cleanliness + parse-preservation properties; AGENTS.md doc.
4. `test(property)` — relocate regression files to documented path
   (`Direct(...)` instead of `WithSource(...)`); addressed Codex's P2 review.
5. `fix(quoted-strings)` — converge per-rule fixes to a fixed point; expand
   the property matrix to six configs (5 YAML + 1 TOML); add three
   deterministic regression tests + two CLI regression tests.
6. `style` — `cargo fmt` fixup missed in commit 5.

## Caveats / known scope limits

- The `apply_rule_fix` loop is bounded at 8 iterations as a safety belt
  against oscillation. Per the project's "leave unreachable branches
  uncovered rather than asserting" guidance in AGENTS.md, this is not
  wrapped in a `debug_assert!`. Property tests catch non-convergence
  as an idempotence failure regardless.
- The `DoubleQuoted` generator alphabet deliberately excludes `\\`, `\n`,
  `\t`. Under any `quote-type: single` config without the escape allowance,
  these would correctly trigger the fixer's "decline to convert" path,
  leaving a surviving diagnostic that the cleanliness property would flag.
  The `best-practice-toml` config + deterministic regression tests cover
  that surface explicitly instead.
- Generator scope: single-level block mapping with flow-collection values,
  plain identifiers, single- and double-quoted scalars, optional inline
  comments. Nested block mappings, block sequences, multi-line scalars,
  document markers, tags, and anchors are out of scope for v1. AGENTS.md
  documents the workflow for extending the generator alongside new fixers.
- This PR expands #180's narrow acceptance: the idempotence fix is a real
  behavioral change to `apply_safe_fixes`. Worth highlighting in any
  squash-commit message or release notes.

## Test plan

- [x] `cargo test --test property_safe_fix` — 7/7 pass (3 proptest
      properties × 256 cases × 6 configs ≈ 4,600 case-config executions
      + 4 deterministic tests) in ~2.5s
- [x] `cargo test --test cli_fix` — 11/11 pass (9 existing + 2 new
      conventional regression tests)
- [x] `prek run --all-files` — all 29 hooks pass, stable across reruns
- [x] `./scripts/coverage-missing.sh` — `Coverage OK: no uncovered regions`
- [x] `uv run scripts/source_size.py --compare-to main` — src +28 lines
      (lint.rs split + apply_rule_fix loop), tests +670 lines
      (property suite + matrix + regression tests)
- [x] Codex review — no regressions flagged
- [x] CI green on the branch