### PR TITLE
Phase 1: migrate event-stream parser from saphyr-parser to granit-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,9 +600,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -985,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -1382,9 +1392,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1555,13 +1565,13 @@ dependencies = [
  "dirs-next",
  "encoding_rs",
  "globset",
+ "granit-parser",
  "ignore",
  "jsonschema",
  "proptest",
  "rayon",
  "regex",
  "saphyr",
- "saphyr-parser",
  "schemars",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ globset = "0.4.18"
 ignore = "0.4.25"
 rayon = "1.11.0"
 schemars = { version = "1.2.1", features = ["derive"] }
-saphyr-parser = "0.0.6"
+granit-parser = "0.0.3"
 saphyr = "0.0.6"
 dirs-next = "2.0.0"
 regex = "1"

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -44,8 +44,8 @@ pub struct LintProblem {
 }
 
 struct NullSink;
-impl<'i> saphyr_parser::EventReceiver<'i> for NullSink {
-    fn on_event(&mut self, _ev: saphyr_parser::Event<'i>) {}
+impl<'i> granit_parser::EventReceiver<'i> for NullSink {
+    fn on_event(&mut self, _ev: granit_parser::Event<'i>) {}
 }
 
 /// Lint a single YAML file and return diagnostics in yamllint format order.
@@ -550,7 +550,7 @@ fn collect_line_length_diagnostics(
 }
 
 fn syntax_diagnostic(content: &str) -> Option<LintProblem> {
-    let mut parser = saphyr_parser::Parser::new_from_str(content);
+    let mut parser = granit_parser::Parser::new_from_str(content);
     let mut sink = NullSink;
     match parser.load(&mut sink, true) {
         Ok(()) => None,

--- a/src/rules/comments.rs
+++ b/src/rules/comments.rs
@@ -1,4 +1,4 @@
-use granit_parser::{Event, Parser, Placement, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Placement, Span};
 
 use crate::config::YamlLintConfig;
 
@@ -196,26 +196,30 @@ struct CommentInfo {
 }
 
 fn collect_comments(buffer: &str) -> Vec<CommentInfo> {
-    struct Collector {
-        comments: Vec<CommentInfo>,
-    }
-    impl SpannedEventReceiver<'_> for Collector {
-        fn on_event(&mut self, event: Event<'_>, span: Span) {
-            if let Event::Comment(text, placement) = event {
-                self.comments.push(CommentInfo {
+    let mut parser = Parser::new_from_str(buffer);
+    let mut comments = Vec::new();
+    let mut last_err_at: Option<usize> = None;
+    while let Some(res) = parser.next_event() {
+        match res {
+            Ok((Event::Comment(text, placement), span)) => {
+                comments.push(CommentInfo {
                     span,
                     text: text.into_owned(),
                     placement,
                 });
+                last_err_at = None;
+            }
+            Ok(_) => last_err_at = None,
+            Err(e) => {
+                let pos = e.marker().index();
+                if last_err_at == Some(pos) {
+                    break;
+                }
+                last_err_at = Some(pos);
             }
         }
     }
-    let mut parser = Parser::new_from_str(buffer);
-    let mut collector = Collector {
-        comments: Vec::new(),
-    };
-    let _ = parser.load(&mut collector, true);
-    collector.comments
+    comments
 }
 
 fn line_start_byte(buffer: &str, byte_offset: usize) -> usize {

--- a/src/rules/comments.rs
+++ b/src/rules/comments.rs
@@ -1,8 +1,6 @@
+use granit_parser::{Event, Parser, Placement, Span, SpannedEventReceiver};
+
 use crate::config::YamlLintConfig;
-use crate::rules::support::line_syntax::{
-    BlockScalarTracker, is_at_value_position, leading_whitespace_width,
-    split_lines_preserve_endings,
-};
 
 pub const ID: &str = "comments";
 
@@ -54,237 +52,172 @@ pub struct Violation {
     pub message: String,
 }
 
+/// Run the comments rule against `buffer`.
+///
+/// # Panics
+///
+/// Panics if granit's parser fails to populate byte offsets on comment
+/// spans; with [`Parser::new_from_str`] this is always populated.
 #[must_use]
 pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     let mut violations = Vec::new();
-    let mut quote_state = QuoteState::default();
-    let mut block_tracker = BlockScalarTracker::default();
-
-    for (line_idx, line) in buffer.lines().enumerate() {
-        let indent = leading_whitespace_width(line);
-        let content = &line[indent..];
-
-        if block_tracker.consume_line(indent, content) {
-            continue;
-        }
-
-        let Some(comment_start) = find_comment_start(line, &mut quote_state) else {
-            block_tracker.observe_indicator(indent, content);
-            continue;
-        };
+    for comment in collect_comments(buffer) {
+        let line = comment.span.start.line();
+        let hash_column = comment.span.start.col() + 1;
+        let is_inline = comment.placement == Placement::Right;
 
         if let Some(required) = cfg.min_spaces_from_content()
-            && is_inline_comment(line, comment_start)
-            && inline_spacing_width(line, comment_start) < required
+            && is_inline
         {
-            violations.push(Violation {
-                line: line_idx + 1,
-                column: column_at(line, comment_start),
-                message: format!("too few spaces before comment: expected {required}"),
-            });
+            let byte_start =
+                comment.span.start.byte_offset().expect(
+                    "granit Parser::new_from_str always populates byte offsets",
+                );
+            let line_start = line_start_byte(buffer, byte_start);
+            let spacing = buffer[line_start..byte_start]
+                .chars()
+                .rev()
+                .take_while(|ch| matches!(ch, ' ' | '\t'))
+                .count();
+            if spacing < required {
+                violations.push(Violation {
+                    line,
+                    column: hash_column,
+                    message: format!(
+                        "too few spaces before comment: expected {required}"
+                    ),
+                });
+            }
         }
 
         if !cfg.require_starting_space() {
             continue;
         }
 
-        let after_hash_idx = comment_start + skip_hashes(&line[comment_start..]);
-        if after_hash_idx >= line.len() {
+        let extra_hashes_count = comment.text.chars().take_while(|c| *c == '#').count();
+        let after_hashes = comment.text.trim_start_matches('#');
+        let Some(next_char) = after_hashes.chars().next() else {
             continue;
-        }
+        };
 
-        let next_char = line[after_hash_idx..].chars().next().unwrap_or(' ');
-
-        if cfg.ignore_shebangs()
-            && line_idx == 0
-            && comment_start == 0
-            && next_char == '!'
-        {
+        if cfg.ignore_shebangs() && line == 1 && hash_column == 1 && next_char == '!' {
             continue;
         }
 
         if next_char != ' ' {
             violations.push(Violation {
-                line: line_idx + 1,
-                column: column_at(line, after_hash_idx),
+                line,
+                column: hash_column + 1 + extra_hashes_count,
                 message: "missing starting space in comment".to_string(),
             });
         }
-
-        block_tracker.observe_indicator(indent, content);
     }
 
     violations
 }
 
+/// Apply the comments rule's auto-fix to `buffer`.
+///
+/// # Panics
+///
+/// Panics if granit's parser fails to populate byte offsets on comment
+/// spans; with [`Parser::new_from_str`] this is always populated.
 #[must_use]
 pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
-    let mut quote_state = QuoteState::default();
-    let mut block_tracker = BlockScalarTracker::default();
-    let mut output = String::with_capacity(buffer.len());
-    let mut changed = false;
+    let mut edits: Vec<(usize, String)> = Vec::new();
 
-    for (line_idx, raw_line, ending) in split_lines_preserve_endings(buffer) {
-        let indent = leading_whitespace_width(raw_line);
-        let content = &raw_line[indent..];
+    for comment in collect_comments(buffer) {
+        let byte_start = comment
+            .span
+            .start
+            .byte_offset()
+            .expect("granit Parser::new_from_str always populates byte offsets");
+        let line = comment.span.start.line();
+        let hash_column = comment.span.start.col() + 1;
+        let is_inline = comment.placement == Placement::Right;
 
-        let consumed = block_tracker.consume_line(indent, content);
-        let updated_line = if consumed {
-            raw_line.to_string()
-        } else if let Some(comment_start) =
-            find_comment_start(raw_line, &mut quote_state)
+        if let Some(required) = cfg.min_spaces_from_content()
+            && is_inline
         {
-            fix_comment_line(raw_line, line_idx, comment_start, cfg, &mut changed)
-        } else {
-            raw_line.to_string()
+            let line_start = line_start_byte(buffer, byte_start);
+            let spacing = buffer[line_start..byte_start]
+                .chars()
+                .rev()
+                .take_while(|ch| matches!(ch, ' ' | '\t'))
+                .count();
+            if spacing < required {
+                edits.push((byte_start, " ".repeat(required - spacing)));
+            }
+        }
+
+        if !cfg.require_starting_space() {
+            continue;
+        }
+
+        let extra_hash_bytes: usize = comment
+            .text
+            .chars()
+            .take_while(|c| *c == '#')
+            .map(char::len_utf8)
+            .sum();
+        let after_hashes = &comment.text[extra_hash_bytes..];
+        let Some(next_char) = after_hashes.chars().next() else {
+            continue;
         };
 
-        if !consumed {
-            let indent = leading_whitespace_width(&updated_line);
-            let content = &updated_line[indent..];
-            block_tracker.observe_indicator(indent, content);
-        }
-
-        output.push_str(&updated_line);
-        output.push_str(ending);
-    }
-
-    changed.then_some(output)
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-struct QuoteState {
-    in_single: bool,
-    in_double: bool,
-    escaped: bool,
-    flow_depth: u32,
-}
-
-fn find_comment_start(line: &str, state: &mut QuoteState) -> Option<usize> {
-    let chars: Vec<(usize, char)> = line.char_indices().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        let (byte_idx, ch) = chars[i];
-
-        if ch == '\\' && !state.in_single {
-            state.escaped = !state.escaped;
-            i += 1;
+        if cfg.ignore_shebangs() && line == 1 && hash_column == 1 && next_char == '!' {
             continue;
         }
 
-        if state.escaped {
-            state.escaped = false;
-            i += 1;
-            continue;
-        }
-
-        match ch {
-            '\'' if !state.in_double => {
-                if state.in_single {
-                    if chars.get(i + 1).map(|(_, c)| *c) == Some('\'') {
-                        i += 2;
-                        continue;
-                    }
-                    state.in_single = false;
-                } else if is_at_value_position(&chars, i, state.flow_depth) {
-                    state.in_single = true;
-                }
-            }
-            '"' if !state.in_single => {
-                if state.in_double || is_at_value_position(&chars, i, state.flow_depth)
-                {
-                    state.in_double = !state.in_double;
-                }
-            }
-            '[' | '{' if !state.in_single && !state.in_double => {
-                state.flow_depth = state.flow_depth.saturating_add(1);
-            }
-            ']' | '}' if !state.in_single && !state.in_double => {
-                state.flow_depth = state.flow_depth.saturating_sub(1);
-            }
-            '#' if !state.in_single && !state.in_double => {
-                if is_comment_position(line, byte_idx) {
-                    return Some(byte_idx);
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-
-    state.escaped = false;
-    None
-}
-
-fn is_inline_comment(line: &str, comment_start: usize) -> bool {
-    !line[..comment_start].trim().is_empty()
-}
-
-fn inline_spacing_width(line: &str, comment_start: usize) -> usize {
-    line[..comment_start]
-        .chars()
-        .rev()
-        .take_while(|ch| ch.is_whitespace())
-        .count()
-}
-
-fn skip_hashes(slice: &str) -> usize {
-    slice
-        .chars()
-        .take_while(|ch| *ch == '#')
-        .map(char::len_utf8)
-        .sum()
-}
-
-fn column_at(line: &str, byte_idx: usize) -> usize {
-    line[..byte_idx].chars().count() + 1
-}
-
-fn is_comment_position(line: &str, idx: usize) -> bool {
-    line[..idx].chars().last().is_none_or(char::is_whitespace)
-}
-
-fn fix_comment_line(
-    line: &str,
-    line_idx: usize,
-    comment_start: usize,
-    cfg: &Config,
-    changed: &mut bool,
-) -> String {
-    let mut line = line.to_string();
-    let mut inserted_before_comment = 0usize;
-
-    if let Some(required) = cfg.min_spaces_from_content()
-        && is_inline_comment(&line, comment_start)
-    {
-        let spacing = inline_spacing_width(&line, comment_start);
-        if spacing < required {
-            inserted_before_comment = required - spacing;
-            line.insert_str(comment_start, &" ".repeat(inserted_before_comment));
-            *changed = true;
+        if next_char != ' ' {
+            edits.push((
+                byte_start + '#'.len_utf8() + extra_hash_bytes,
+                " ".to_string(),
+            ));
         }
     }
 
-    if !cfg.require_starting_space() {
-        return line;
+    if edits.is_empty() {
+        return None;
     }
 
-    let comment_start = comment_start + inserted_before_comment;
-    let after_hash_idx = comment_start + skip_hashes(&line[comment_start..]);
-    if after_hash_idx >= line.len() {
-        return line;
+    edits.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut output = buffer.to_string();
+    for (offset, text) in edits {
+        output.insert_str(offset, &text);
     }
+    Some(output)
+}
 
-    let next_char = line[after_hash_idx..].chars().next().unwrap_or(' ');
-    if cfg.ignore_shebangs() && line_idx == 0 && comment_start == 0 && next_char == '!'
-    {
-        return line;
+struct CommentInfo {
+    span: Span,
+    text: String,
+    placement: Placement,
+}
+
+fn collect_comments(buffer: &str) -> Vec<CommentInfo> {
+    struct Collector {
+        comments: Vec<CommentInfo>,
     }
-
-    if next_char != ' ' {
-        line.insert(after_hash_idx, ' ');
-        *changed = true;
+    impl SpannedEventReceiver<'_> for Collector {
+        fn on_event(&mut self, event: Event<'_>, span: Span) {
+            if let Event::Comment(text, placement) = event {
+                self.comments.push(CommentInfo {
+                    span,
+                    text: text.into_owned(),
+                    placement,
+                });
+            }
+        }
     }
+    let mut parser = Parser::new_from_str(buffer);
+    let mut collector = Collector {
+        comments: Vec::new(),
+    };
+    let _ = parser.load(&mut collector, true);
+    collector.comments
+}
 
-    line
+fn line_start_byte(buffer: &str, byte_offset: usize) -> usize {
+    buffer[..byte_offset].rfind('\n').map_or(0, |i| i + 1)
 }

--- a/src/rules/document_end.rs
+++ b/src/rules/document_end.rs
@@ -8,7 +8,7 @@
 //! existing `...` markers — is never auto-fixed.
 use std::cmp;
 
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::buffer_newline;

--- a/src/rules/document_start.rs
+++ b/src/rules/document_start.rs
@@ -9,7 +9,7 @@
 //! `present: false` case — removing existing `---` markers — is never
 //! auto-fixed because removal can collide with multi-document boundaries
 //! the rule does not track.
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::buffer_newline;

--- a/src/rules/empty_lines.rs
+++ b/src/rules/empty_lines.rs
@@ -4,7 +4,7 @@
 //! scalar (literal/folded block scalar, multi-line single- or double-quoted
 //! scalar, or multi-line plain scalar) are left untouched because blank
 //! lines inside such scalars contribute to the parsed value. The protected
-//! line set is computed via `saphyr_parser`, so the rule bails (returns
+//! line set is computed via `granit_parser`, so the rule bails (returns
 //! `None`) when the buffer cannot be parsed. Runs outside those contexts
 //! (and the leading/trailing run governed by `max-start`/`max-end`) are
 //! trimmed to the configured maxima.

--- a/src/rules/empty_values.rs
+++ b/src/rules/empty_values.rs
@@ -1,4 +1,4 @@
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 
@@ -218,11 +218,11 @@ impl SpannedEventReceiver<'_> for EmptyValuesReceiver<'_> {
             | Event::DocumentEnd => {
                 self.reset();
             }
-            Event::MappingStart(_, _) => {
+            Event::MappingStart(_, _, _) => {
                 self.begin_node();
                 self.push_container(span, ContainerKind::Mapping);
             }
-            Event::SequenceStart(_, _) => {
+            Event::SequenceStart(_, _, _) => {
                 self.begin_node();
                 self.push_container(span, ContainerKind::Sequence);
             }
@@ -236,14 +236,14 @@ impl SpannedEventReceiver<'_> for EmptyValuesReceiver<'_> {
             Event::Alias(_) => {
                 self.begin_node();
             }
-            Event::Nothing => {}
+            Event::Comment(_, _) | Event::Nothing => {}
         }
     }
 }
 
 #[allow(dead_code)]
 pub fn coverage_touch_nothing_branch() {
-    use saphyr_parser::{Marker, Span};
+    use granit_parser::{Marker, Span};
 
     let cfg_struct = crate::config::YamlLintConfig::default();
     let config = Config::resolve(&cfg_struct);

--- a/src/rules/float_values.rs
+++ b/src/rules/float_values.rs
@@ -1,4 +1,4 @@
-use saphyr_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::span_utils::span_char_index_to_byte;

--- a/src/rules/key_duplicates.rs
+++ b/src/rules/key_duplicates.rs
@@ -1,4 +1,4 @@
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::mapping_key_walker::Walker;
@@ -58,15 +58,15 @@ impl SpannedEventReceiver<'_> for KeyDuplicatesReceiver<'_> {
             Event::StreamStart => self.state.reset_stream(),
             Event::DocumentStart(_) => self.state.document_start(),
             Event::DocumentEnd => self.state.document_end(),
-            Event::SequenceStart(_, _) => self.state.enter_sequence(),
+            Event::SequenceStart(_, _, _) => self.state.enter_sequence(),
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
-            Event::MappingStart(_, _) => self.state.enter_mapping(),
+            Event::MappingStart(_, _, _) => self.state.enter_mapping(),
             Event::Scalar(value, _, _, _) => {
                 self.state
                     .handle_scalar(value.as_ref(), span, &mut self.violations);
             }
             Event::Alias(_) => self.state.handle_alias(),
-            Event::StreamEnd | Event::Nothing => {}
+            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
         }
     }
 }

--- a/src/rules/key_ordering.rs
+++ b/src/rules/key_ordering.rs
@@ -1,5 +1,5 @@
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 use regex::Regex;
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
 use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 
 use crate::config::YamlLintConfig;
@@ -148,14 +148,17 @@ impl SpannedEventReceiver<'_> for KeyOrderingReceiver<'_> {
             Event::StreamStart => self.state.reset_stream(),
             Event::DocumentStart(_) => self.state.document_start(),
             Event::DocumentEnd => self.state.document_end(),
-            Event::SequenceStart(_, _) => self.state.enter_sequence(),
+            Event::SequenceStart(_, _, _) => self.state.enter_sequence(),
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
-            Event::MappingStart(_, _) => self.state.enter_mapping(),
+            Event::MappingStart(_, _, _) => self.state.enter_mapping(),
             Event::Scalar(value, _, _, _) => {
                 self.state
                     .handle_scalar(value.as_ref(), span, &mut self.violations);
             }
-            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+            Event::Comment(_, _)
+            | Event::Alias(_)
+            | Event::StreamEnd
+            | Event::Nothing => {}
         }
     }
 }

--- a/src/rules/line_length.rs
+++ b/src/rules/line_length.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 
@@ -294,7 +294,7 @@ impl SpannedEventReceiver<'_> for InlineMappingDetector<'_> {
         }
 
         match event {
-            Event::MappingStart(_, _) => {
+            Event::MappingStart(_, _, _) => {
                 self.mappings.push(MappingState { expect_key: true });
             }
             Event::MappingEnd => {
@@ -302,13 +302,14 @@ impl SpannedEventReceiver<'_> for InlineMappingDetector<'_> {
             }
             Event::Scalar(_, _, _, _) if self.mappings.is_empty() => {}
             Event::Scalar(_, _, _, _) => self.handle_scalar_event(span),
-            Event::SequenceStart(_, _)
+            Event::SequenceStart(_, _, _)
             | Event::SequenceEnd
             | Event::StreamStart
             | Event::StreamEnd
             | Event::DocumentStart(_)
             | Event::DocumentEnd
             | Event::Alias(_)
+            | Event::Comment(_, _)
             | Event::Nothing => {}
         }
     }

--- a/src/rules/octal_values.rs
+++ b/src/rules/octal_values.rs
@@ -1,4 +1,4 @@
-use saphyr_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -1,6 +1,8 @@
+use granit_parser::{
+    Event, Parser, ScalarStyle, Span, SpannedEventReceiver, StructureStyle, Tag,
+};
 use regex::Regex;
 use saphyr::Yaml;
-use saphyr_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver, Tag};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::mapping_key_walker::Walker;
@@ -206,14 +208,12 @@ impl SpannedEventReceiver<'_> for QuotedStringsReceiver<'_> {
             Event::StreamStart => self.state.reset_stream(),
             Event::DocumentStart(_) => self.state.document_start(),
             Event::DocumentEnd => self.state.document_end(),
-            Event::SequenceStart(_, _) => {
-                let flow = is_flow_sequence(self.state.buffer, span);
-                self.state.enter_sequence(flow);
+            Event::SequenceStart(style, _, _) => {
+                self.state.enter_sequence(style == StructureStyle::Flow);
             }
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
-            Event::MappingStart(_, _) => {
-                let flow = is_flow_mapping(self.state.buffer, span);
-                self.state.enter_mapping(flow);
+            Event::MappingStart(style, _, _) => {
+                self.state.enter_mapping(style == StructureStyle::Flow);
             }
             Event::Scalar(value, style, _, tag) => {
                 self.state.handle_scalar(
@@ -224,7 +224,10 @@ impl SpannedEventReceiver<'_> for QuotedStringsReceiver<'_> {
                     &mut self.diagnostics,
                 );
             }
-            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+            Event::Comment(_, _)
+            | Event::Alias(_)
+            | Event::StreamEnd
+            | Event::Nothing => {}
         }
     }
 }
@@ -460,25 +463,6 @@ fn build_violation(span: Span, message: String) -> Violation {
         column: span.start.col() + 1,
         message,
     }
-}
-
-fn is_flow_sequence(buffer: &str, span: Span) -> bool {
-    matches!(
-        next_non_whitespace_char(buffer, span.start.index()),
-        Some('[')
-    )
-}
-
-fn is_flow_mapping(buffer: &str, span: Span) -> bool {
-    matches!(
-        next_non_whitespace_char(buffer, span.start.index()),
-        Some('{')
-    )
-}
-
-fn next_non_whitespace_char(text: &str, byte_idx: usize) -> Option<char> {
-    text.get(byte_idx..)
-        .and_then(|tail| tail.chars().find(|ch| !ch.is_whitespace()))
 }
 
 fn is_core_tag(tag: &Tag) -> bool {
@@ -799,14 +783,12 @@ impl SpannedEventReceiver<'_> for ConsistentQuoteStyleFinder<'_> {
             Event::StreamStart => self.state.reset_stream(),
             Event::DocumentStart(_) => self.state.document_start(),
             Event::DocumentEnd => self.state.document_end(),
-            Event::SequenceStart(_, _) => {
-                let flow = is_flow_sequence(self.state.buffer, span);
-                self.state.enter_sequence(flow);
+            Event::SequenceStart(style, _, _) => {
+                self.state.enter_sequence(style == StructureStyle::Flow);
             }
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
-            Event::MappingStart(_, _) => {
-                let flow = is_flow_mapping(self.state.buffer, span);
-                self.state.enter_mapping(flow);
+            Event::MappingStart(style, _, _) => {
+                self.state.enter_mapping(style == StructureStyle::Flow);
             }
             Event::Scalar(value, style, _, tag) => {
                 self.state.collect_consistent_quote_style(
@@ -816,7 +798,10 @@ impl SpannedEventReceiver<'_> for ConsistentQuoteStyleFinder<'_> {
                     span,
                 );
             }
-            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+            Event::Comment(_, _)
+            | Event::Alias(_)
+            | Event::StreamEnd
+            | Event::Nothing => {}
         }
     }
 }
@@ -858,14 +843,12 @@ impl SpannedEventReceiver<'_> for QuotedStringsFixer<'_> {
             Event::StreamStart => self.state.reset_stream(),
             Event::DocumentStart(_) => self.state.document_start(),
             Event::DocumentEnd => self.state.document_end(),
-            Event::SequenceStart(_, _) => {
-                let flow = is_flow_sequence(self.state.buffer, span);
-                self.state.enter_sequence(flow);
+            Event::SequenceStart(style, _, _) => {
+                self.state.enter_sequence(style == StructureStyle::Flow);
             }
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
-            Event::MappingStart(_, _) => {
-                let flow = is_flow_mapping(self.state.buffer, span);
-                self.state.enter_mapping(flow);
+            Event::MappingStart(style, _, _) => {
+                self.state.enter_mapping(style == StructureStyle::Flow);
             }
             Event::Scalar(value, style, _, tag) => {
                 if let Some(r) =
@@ -875,7 +858,10 @@ impl SpannedEventReceiver<'_> for QuotedStringsFixer<'_> {
                     self.replacements.push(r);
                 }
             }
-            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+            Event::Comment(_, _)
+            | Event::Alias(_)
+            | Event::StreamEnd
+            | Event::Nothing => {}
         }
     }
 }

--- a/src/rules/support/flow_collection.rs
+++ b/src/rules/support/flow_collection.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::punctuation::{

--- a/src/rules/support/line_syntax.rs
+++ b/src/rules/support/line_syntax.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use saphyr_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
 
 pub(crate) fn leading_whitespace_width(line: &str) -> usize {
     line.chars()
@@ -152,109 +152,6 @@ pub(crate) fn block_scalar_marker_index(content: &str) -> Option<usize> {
     match bytes[cursor - 1] {
         b':' | b'-' | b'?' => Some(marker_idx),
         _ => None,
-    }
-}
-
-#[derive(Debug, Default)]
-pub(crate) struct BlockScalarTracker {
-    state: Option<BlockScalarState>,
-}
-
-#[derive(Debug)]
-struct BlockScalarState {
-    indicator_indent: usize,
-    content_indent: Option<usize>,
-}
-
-impl BlockScalarTracker {
-    pub(crate) fn consume_line(&mut self, indent: usize, content: &str) -> bool {
-        let Some(state) = self.state.as_mut() else {
-            return false;
-        };
-
-        if content.trim().is_empty() {
-            return true;
-        }
-
-        if let Some(content_indent) = state.content_indent {
-            if indent >= content_indent {
-                return true;
-            }
-
-            if indent <= state.indicator_indent {
-                self.state = None;
-                return false;
-            }
-
-            state.content_indent = Some(content_indent.min(indent));
-            return true;
-        }
-
-        if indent > state.indicator_indent {
-            state.content_indent = Some(indent);
-            return true;
-        }
-
-        self.state = None;
-        false
-    }
-
-    pub(crate) fn observe_indicator(&mut self, indent: usize, content: &str) {
-        let candidate = strip_trailing_comment_preserving_quotes(content).trim_end();
-        if block_scalar_marker_index(candidate).is_some() {
-            self.state = Some(BlockScalarState {
-                indicator_indent: indent,
-                content_indent: None,
-            });
-        }
-    }
-}
-
-pub(crate) fn is_at_value_position(
-    chars: &[(usize, char)],
-    idx: usize,
-    flow_depth: u32,
-) -> bool {
-    let mut cursor = idx;
-    let mut had_whitespace_before_quote = false;
-    while cursor > 0 && matches!(chars[cursor - 1].1, ' ' | '\t') {
-        cursor -= 1;
-        had_whitespace_before_quote = true;
-    }
-    if cursor == 0 {
-        return true;
-    }
-    loop {
-        let mut token_start = cursor;
-        while token_start > 0
-            && !matches!(
-                chars[token_start - 1].1,
-                ' ' | '\t' | '[' | '{' | ',' | '"' | '\''
-            )
-        {
-            token_start -= 1;
-        }
-        if !matches!(chars[token_start].1, '!' | '&') {
-            break;
-        }
-        let mut next_cursor = token_start;
-        while next_cursor > 0 && matches!(chars[next_cursor - 1].1, ' ' | '\t') {
-            next_cursor -= 1;
-        }
-        if next_cursor == 0 {
-            return true;
-        }
-        if next_cursor == token_start {
-            let prev = chars[next_cursor - 1].1;
-            return prev == '[' || prev == '{' || prev == ',';
-        }
-        cursor = next_cursor;
-    }
-    match chars[cursor - 1].1 {
-        ':' if flow_depth > 0 => true,
-        ':' | '-' | '?' => had_whitespace_before_quote,
-        '[' | '{' | ',' => true,
-        _ => false,
     }
 }
 

--- a/src/rules/support/punctuation.rs
+++ b/src/rules/support/punctuation.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 pub(crate) fn collect_scalar_ranges(buffer: &str) -> Vec<Range<usize>> {
     let mut parser = Parser::new_from_str(buffer);

--- a/src/rules/trailing_spaces.rs
+++ b/src/rules/trailing_spaces.rs
@@ -9,9 +9,9 @@
 //! that drops the implicit folded space). Trailing whitespace inside
 //! multi-line single-quoted and multi-line plain scalars folds away at
 //! parse time, so those lines remain fixable. The protected line set is
-//! computed via `saphyr_parser`, so the rule bails (returns `None`) when
+//! computed via `granit_parser`, so the rule bails (returns `None`) when
 //! the buffer cannot be parsed.
-use saphyr_parser::ScalarStyle;
+use granit_parser::ScalarStyle;
 
 use crate::rules::support::line_syntax::{
     protected_scalar_lines, split_lines_preserve_endings,

--- a/src/rules/truthy.rs
+++ b/src/rules/truthy.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use saphyr_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
+use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::comment_start_preserving_quotes;
@@ -280,9 +280,9 @@ impl SpannedEventReceiver<'_> for TruthyReceiver<'_> {
             }
             Event::DocumentStart(_) => self.state.document_start(span),
             Event::DocumentEnd => self.state.document_end(),
-            Event::SequenceStart(_, _) => self.state.enter_sequence(),
+            Event::SequenceStart(_, _, _) => self.state.enter_sequence(),
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
-            Event::MappingStart(_, _) => self.state.enter_mapping(),
+            Event::MappingStart(_, _, _) => self.state.enter_mapping(),
             Event::Scalar(value, style, _, tag) => {
                 let tagged = tag.is_some();
                 self.state.handle_scalar(
@@ -293,7 +293,10 @@ impl SpannedEventReceiver<'_> for TruthyReceiver<'_> {
                     &mut self.diagnostics,
                 );
             }
-            Event::Alias(_) | Event::StreamEnd | Event::Nothing => {}
+            Event::Comment(_, _)
+            | Event::Alias(_)
+            | Event::StreamEnd
+            | Event::Nothing => {}
         }
     }
 }

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -542,31 +542,6 @@ fn fix_preserves_top_level_tagged_block_scalar_body() {
 }
 
 #[test]
-fn fix_rejects_block_marker_without_space_between_colon_and_tag() {
-    let dir = tempdir().unwrap();
-    let file = dir.path().join("input.yaml");
-    // `:!!str |` is not a valid block-scalar header (`:` needs whitespace before
-    // the tag). The line is fed to `BlockScalarTracker::observe_indicator` while
-    // walking the file; the helper must reject it so the comment scanner can
-    // still see this line as ordinary content rather than a scalar header.
-    fs::write(&file, "key: a\n:!!str |\nkey2: b  #c\n").unwrap();
-    fs::write(
-        dir.path().join(".ryl.toml"),
-        "[rules]\ndocument-start = 'disable'\ncomments = 'enable'\n",
-    )
-    .unwrap();
-
-    let exe = env!("CARGO_BIN_EXE_ryl");
-    let _ = run(Command::new(exe).arg("--fix").arg(&file));
-
-    let fixed = fs::read_to_string(&file).unwrap();
-    assert!(
-        fixed.contains("# c"),
-        "comments rule must still fire after a `:!!str |` line: {fixed:?}"
-    );
-}
-
-#[test]
 fn fix_preserves_block_scalar_body_with_tag_and_anchor_headers() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("input.yaml");

--- a/tests/rule_comments.rs
+++ b/tests/rule_comments.rs
@@ -140,14 +140,14 @@ fn ignores_hash_inside_single_quotes() {
 }
 
 #[test]
-fn handles_escaped_hash_inside_double_quotes() {
+fn handles_hash_inside_double_quotes() {
     let resolved = build_config("rules:\n  comments: {}\n");
-    let hits = comments::check("string: \"path\\#not comment\" # comment\n", &resolved);
+    let hits = comments::check("string: \"path#not comment\" # comment\n", &resolved);
     assert_eq!(
         hits,
         vec![Violation {
             line: 1,
-            column: 29,
+            column: 28,
             message: "too few spaces before comment: expected 2".to_string(),
         }]
     );

--- a/tests/rule_comments.rs
+++ b/tests/rule_comments.rs
@@ -254,3 +254,31 @@ fn fix_returns_none_for_empty_input() {
     let fixed = comments::fix("", &resolved);
     assert_eq!(fixed, None);
 }
+
+#[test]
+fn checks_comments_after_undeclared_anchor_alias() {
+    let resolved = build_config("rules:\n  comments: {}\n");
+    let hits = comments::check("a: *missing\nb: 1 #bad\n", &resolved);
+    assert_eq!(
+        hits,
+        vec![
+            Violation {
+                line: 2,
+                column: 6,
+                message: "too few spaces before comment: expected 2".to_string(),
+            },
+            Violation {
+                line: 2,
+                column: 7,
+                message: "missing starting space in comment".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn fix_inserts_spaces_for_comment_after_undeclared_anchor_alias() {
+    let resolved = build_config("rules:\n  comments: {}\n");
+    let fixed = comments::fix("a: *missing\nb: 1 #bad\n", &resolved);
+    assert_eq!(fixed, Some("a: *missing\nb: 1  # bad\n".to_string()));
+}

--- a/tests/rule_comments_indentation.rs
+++ b/tests/rule_comments_indentation.rs
@@ -172,3 +172,43 @@ fn fix_preserves_comment_alignment_state_across_crlf_blank_lines() {
         Some("root:\r\n  # first\r\n\r\n  # second\r\n  value: 1\r\n".to_string())
     );
 }
+
+#[test]
+fn recognises_tagged_block_scalar_header() {
+    let input = "key: !!str |\n  body\n  # inside-body\nnext: value\n";
+    let hits = run(input);
+    assert!(
+        hits.is_empty(),
+        "comments inside tagged block scalar should be skipped: {hits:?}"
+    );
+}
+
+#[test]
+fn recognises_anchored_block_scalar_header() {
+    let input = "key: &anchor >\n  body\n  # inside-body\nnext: value\n";
+    let hits = run(input);
+    assert!(
+        hits.is_empty(),
+        "comments inside anchored block scalar should be skipped: {hits:?}"
+    );
+}
+
+#[test]
+fn recognises_top_level_anchor_then_block_scalar_marker() {
+    let input = "&anchor |\n  body\n";
+    let hits = run(input);
+    assert!(
+        hits.is_empty(),
+        "top-level anchored block scalar should parse: {hits:?}"
+    );
+}
+
+#[test]
+fn rejects_block_marker_following_non_indicator_token() {
+    let input = "key: value |\n  more\n";
+    let hits = run(input);
+    assert!(
+        hits.is_empty(),
+        "`|` after a plain scalar is not a block-scalar header: {hits:?}"
+    );
+}

--- a/tests/yamllint_compat_syntax.rs
+++ b/tests/yamllint_compat_syntax.rs
@@ -169,7 +169,7 @@ fn yamllint_exit_behavior_matches_for_syntax_only() {
             yam_bad_err
         };
 
-        if let (Some((rf, rl, rc)), Some((yf, yl, yc))) =
+        if let (Some((rf, _rl, _rc)), Some((yf, _yl, _yc))) =
             (parse_loc(&r_msg, kind), parse_loc(&y_msg, kind))
         {
             assert!(
@@ -180,8 +180,6 @@ fn yamllint_exit_behavior_matches_for_syntax_only() {
                 yf.ends_with("bad.yaml"),
                 "yamllint location should reference bad.yaml ({label}): {yf}"
             );
-            assert_eq!(rl, yl, "line numbers should match ({label})");
-            assert_eq!(rc, yc, "column numbers should match ({label})");
         } else {
             panic!(
                 "could not parse location ({label})\nryl:\n{r_msg}\nyamllint:\n{y_msg}"


### PR DESCRIPTION
## Summary

Phase 1 of #188 — swap the event-stream parser from `saphyr-parser` to `granit-parser` and progressively replace hand-rolled scanners with the new event metadata granit exposes.

- `Cargo.toml`: `saphyr-parser = 0.0.6` → `granit-parser = 0.0.3`. `saphyr = 0.0.6` stays for the DOM (`YamlOwned` etc.); Phase 2 will vendor that subset onto granit and drop the saphyr dep entirely.
- Updated every `Event::MappingStart` / `Event::SequenceStart` pattern site for the new `StructureStyle` first arg, and added `Event::Comment(_, _)` arms where event matches enumerate variants.
- `rules/quoted_strings.rs`: replaced `is_flow_sequence` / `is_flow_mapping` buffer scans with `StructureStyle::Flow` from the events.
- `rules/comments.rs`: rewrote to consume `Event::Comment(text, Placement)` directly. Deleted the hand-rolled `QuoteState` scanner, `find_comment_start`, `is_comment_position`, and the line-based `BlockScalarTracker` dependency.
- `rules/support/line_syntax.rs`: removed `BlockScalarTracker` and `is_at_value_position` (no remaining callers).
- `rules/comments.rs::collect_comments`: drives granit via the iterator API so `Event::Comment` events past recoverable errors (e.g. unknown anchor) are still captured; tracks the last error position and breaks on consecutive same-position errors so unrecoverable parses can't deadlock the loop. Addresses the Codex review finding (P2).

Net `src/` size: **−177 lines / −4.7 KiB**.

## Test plan

- [x] `cargo test` — 1042 passed
- [x] `prek run --all-files` — all hooks pass
- [x] `./scripts/coverage-missing.sh` — no uncovered regions
- [x] `cargo test --test property_safe_fix` — parse-preservation invariant holds across the swap
- [x] Regression tests added: `rule_comments::checks_comments_after_undeclared_anchor_alias` and `rule_comments::fix_inserts_spaces_for_comment_after_undeclared_anchor_alias`
- [x] Coverage tests added in `tests/rule_comments_indentation.rs` for the tag/anchor branches of `block_scalar_marker_index` previously reached only via the deleted comments-rule code path

## Behaviour-change tests

Granit is stricter than saphyr on invalid YAML; the following tests were adjusted in this PR:

- `tests/yamllint_compat_syntax`: relaxed strict line/col parity with yamllint — both still detect the syntax error but report different positions (granit points at the open token, yamllint at EOF). Accepted as granit's location is the more useful one.
- `tests/rule_comments::handles_escaped_hash_inside_double_quotes` → renamed to `handles_hash_inside_double_quotes`; fixture uses valid YAML (granit correctly rejects `\#` as an invalid double-quoted escape).
- Removed `tests/cli_fix::fix_rejects_block_marker_without_space_between_colon_and_tag` — its premise (a flaw in the old line-based `BlockScalarTracker`) is structurally impossible with parser-based comment detection.

## Phase 2

Phase 2 (vendoring saphyr's DOM subset onto granit, dropping the saphyr dep) is tracked separately. See the [Phase 2 handoff comment](https://github.com/owenlamont/ryl/issues/188#issuecomment-4544029924) on the issue for context and gotchas surfaced during Phase 1.

Closes part 1 of #188.