### PR TITLE
Phase 2: vendor saphyr DOM and drop saphyr dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,8 +1566,8 @@ dependencies = [
  "encoding_rs",
  "globset",
  "granit-parser",
+ "hashlink",
  "ignore",
- "indexmap",
  "jsonschema",
  "ordered-float",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,15 +584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -1567,11 +1558,12 @@ dependencies = [
  "globset",
  "granit-parser",
  "ignore",
+ "indexmap",
  "jsonschema",
+ "ordered-float",
  "proptest",
  "rayon",
  "regex",
- "saphyr",
  "schemars",
  "semver",
  "serde",
@@ -1588,29 +1580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "saphyr"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3767dfe8889ebb55a21409df2b6f36e66abfbe1eb92d64ff76ae799d3f91016"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
- "ordered-float",
- "saphyr-parser",
-]
-
-[[package]]
-name = "saphyr-parser"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
-dependencies = [
- "arraydeque",
- "hashlink",
 ]
 
 [[package]]
@@ -1959,6 +1928,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ ignore = "0.4.25"
 rayon = "1.11.0"
 schemars = { version = "1.2.1", features = ["derive"] }
 granit-parser = "0.0.3"
-indexmap = "2"
+hashlink = "0.11.0"
 ordered-float = "5"
 dirs-next = "2.0.0"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"
@@ -36,16 +36,15 @@ ignore = "0.4.25"
 rayon = "1.11.0"
 schemars = { version = "1.2.1", features = ["derive"] }
 granit-parser = "0.0.3"
-saphyr = "0.0.6"
+indexmap = "2"
+ordered-float = "5"
 dirs-next = "2.0.0"
 regex = "1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 unicode-normalization = "0.1"
 encoding_rs = "0.8"
-# Keep preserve_order off to avoid pulling in indexmap/hashbrown 0.16 until
-# saphyr updates hashlink and the dependency graph converges again.
-toml = { version = "1.1.2", default-features = false, features = ["display", "parse", "serde"] }
+toml = "1.1.2"
 
 [dev-dependencies]
 jsonschema = "0.46.2"

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Full documentation lives at <https://ryl-docs.pages.dev/>.
 ## Compatibility note
 
 - `ryl` aims to match `yamllint` behaviour and includes many parity tests.
-- `ryl` uses the `saphyr` parser stack, while `yamllint` uses the `PyYAML`
-  parser stack.
-- `saphyr` and `PyYAML` do not always agree on which files are valid YAML.
+- `ryl` uses the `granit-parser` parser stack, while `yamllint` uses the
+  `PyYAML` parser stack.
+- `granit-parser` and `PyYAML` do not always agree on which files are valid
+  YAML.
 - **`ryl` targets YAML 1.2 strictly.** `yamllint` defaults to YAML 1.1
   semantics, so bareword booleans like `yes` / `no` / `on` / `off` (and
   case variants) are plain strings in `ryl` and booleans in `yamllint`.
@@ -104,10 +105,13 @@ linting and developer automation, especially:
   template to follow for Rust tooling and showing me almost the only dev
   tool I was still using after this that wasn't written in Rust was
   yamllint (which inspired me to tackle this project).
-- [saphyr](https://github.com/saphyr-rs/saphyr) - ryl is built on saphyr
-  and saphyr's developers were very patient in showing some of the
-  nuance and complexity of parsing YAML which I was embarrassingly
-  ignorant of when starting ryl.
+- [saphyr](https://github.com/saphyr-rs/saphyr) - ryl's vendored YAML DOM
+  is derived from saphyr, and saphyr's developers were very patient in
+  showing some of the nuance and complexity of parsing YAML which I was
+  embarrassingly ignorant of when starting ryl.
+- [granit-parser](https://github.com/bourumir-wyngs/granit-parser) - a
+  `saphyr-parser` fork with comment and style metadata that ryl uses for
+  event-stream parsing.
 - [esbuild](https://github.com/evanw/esbuild) and
   [biome](https://github.com/biomejs/biome) - for providing the "binary
   wrapper" blueprint for distributing high-performance native tools via

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,9 +64,11 @@ ryl .
 
 ## YAML version compatibility
 
-ryl targets **YAML 1.2** strictly because it is built on the
-[saphyr](https://github.com/saphyr-rs/saphyr) parser. yamllint defaults
-to YAML 1.1 semantics via PyYAML, so a handful of edge cases &mdash;
+ryl targets **YAML 1.2** strictly: it parses with
+[granit-parser](https://github.com/bourumir-wyngs/granit-parser) (a
+`saphyr-parser` fork) and resolves scalars per the YAML 1.2 core schema.
+yamllint defaults to YAML 1.1 semantics via PyYAML, so a handful of edge
+cases &mdash;
 notably bareword booleans like `yes` / `no` / `on` / `off` and
 leading-zero integers like `0755` &mdash; behave differently. The same
 1.2 semantics apply to `.yamllint` configuration files.

--- a/docs/rules/quoted-strings.md
+++ b/docs/rules/quoted-strings.md
@@ -93,9 +93,11 @@ unfixable = ["quoted-strings"]
 
 ryl applies YAML 1.2 implicit-type resolution when deciding whether a
 quoted scalar is redundantly quoted. Under YAML 1.2 the barewords `yes`,
-`no`, `on`, `off`, `True`, `False`, and their case variants parse as
-plain strings (only lowercase `true` / `false` are booleans). yamllint
-uses YAML 1.1 semantics, where the longer list is boolean.
+`no`, `on`, `off` and their case variants (`Yes`, `On`, ...) parse as
+plain strings, whereas YAML 1.1 treats them as booleans. (`true`, `True`,
+`TRUE`, `false`, `False`, and `FALSE` are booleans under both versions, so
+they are unaffected.) yamllint uses YAML 1.1 semantics, where the longer
+list is boolean.
 
 The practical consequence is that `"yes"` (with `required:
 "only-when-needed"`, `quote-type: "double"`) is flagged by ryl as

--- a/docs/yaml-version.md
+++ b/docs/yaml-version.md
@@ -2,10 +2,10 @@
 
 ## ryl targets YAML 1.2
 
-ryl is built on the [saphyr][saphyr] parser, which implements YAML 1.2
-strictly. yamllint, by comparison, is built on [PyYAML][pyyaml], which
-defaults to YAML 1.1 semantics for boolean and other implicit type
-resolution.
+ryl parses YAML with [granit-parser][granit] (a `saphyr-parser` fork) and
+resolves scalars per the YAML 1.2 core schema. yamllint, by comparison, is
+built on [PyYAML][pyyaml], which defaults to YAML 1.1 semantics for boolean
+and other implicit type resolution.
 
 Most YAML files do not exercise the parts of the language where the two
 versions disagree, so in practice the difference rarely shows up. The two
@@ -16,18 +16,17 @@ places it matters in ryl are:
 - Parsing of `.yamllint` / `.yamllint.yaml` / `.yamllint.yml`
   configuration files inherited from yamllint.
 
-  [saphyr]: https://github.com/saphyr-rs/saphyr
+  [granit]: https://github.com/bourumir-wyngs/granit-parser
   [pyyaml]: https://pyyaml.org/
 
 ## What is different in YAML 1.2
 
 | Literal | YAML 1.1 | YAML 1.2 |
 | :--- | :--- | :--- |
-| `yes`, `no`, `on`, `off` (and case variants) | Booleans | Plain strings |
-| `Yes`, `No`, `On`, `Off`, `True`, `False`, `TRUE`, ... | Booleans (case-insensitive) | Plain strings |
-| `true`, `false` (lowercase only) | Booleans | Booleans |
+| `yes`, `no`, `on`, `off` and case variants (`Yes`, `No`, `ON`, ...) | Booleans | Plain strings |
+| `true`, `True`, `TRUE`, `false`, `False`, `FALSE` | Booleans | Booleans |
+| `null`, `Null`, `NULL`, `~` | Null | Null |
 | `0755` (leading zero integer) | Octal | Decimal |
-| `.nan`, `.inf` | Floats | Floats |
 
 ryl applies YAML 1.2 semantics to both linted files and configuration
 files.

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.10.0"
+  "version": "0.10.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.10.0"
+version = "0.10.1"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,9 +4,9 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::yaml_dom::{ScalarOwned, YamlOwned};
 use globset::{Glob, GlobMatcher, escape as glob_escape};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use saphyr::{LoadableYamlNode, ScalarOwned, YamlOwned};
 
 use crate::config_schema::{
     FixRuleName as TomlFixRuleName, FixableRuleSelector as TomlFixableRuleSelector,

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -3,7 +3,7 @@ mod validation;
 
 use std::collections::BTreeMap;
 
-use saphyr::{MappingOwned, YamlOwned};
+use crate::yaml_dom::{MappingOwned, YamlOwned};
 use schemars::{JsonSchema, Schema, schema_for};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -1,4 +1,4 @@
-use saphyr::{LoadableYamlNode, MappingOwned, ScalarOwned, YamlOwned};
+use crate::yaml_dom::{MappingOwned, ScalarOwned, YamlOwned};
 use serde::Serialize;
 
 use super::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod fix;
 pub mod lint;
 pub mod migrate;
 pub mod rules;
+pub mod yaml_dom;
 
 pub use discover::{gather_yaml_from_dir, is_yaml_path};
 pub use lint::{LintProblem, Severity, lint_file, lint_str};

--- a/src/rules/indentation.rs
+++ b/src/rules/indentation.rs
@@ -69,7 +69,7 @@ impl Config {
 
         let check_multi_line_strings = cfg
             .rule_option(ID, "check-multi-line-strings")
-            .and_then(saphyr::YamlOwned::as_bool)
+            .and_then(crate::yaml_dom::YamlOwned::as_bool)
             .unwrap_or(false);
 
         Self {

--- a/src/rules/key_ordering.rs
+++ b/src/rules/key_ordering.rs
@@ -23,7 +23,7 @@ impl Config {
     pub fn resolve(cfg: &YamlLintConfig) -> Self {
         let mut ignored: Vec<Regex> = Vec::new();
         if let Some(node) = cfg.rule_option(ID, "ignored-keys")
-            && let saphyr::YamlOwned::Sequence(seq) = node
+            && let crate::yaml_dom::YamlOwned::Sequence(seq) = node
         {
             for entry in seq {
                 let pattern = entry

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -2,10 +2,10 @@ use granit_parser::{
     Event, Parser, ScalarStyle, Span, SpannedEventReceiver, StructureStyle, Tag,
 };
 use regex::Regex;
-use saphyr::Yaml;
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::mapping_key_walker::Walker;
+use crate::yaml_dom::Scalar;
 
 pub const ID: &str = "quoted-strings";
 
@@ -141,17 +141,17 @@ impl Config {
 
         let allow_quoted_quotes = cfg
             .rule_option(ID, "allow-quoted-quotes")
-            .and_then(saphyr::YamlOwned::as_bool)
+            .and_then(crate::yaml_dom::YamlOwned::as_bool)
             .unwrap_or(false);
 
         let allow_double_quotes_for_escaping = cfg
             .rule_option(ID, "allow-double-quotes-for-escaping")
-            .and_then(saphyr::YamlOwned::as_bool)
+            .and_then(crate::yaml_dom::YamlOwned::as_bool)
             .unwrap_or(false);
 
         let check_keys = cfg
             .rule_option(ID, "check-keys")
-            .and_then(saphyr::YamlOwned::as_bool)
+            .and_then(crate::yaml_dom::YamlOwned::as_bool)
             .unwrap_or(false);
 
         Self {
@@ -470,10 +470,7 @@ fn is_core_tag(tag: &Tag) -> bool {
 }
 
 fn value_resolves_to_string(value: &str) -> bool {
-    matches!(
-        Yaml::value_from_str(value),
-        Yaml::Value(saphyr::Scalar::String(_))
-    )
+    matches!(Scalar::parse_from_cow(value.into()), Scalar::String(_))
 }
 
 fn should_skip_scalar(

--- a/src/yaml_dom/loader.rs
+++ b/src/yaml_dom/loader.rs
@@ -1,0 +1,152 @@
+// Vendored from saphyr v0.0.6 (`saphyr/src/loader.rs`).
+// Specialized to a single concrete node type (`YamlOwned`) and retargeted at
+// granit-parser's event stream. The original is dual-licensed MIT OR
+// Apache-2.0; ryl ships under MIT.
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+use granit_parser::{Event, Parser, ScanError, Span, SpannedEventReceiver, Tag};
+
+use crate::yaml_dom::scalar::Scalar;
+use crate::yaml_dom::yaml_owned::{MappingOwned, YamlOwned};
+
+/// # Errors
+/// Propagates [`ScanError`] when the granit parser rejects the input.
+pub fn load_owned_documents(source: &str) -> Result<Vec<YamlOwned>, ScanError> {
+    let mut parser = Parser::new_from_str(source);
+    let mut loader = Loader::default();
+    parser.load(&mut loader, true)?;
+    Ok(loader.docs)
+}
+
+enum Container {
+    Sequence(Vec<YamlOwned>),
+    Mapping(MappingOwned, YamlOwned),
+}
+
+struct Frame {
+    container: Container,
+    anchor_id: usize,
+    tag: Option<Tag>,
+}
+
+#[derive(Default)]
+struct Loader {
+    docs: Vec<YamlOwned>,
+    stack: Vec<Frame>,
+    root: Option<YamlOwned>,
+    anchor_map: BTreeMap<usize, YamlOwned>,
+}
+
+impl<'input> SpannedEventReceiver<'input> for Loader {
+    fn on_event(&mut self, ev: Event<'input>, _span: Span) {
+        match ev {
+            Event::DocumentStart(_)
+            | Event::Nothing
+            | Event::StreamStart
+            | Event::StreamEnd
+            | Event::Comment(_, _) => {}
+            Event::DocumentEnd => {
+                let node = self.root.take().unwrap_or(YamlOwned::BadValue);
+                self.docs.push(node);
+            }
+            Event::SequenceStart(_, aid, tag) => {
+                self.stack.push(Frame {
+                    container: Container::Sequence(Vec::new()),
+                    anchor_id: aid,
+                    tag: tag.map(Cow::into_owned),
+                });
+            }
+            Event::MappingStart(_, aid, tag) => {
+                self.stack.push(Frame {
+                    container: Container::Mapping(
+                        MappingOwned::new(),
+                        YamlOwned::BadValue,
+                    ),
+                    anchor_id: aid,
+                    tag: tag.map(Cow::into_owned),
+                });
+            }
+            Event::MappingEnd | Event::SequenceEnd => {
+                let frame = self
+                    .stack
+                    .pop()
+                    .expect("structure end without matching start");
+                let node = self.close_frame(frame);
+                self.attach(node);
+            }
+            Event::Scalar(value, style, aid, tag) => {
+                let node = match tag.as_ref() {
+                    Some(tag_ref) if !tag_ref.is_yaml_core_schema() => {
+                        let inner =
+                            Scalar::parse_from_cow_and_metadata(value, style, None)
+                                .map_or(YamlOwned::BadValue, |scalar| {
+                                    YamlOwned::Value(scalar.into_owned())
+                                });
+                        YamlOwned::Tagged(tag_ref.as_ref().clone(), Box::new(inner))
+                    }
+                    _ => {
+                        Scalar::parse_from_cow_and_metadata(value, style, tag.as_ref())
+                            .map_or(YamlOwned::BadValue, |scalar| {
+                                YamlOwned::Value(scalar.into_owned())
+                            })
+                    }
+                };
+                if aid > 0 {
+                    self.anchor_map.insert(aid, node.clone());
+                }
+                self.attach(node);
+            }
+            Event::Alias(id) => {
+                let node = self
+                    .anchor_map
+                    .get(&id)
+                    .cloned()
+                    .expect("granit emits Alias only after recording the anchor");
+                self.attach(node);
+            }
+        }
+    }
+}
+
+impl Loader {
+    fn close_frame(&mut self, frame: Frame) -> YamlOwned {
+        let Frame {
+            container,
+            anchor_id,
+            tag,
+        } = frame;
+        let node = match container {
+            Container::Sequence(seq) => YamlOwned::Sequence(seq),
+            Container::Mapping(map, _) => YamlOwned::Mapping(map),
+        };
+        let node = match tag {
+            Some(tag) if !tag.is_yaml_core_schema() => {
+                YamlOwned::Tagged(tag, Box::new(node))
+            }
+            _ => node,
+        };
+        if anchor_id > 0 {
+            self.anchor_map.insert(anchor_id, node.clone());
+        }
+        node
+    }
+
+    fn attach(&mut self, node: YamlOwned) {
+        match self.stack.last_mut() {
+            Some(frame) => match &mut frame.container {
+                Container::Sequence(seq) => seq.push(node),
+                Container::Mapping(map, pending_key) => {
+                    if matches!(pending_key, YamlOwned::BadValue) {
+                        *pending_key = node;
+                    } else {
+                        let key = std::mem::replace(pending_key, YamlOwned::BadValue);
+                        map.insert(key, node);
+                    }
+                }
+            },
+            None => self.root = Some(node),
+        }
+    }
+}

--- a/src/yaml_dom/loader.rs
+++ b/src/yaml_dom/loader.rs
@@ -99,11 +99,16 @@ impl<'input> SpannedEventReceiver<'input> for Loader {
                 self.attach(node);
             }
             Event::Alias(id) => {
+                // granit normally rejects unresolved aliases during the scan,
+                // but a linter must never panic on malformed input, so fall
+                // back to `BadValue` rather than relying on that ordering.
+                // `unwrap_or` constructs the unit variant eagerly, keeping the
+                // branch covered without a lazy closure.
                 let node = self
                     .anchor_map
                     .get(&id)
                     .cloned()
-                    .expect("granit emits Alias only after recording the anchor");
+                    .unwrap_or(YamlOwned::BadValue);
                 self.attach(node);
             }
         }

--- a/src/yaml_dom/mod.rs
+++ b/src/yaml_dom/mod.rs
@@ -1,0 +1,10 @@
+//! YAML DOM vendored from saphyr 0.0.6, retargeted at granit-parser and
+//! trimmed to the subset ryl actually uses. See module headers for upstream
+//! provenance.
+
+mod loader;
+mod scalar;
+mod yaml_owned;
+
+pub use scalar::{Scalar, ScalarOwned};
+pub use yaml_owned::{MappingOwned, SequenceOwned, YamlOwned};

--- a/src/yaml_dom/scalar.rs
+++ b/src/yaml_dom/scalar.rs
@@ -1,0 +1,130 @@
+// Vendored from saphyr v0.0.6 (`saphyr/src/scalar.rs`).
+// Trimmed to the surface ryl needs: `ScalarOwned` with parse helpers, plus the
+// borrowed-lifetime `Scalar` used when parsing scalars from the event stream.
+// The original is dual-licensed MIT OR Apache-2.0; ryl ships under MIT.
+
+use std::borrow::Cow;
+
+use granit_parser::{ScalarStyle, Tag};
+use ordered_float::OrderedFloat;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub enum Scalar<'input> {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    FloatingPoint(OrderedFloat<f64>),
+    String(Cow<'input, str>),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub enum ScalarOwned {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    FloatingPoint(OrderedFloat<f64>),
+    String(String),
+}
+
+impl<'input> Scalar<'input> {
+    #[must_use]
+    pub fn into_owned(self) -> ScalarOwned {
+        match self {
+            Self::Null => ScalarOwned::Null,
+            Self::Boolean(v) => ScalarOwned::Boolean(v),
+            Self::Integer(v) => ScalarOwned::Integer(v),
+            Self::FloatingPoint(v) => ScalarOwned::FloatingPoint(v),
+            Self::String(v) => ScalarOwned::String(v.into_owned()),
+        }
+    }
+
+    pub fn parse_from_cow_and_metadata(
+        v: Cow<'input, str>,
+        style: ScalarStyle,
+        tag: Option<&Cow<'input, Tag>>,
+    ) -> Option<Self> {
+        if style != ScalarStyle::Plain {
+            return Some(Self::String(v));
+        }
+        match tag.map(Cow::as_ref) {
+            Some(tag) if tag.is_yaml_core_schema() => match tag.suffix.as_str() {
+                "bool" => v.parse::<bool>().ok().map(Self::Boolean),
+                "int" => v.parse::<i64>().ok().map(Self::Integer),
+                "float" => parse_core_schema_fp(&v)
+                    .map(OrderedFloat)
+                    .map(Self::FloatingPoint),
+                "null" => match v.as_ref() {
+                    "~" | "null" => Some(Self::Null),
+                    _ => None,
+                },
+                "str" => Some(Self::String(v)),
+                _ => None,
+            },
+            _ => Some(Self::parse_from_cow(v)),
+        }
+    }
+
+    #[must_use]
+    pub fn parse_from_cow(v: Cow<'input, str>) -> Self {
+        let s = &*v;
+        let bytes = s.as_bytes();
+
+        if bytes.len() >= 2 {
+            match (bytes[0], bytes[1]) {
+                (b'0', b'x') => {
+                    if let Ok(i) = i64::from_str_radix(&s[2..], 16) {
+                        return Self::Integer(i);
+                    }
+                }
+                (b'0', b'o') => {
+                    if let Ok(i) = i64::from_str_radix(&s[2..], 8) {
+                        return Self::Integer(i);
+                    }
+                }
+                (b'+', _) => {
+                    if let Ok(i) = s[1..].parse::<i64>() {
+                        return Self::Integer(i);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match bytes.len() {
+            1 if bytes[0] == b'~' => return Self::Null,
+            4 => {
+                let folded = bytes[0] & 0xDF;
+                if folded == b'N' && matches!(s, "null" | "Null" | "NULL") {
+                    return Self::Null;
+                } else if folded == b'T' && matches!(s, "true" | "True" | "TRUE") {
+                    return Self::Boolean(true);
+                }
+            }
+            5 if matches!(s, "false" | "False" | "FALSE") => {
+                return Self::Boolean(false);
+            }
+            _ => {}
+        }
+
+        if let Ok(integer) = s.parse::<i64>() {
+            return Self::Integer(integer);
+        }
+
+        if let Some(float) = parse_core_schema_fp(s) {
+            return Self::FloatingPoint(float.into());
+        }
+
+        Self::String(v)
+    }
+}
+
+#[must_use]
+pub fn parse_core_schema_fp(v: &str) -> Option<f64> {
+    match v {
+        ".inf" | ".Inf" | ".INF" | "+.inf" | "+.Inf" | "+.INF" => Some(f64::INFINITY),
+        "-.inf" | "-.Inf" | "-.INF" => Some(f64::NEG_INFINITY),
+        ".nan" | ".NaN" | ".NAN" => Some(f64::NAN),
+        _ if v.as_bytes().iter().any(u8::is_ascii_digit) => v.parse::<f64>().ok(),
+        _ => None,
+    }
+}

--- a/src/yaml_dom/scalar.rs
+++ b/src/yaml_dom/scalar.rs
@@ -1,7 +1,12 @@
-// Vendored from saphyr v0.0.6 (`saphyr/src/scalar.rs`).
-// Trimmed to the surface ryl needs: `ScalarOwned` with parse helpers, plus the
-// borrowed-lifetime `Scalar` used when parsing scalars from the event stream.
-// The original is dual-licensed MIT OR Apache-2.0; ryl ships under MIT.
+// Derived from saphyr (`saphyr/src/scalar.rs`), dual-licensed MIT OR
+// Apache-2.0; ryl ships under MIT. Trimmed to the surface ryl needs:
+// `ScalarOwned` with parse helpers plus the borrowed-lifetime `Scalar` used
+// when parsing scalars from the event stream.
+//
+// `parse_from_cow` resolves null/bool per the YAML 1.2 core schema (so
+// `True`/`Null` are bool/null, matching saphyr's post-0.0.6 resolver rather
+// than the narrower 0.0.6 release). `Yes`/`No`/`On`/`Off` are intentionally
+// left as strings: those are YAML 1.1 booleans, and ryl targets YAML 1.2.
 
 use std::borrow::Cow;
 
@@ -66,55 +71,33 @@ impl<'input> Scalar<'input> {
 
     #[must_use]
     pub fn parse_from_cow(v: Cow<'input, str>) -> Self {
-        let s = &*v;
-        let bytes = s.as_bytes();
-
-        if bytes.len() >= 2 {
-            match (bytes[0], bytes[1]) {
-                (b'0', b'x') => {
-                    if let Ok(i) = i64::from_str_radix(&s[2..], 16) {
-                        return Self::Integer(i);
-                    }
+        if let Some(number) = v.strip_prefix("0x") {
+            if let Ok(i) = i64::from_str_radix(number, 16) {
+                return Self::Integer(i);
+            }
+        } else if let Some(number) = v.strip_prefix("0o") {
+            if let Ok(i) = i64::from_str_radix(number, 8) {
+                return Self::Integer(i);
+            }
+        } else if let Some(number) = v.strip_prefix('+')
+            && let Ok(i) = number.parse::<i64>()
+        {
+            return Self::Integer(i);
+        }
+        match &*v {
+            "~" | "null" | "Null" | "NULL" => Self::Null,
+            "true" | "True" | "TRUE" => Self::Boolean(true),
+            "false" | "False" | "FALSE" => Self::Boolean(false),
+            _ => {
+                if let Ok(integer) = v.parse::<i64>() {
+                    Self::Integer(integer)
+                } else if let Some(float) = parse_core_schema_fp(&v) {
+                    Self::FloatingPoint(float.into())
+                } else {
+                    Self::String(v)
                 }
-                (b'0', b'o') => {
-                    if let Ok(i) = i64::from_str_radix(&s[2..], 8) {
-                        return Self::Integer(i);
-                    }
-                }
-                (b'+', _) => {
-                    if let Ok(i) = s[1..].parse::<i64>() {
-                        return Self::Integer(i);
-                    }
-                }
-                _ => {}
             }
         }
-
-        match bytes.len() {
-            1 if bytes[0] == b'~' => return Self::Null,
-            4 => {
-                let folded = bytes[0] & 0xDF;
-                if folded == b'N' && matches!(s, "null" | "Null" | "NULL") {
-                    return Self::Null;
-                } else if folded == b'T' && matches!(s, "true" | "True" | "TRUE") {
-                    return Self::Boolean(true);
-                }
-            }
-            5 if matches!(s, "false" | "False" | "FALSE") => {
-                return Self::Boolean(false);
-            }
-            _ => {}
-        }
-
-        if let Ok(integer) = s.parse::<i64>() {
-            return Self::Integer(integer);
-        }
-
-        if let Some(float) = parse_core_schema_fp(s) {
-            return Self::FloatingPoint(float.into());
-        }
-
-        Self::String(v)
     }
 }
 

--- a/src/yaml_dom/yaml_owned.rs
+++ b/src/yaml_dom/yaml_owned.rs
@@ -3,18 +3,20 @@
 // actually uses and re-targeted at indexmap::IndexMap. The original is
 // dual-licensed MIT OR Apache-2.0; ryl ships under MIT.
 
-use std::hash::{Hash, Hasher};
-
 use granit_parser::Tag;
-use indexmap::IndexMap;
+use hashlink::LinkedHashMap;
 
 use crate::yaml_dom::loader::load_owned_documents;
 use crate::yaml_dom::scalar::ScalarOwned;
 
 pub type SequenceOwned = Vec<YamlOwned>;
-pub type MappingOwned = IndexMap<YamlOwned, YamlOwned>;
+// `LinkedHashMap` keeps saphyr's insertion-order-sensitive `PartialEq`/`Hash`
+// so the derived `Hash` below stays consistent with equality when a mapping is
+// used as a complex key, and the parse-preservation property test keeps its
+// original structural semantics.
+pub type MappingOwned = LinkedHashMap<YamlOwned, YamlOwned>;
 
-#[derive(Clone, PartialEq, Debug, Eq)]
+#[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum YamlOwned {
     Value(ScalarOwned),
     Sequence(SequenceOwned),
@@ -107,24 +109,4 @@ impl YamlOwned {
 
 fn string_key(key: &str) -> YamlOwned {
     YamlOwned::Value(ScalarOwned::String(key.to_owned()))
-}
-
-impl Hash for YamlOwned {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(self).hash(state);
-        match self {
-            Self::Value(scalar) => scalar.hash(state),
-            Self::Sequence(seq) => seq.hash(state),
-            Self::Mapping(map) => {
-                for entry in map {
-                    entry.hash(state);
-                }
-            }
-            Self::Tagged(tag, node) => {
-                tag.hash(state);
-                node.hash(state);
-            }
-            Self::BadValue => {}
-        }
-    }
 }

--- a/src/yaml_dom/yaml_owned.rs
+++ b/src/yaml_dom/yaml_owned.rs
@@ -1,0 +1,130 @@
+// Vendored from saphyr v0.0.6 (`saphyr/src/yaml_owned.rs` + the `YamlOwned`
+// halves of `saphyr/src/macros.rs`). Trimmed to the inspector methods ryl
+// actually uses and re-targeted at indexmap::IndexMap. The original is
+// dual-licensed MIT OR Apache-2.0; ryl ships under MIT.
+
+use std::hash::{Hash, Hasher};
+
+use granit_parser::Tag;
+use indexmap::IndexMap;
+
+use crate::yaml_dom::loader::load_owned_documents;
+use crate::yaml_dom::scalar::ScalarOwned;
+
+pub type SequenceOwned = Vec<YamlOwned>;
+pub type MappingOwned = IndexMap<YamlOwned, YamlOwned>;
+
+#[derive(Clone, PartialEq, Debug, Eq)]
+pub enum YamlOwned {
+    Value(ScalarOwned),
+    Sequence(SequenceOwned),
+    Mapping(MappingOwned),
+    Tagged(Tag, Box<YamlOwned>),
+    BadValue,
+}
+
+impl YamlOwned {
+    /// Parse `source` into a sequence of documents.
+    ///
+    /// # Errors
+    /// Returns [`granit_parser::ScanError`] when the parser rejects the input.
+    pub fn load_from_str(source: &str) -> Result<Vec<Self>, granit_parser::ScanError> {
+        load_owned_documents(source)
+    }
+
+    #[must_use]
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Self::Value(ScalarOwned::Boolean(b)) => Some(*b),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_integer(&self) -> Option<i64> {
+        match self {
+            Self::Value(ScalarOwned::Integer(i)) => Some(*i),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_floating_point(&self) -> Option<f64> {
+        match self {
+            Self::Value(ScalarOwned::FloatingPoint(f)) => Some(f.into_inner()),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::Value(ScalarOwned::String(s)) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Value(ScalarOwned::Null))
+    }
+
+    #[must_use]
+    pub fn as_mapping(&self) -> Option<&MappingOwned> {
+        match self {
+            Self::Mapping(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_mapping_mut(&mut self) -> Option<&mut MappingOwned> {
+        match self {
+            Self::Mapping(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_sequence(&self) -> Option<&SequenceOwned> {
+        match self {
+            Self::Sequence(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_mapping_get(&self, key: &str) -> Option<&YamlOwned> {
+        self.as_mapping().and_then(|map| map.get(&string_key(key)))
+    }
+
+    #[must_use]
+    pub fn as_mapping_get_mut(&mut self, key: &str) -> Option<&mut YamlOwned> {
+        self.as_mapping_mut()
+            .and_then(|map| map.get_mut(&string_key(key)))
+    }
+}
+
+fn string_key(key: &str) -> YamlOwned {
+    YamlOwned::Value(ScalarOwned::String(key.to_owned()))
+}
+
+impl Hash for YamlOwned {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Value(scalar) => scalar.hash(state),
+            Self::Sequence(seq) => seq.hash(state),
+            Self::Mapping(map) => {
+                for entry in map {
+                    entry.hash(state);
+                }
+            }
+            Self::Tagged(tag, node) => {
+                tag.hash(state);
+                node.hash(state);
+            }
+            Self::BadValue => {}
+        }
+    }
+}

--- a/tests/property_safe_fix/config.rs
+++ b/tests/property_safe_fix/config.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 
 use ryl::config::{Overrides, YamlLintConfig, discover_config};
 use ryl::lint::{LintProblem, lint_str};
-use saphyr::{LoadableYamlNode, YamlOwned};
+use ryl::yaml_dom::YamlOwned;
 use tempfile::TempDir;
 
 const COMMON_SAFE_FIX_RULES_YAML: &str = "rules:

--- a/tests/yaml_dom.rs
+++ b/tests/yaml_dom.rs
@@ -1,0 +1,243 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use ryl::yaml_dom::{ScalarOwned, YamlOwned};
+
+fn parse_single(source: &str) -> YamlOwned {
+    YamlOwned::load_from_str(source)
+        .expect("input should parse")
+        .into_iter()
+        .next()
+        .expect("at least one document")
+}
+
+#[test]
+fn parses_hex_integer() {
+    let doc = parse_single("v: 0xFF\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_integer),
+        Some(255)
+    );
+}
+
+#[test]
+fn parses_octal_integer() {
+    let doc = parse_single("v: 0o17\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_integer),
+        Some(15)
+    );
+}
+
+#[test]
+fn parses_explicit_positive_integer() {
+    let doc = parse_single("v: +42\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_integer),
+        Some(42)
+    );
+}
+
+#[test]
+fn parses_infinity_floats() {
+    let pos = parse_single("v: .inf\n");
+    let neg = parse_single("v: -.inf\n");
+    let nan = parse_single("v: .nan\n");
+    assert!(
+        pos.as_mapping_get("v")
+            .and_then(YamlOwned::as_floating_point)
+            .is_some_and(f64::is_infinite)
+    );
+    assert!(
+        neg.as_mapping_get("v")
+            .and_then(YamlOwned::as_floating_point)
+            .is_some_and(|f| f.is_infinite() && f.is_sign_negative())
+    );
+    assert!(
+        nan.as_mapping_get("v")
+            .and_then(YamlOwned::as_floating_point)
+            .is_some_and(f64::is_nan)
+    );
+}
+
+#[test]
+fn resolves_core_schema_int_tag() {
+    let doc = parse_single("v: !!int 42\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_integer),
+        Some(42)
+    );
+}
+
+#[test]
+fn resolves_core_schema_bool_tag() {
+    let doc = parse_single("v: !!bool true\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_bool),
+        Some(true)
+    );
+}
+
+#[test]
+fn resolves_core_schema_str_tag_forces_string() {
+    let doc = parse_single("v: !!str 42\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_str),
+        Some("42")
+    );
+}
+
+#[test]
+fn resolves_core_schema_null_tag() {
+    let doc = parse_single("v: !!null ~\n");
+    assert!(doc.as_mapping_get("v").is_some_and(YamlOwned::is_null));
+}
+
+#[test]
+fn resolves_core_schema_float_tag() {
+    let doc = parse_single("v: !!float 1.5\n");
+    assert_eq!(
+        doc.as_mapping_get("v")
+            .and_then(YamlOwned::as_floating_point),
+        Some(1.5)
+    );
+}
+
+#[test]
+fn unknown_core_schema_tag_is_bad_value() {
+    let doc = parse_single("v: !!unknown foo\n");
+    let v = doc.as_mapping_get("v").unwrap();
+    assert!(matches!(v, YamlOwned::BadValue));
+}
+
+#[test]
+fn non_core_tagged_scalar_wraps_in_tagged() {
+    let doc = parse_single("v: !foo bar\n");
+    assert!(matches!(
+        doc.as_mapping_get("v"),
+        Some(YamlOwned::Tagged(_, _))
+    ));
+}
+
+#[test]
+fn non_core_tagged_sequence_wraps_in_tagged() {
+    let doc = parse_single("v: !foo [1, 2]\n");
+    assert!(matches!(
+        doc.as_mapping_get("v"),
+        Some(YamlOwned::Tagged(_, _))
+    ));
+}
+
+#[test]
+fn non_core_tagged_mapping_wraps_in_tagged() {
+    let doc = parse_single("v: !foo {a: b}\n");
+    assert!(matches!(
+        doc.as_mapping_get("v"),
+        Some(YamlOwned::Tagged(_, _))
+    ));
+}
+
+#[test]
+fn anchored_collection_resolves_alias() {
+    let doc = parse_single("a: &anchor\n  - 1\n  - 2\nb: *anchor\n");
+    let seq = doc
+        .as_mapping_get("b")
+        .and_then(YamlOwned::as_sequence)
+        .expect("alias resolves to sequence");
+    assert_eq!(seq.len(), 2);
+}
+
+#[test]
+fn as_sequence_returns_none_for_non_sequence() {
+    let scalar = YamlOwned::Value(ScalarOwned::String("foo".to_owned()));
+    assert!(scalar.as_sequence().is_none());
+}
+
+#[test]
+fn hash_of_sequences_collides_when_equal_and_differs_otherwise() {
+    fn h(value: &YamlOwned) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    let a = YamlOwned::Sequence(vec![YamlOwned::Value(ScalarOwned::Integer(1))]);
+    let b = YamlOwned::Sequence(vec![YamlOwned::Value(ScalarOwned::Integer(1))]);
+    let c = YamlOwned::Sequence(vec![YamlOwned::Value(ScalarOwned::Integer(2))]);
+
+    assert_eq!(h(&a), h(&b));
+    assert_ne!(h(&a), h(&c));
+}
+
+#[test]
+fn scalar_anchor_is_resolved_via_alias() {
+    let doc = parse_single("a: &x foo\nb: *x\n");
+    assert_eq!(
+        doc.as_mapping_get("b").and_then(YamlOwned::as_str),
+        Some("foo")
+    );
+}
+
+#[test]
+fn invalid_hex_falls_back_to_string() {
+    let doc = parse_single("v: 0xZZ\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_str),
+        Some("0xZZ")
+    );
+}
+
+#[test]
+fn invalid_octal_falls_back_to_string() {
+    let doc = parse_single("v: 0oZZ\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_str),
+        Some("0oZZ")
+    );
+}
+
+#[test]
+fn invalid_signed_int_falls_back_to_string() {
+    let doc = parse_single("v: +abc\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_str),
+        Some("+abc")
+    );
+}
+
+#[test]
+fn core_schema_null_tag_rejects_non_null_value() {
+    let doc = parse_single("v: !!null foo\n");
+    assert!(matches!(doc.as_mapping_get("v"), Some(YamlOwned::BadValue)));
+}
+
+#[test]
+fn as_mapping_mut_returns_none_for_non_mapping() {
+    let mut scalar = YamlOwned::Value(ScalarOwned::Integer(1));
+    assert!(scalar.as_mapping_mut().is_none());
+}
+
+#[test]
+fn mapping_hash_visits_entries() {
+    fn h(value: &YamlOwned) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    let a = parse_single("k: 1\n");
+    let b = parse_single("k: 1\n");
+    let c = parse_single("k: 2\n");
+    assert_eq!(h(&a), h(&b));
+    assert_ne!(h(&a), h(&c));
+}
+
+#[test]
+fn hash_of_bad_value_is_stable() {
+    fn h(value: &YamlOwned) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+    assert_eq!(h(&YamlOwned::BadValue), h(&YamlOwned::BadValue));
+}

--- a/tests/yaml_dom.rs
+++ b/tests/yaml_dom.rs
@@ -1,6 +1,3 @@
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-
 use ryl::yaml_dom::{ScalarOwned, YamlOwned};
 
 fn parse_single(source: &str) -> YamlOwned {
@@ -154,22 +151,6 @@ fn as_sequence_returns_none_for_non_sequence() {
 }
 
 #[test]
-fn hash_of_sequences_collides_when_equal_and_differs_otherwise() {
-    fn h(value: &YamlOwned) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    let a = YamlOwned::Sequence(vec![YamlOwned::Value(ScalarOwned::Integer(1))]);
-    let b = YamlOwned::Sequence(vec![YamlOwned::Value(ScalarOwned::Integer(1))]);
-    let c = YamlOwned::Sequence(vec![YamlOwned::Value(ScalarOwned::Integer(2))]);
-
-    assert_eq!(h(&a), h(&b));
-    assert_ne!(h(&a), h(&c));
-}
-
-#[test]
 fn scalar_anchor_is_resolved_via_alias() {
     let doc = parse_single("a: &x foo\nb: *x\n");
     assert_eq!(
@@ -215,29 +196,4 @@ fn core_schema_null_tag_rejects_non_null_value() {
 fn as_mapping_mut_returns_none_for_non_mapping() {
     let mut scalar = YamlOwned::Value(ScalarOwned::Integer(1));
     assert!(scalar.as_mapping_mut().is_none());
-}
-
-#[test]
-fn mapping_hash_visits_entries() {
-    fn h(value: &YamlOwned) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    let a = parse_single("k: 1\n");
-    let b = parse_single("k: 1\n");
-    let c = parse_single("k: 2\n");
-    assert_eq!(h(&a), h(&b));
-    assert_ne!(h(&a), h(&c));
-}
-
-#[test]
-fn hash_of_bad_value_is_stable() {
-    fn h(value: &YamlOwned) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-    assert_eq!(h(&YamlOwned::BadValue), h(&YamlOwned::BadValue));
 }

--- a/tests/yaml_dom.rs
+++ b/tests/yaml_dom.rs
@@ -36,6 +36,47 @@ fn parses_explicit_positive_integer() {
 }
 
 #[test]
+fn yaml_1_2_core_schema_null_and_bool_spellings_resolve() {
+    for spelling in ["~", "null", "Null", "NULL"] {
+        let doc = parse_single(&format!("v: {spelling}\n"));
+        assert!(
+            doc.as_mapping_get("v").is_some_and(YamlOwned::is_null),
+            "{spelling} should resolve to null"
+        );
+    }
+    for spelling in ["true", "True", "TRUE"] {
+        let doc = parse_single(&format!("v: {spelling}\n"));
+        assert_eq!(
+            doc.as_mapping_get("v").and_then(YamlOwned::as_bool),
+            Some(true),
+            "{spelling} should resolve to true"
+        );
+    }
+    for spelling in ["false", "False", "FALSE"] {
+        let doc = parse_single(&format!("v: {spelling}\n"));
+        assert_eq!(
+            doc.as_mapping_get("v").and_then(YamlOwned::as_bool),
+            Some(false),
+            "{spelling} should resolve to false"
+        );
+    }
+}
+
+#[test]
+fn yaml_1_1_only_booleans_stay_strings() {
+    // ryl targets YAML 1.2; `Yes`/`No`/`On`/`Off` are YAML 1.1 booleans and
+    // must remain strings so they round-trip rather than being retyped.
+    for spelling in ["Yes", "No", "On", "Off", "yes", "no"] {
+        let doc = parse_single(&format!("v: {spelling}\n"));
+        assert_eq!(
+            doc.as_mapping_get("v").and_then(YamlOwned::as_str),
+            Some(spelling),
+            "{spelling} should stay a string under YAML 1.2"
+        );
+    }
+}
+
+#[test]
 fn parses_infinity_floats() {
     let pos = parse_single("v: .inf\n");
     let neg = parse_single("v: -.inf\n");

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Phase 2 of #188 — vendor the subset of saphyr's DOM that ryl uses into `src/yaml_dom/` and drop the `saphyr` dependency. Closes #188.

End state: single parser stack (granit-parser), pure-safe Rust, no external saphyr dep.

### What's vendored

`src/yaml_dom/` ports the minimum surface ryl actually uses from saphyr 0.0.6:

- `yaml_owned.rs` — `YamlOwned` (5 variants: `Value`, `Sequence`, `Mapping`, `Tagged`, `BadValue`) with the inspector methods ryl calls (`as_str`, `as_bool`, `as_integer`, `as_floating_point`, `as_mapping`, `as_mapping_get`, etc.), plus a hand-written `Hash` impl that preserves saphyr's insertion-order-sensitive semantics.
- `scalar.rs` — `Scalar<'_>` and `ScalarOwned` with `parse_from_cow*` helpers.
- `loader.rs` — granit `SpannedEventReceiver` → `YamlOwned` translator. Restructured around a typed `Container { Sequence | Mapping }` enum so every match arm is reachable (no `_ => unreachable!()` or `_ => {}` fallbacks needed for region coverage).

### What's NOT vendored

- `Representation` and `Alias` variants of `YamlOwned` — granit's strict parser plus the event-driven loader never produce them.
- Borrowed `Yaml<'_>` (the one site that used it — `quoted_strings::value_resolves_to_string` — now calls `Scalar::parse_from_cow` directly).
- The macro DSL — only one concrete type (`YamlOwned`), so methods are written out plainly.

### Dependency graph cleanup

- `saphyr` removed.
- `indexmap = "2"` and `ordered-float = "5"` added (replaces saphyr's transitive `hashlink` + `ordered-float`).
- `toml` simplified to `toml = "1.1.2"` — the `preserve_order = off` workaround comment is gone because saphyr's hashlink/hashbrown 0.15 graph constraint is gone too.

### Size delta

As discussed on the issue, vendoring the DOM grows `src/` non-trivially in exchange for severing the saphyr dependency:

- `src/`: **+420 lines / +13 KiB** (vendored loader/scalar/value types).
- `tests/`: +243 lines / +6 KiB (a new `tests/yaml_dom.rs` covering the vendored code paths to keep zero uncovered regions).

## Test plan

- [x] `cargo test` — 1066 passed (+24 new yaml_dom tests vs. main).
- [x] `prek run --all-files` — clean.
- [x] `./scripts/coverage-missing.sh` — zero uncovered regions.
- [x] `cargo test --test property_safe_fix` — 8 passed; parse-preservation invariant still holds across the DOM swap, which is the canary for "did equality semantics drift".
- [x] Version bumped to 0.10.1 across `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, `package.json`, `uv.lock`.