### PR TITLE
Lint YAML embedded in Markdown; add `[files]` source-kind config (closes #222)

### DIFF
--- a/.ryl.toml
+++ b/.ryl.toml
@@ -1,4 +1,5 @@
-yaml-files = [
+[files]
+yaml = [
     "*.yaml",
     "*.yml",
     ".yamllint",

--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -1,12 +1,14 @@
-yaml-files = ["*.yaml", "*.yml", ".yamllint"]
 ignore = """
 vendor/**
 generated/**
 """
 locale = "en_US.UTF-8"
 
+[files]
+yaml = ["*.yaml", "*.yml", ".yamllint"]
+markdown = ["*.md", "*.markdown"]
+
 [markdown]
-files = ["*.md", "*.markdown"]
 front-matter = true
 fenced-blocks = true
 

--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -5,6 +5,11 @@ generated/**
 """
 locale = "en_US.UTF-8"
 
+[markdown]
+files = ["*.md", "*.markdown"]
+front-matter = true
+fenced-blocks = true
+
 [per-file-ignores]
 "**/values.yaml" = ["document-start"]
 "**/kustomization.yaml" = ["document-start"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,16 @@ sticking to the quick-status step above.
 - Use meaningful function and variable names in tests—comments are discouraged.
 - `#[cfg(test)]` modules inside `src/` is forbidden; add coverage through integration
   tests in `tests/` so LLVM regions stay unique.
+- CLI/system tests that drive `env!("CARGO_BIN_EXE_ryl")` run under CI's environment,
+  where `GITHUB_ACTIONS` makes ryl auto-select the GitHub output format
+  (`::error file=…,line=L,col=C::L:C [rule] message`) rather than the standard format
+  (`  L:C  level  message  (rule)`). Assert **format-agnostically**: match the bare
+  `line:col` (present verbatim in both formats) and the **bare rule id**
+  (`colons`, never `(colons)` — the GitHub format renders it `[colons]`). Do not
+  force `--format` to dodge this and do not assert a specific format's `(rule)`
+  parens or ANSI. The `cli_*_rule` tests follow this; only tests that exercise
+  formatting itself (`cli_format_options`, `yamllint_compat_*`) pin or scrub the
+  format via `--format`/`env_remove`.
 - The vendored SchemaStore yamllint snapshot lives at
   `tests/fixtures/schemastore-yamllint.json`; refresh it with
   `uv run scripts/update_yamllint_schemastore_snapshot.py` instead of fetching from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,18 +332,25 @@ sticking to the quick-status step above.
 ## CLI Behavior
 
 - Accepts one or more inputs: files, directories, or `-` to read from stdin.
-- Directories: recursively scan `.yml`/`.yaml` files, honoring git ignore and
-  git exclude; does not follow symlinks.
-- Files: parsed as YAML even if the extension is not `.yml`/`.yaml`.
-- Markdown embedding (TOML-only, off by default): a `[markdown]` table with
-  `files` glob patterns makes ryl extract YAML from matching Markdown files —
-  front matter and fenced `yaml`/`yml` blocks (each linted as its own document)
-  — with diagnostics mapped back to the Markdown file. `front-matter` and
-  `fenced-blocks` booleans (default true) select sources. The extractor lives in
-  `src/markdown_embed/` (fenced blocks via `pulldown-cmark`; front matter via a
-  line scan). `document-start`, `document-end`, `new-line-at-end-of-file`, and
-  `new-lines` are suppressed inside embedded regions. `--fix` skips Markdown
-  files (check-only) and prints a notice. See `docs/markdown.md`.
+- Directories: recursively scanned, honoring git ignore and git exclude; does not
+  follow symlinks. Each file's source kind is resolved from the `[files]` globs
+  (TOML) or `yaml-files` (YAML); files matching no kind are skipped.
+- Files named explicitly are linted as their resolved source kind; one that
+  matches no `[files]` kind is rejected with an error (rather than silently
+  treated as YAML).
+- Source kinds (`config::SourceKind`): the `[files]` TOML table maps `yaml` and
+  `markdown` to glob lists (`yaml` defaults to `*.yaml`/`*.yml`/`.yamllint`). A
+  file matching two kinds is a hard error. `yaml-files` is rejected in TOML (use
+  `[files].yaml`); it remains valid in the legacy YAML config.
+- Markdown embedding (off by default; enabled by listing `[files].markdown`
+  globs): ryl extracts front matter and fenced `yaml`/`yml` blocks (each linted as
+  its own document), mapping diagnostics back to the Markdown file. The
+  `[markdown]` table's `front-matter`/`fenced-blocks` booleans (default true)
+  select sources. The extractor lives in `src/markdown_embed/` (fenced blocks via
+  `pulldown-cmark`; front matter via a line scan). `document-start`,
+  `document-end`, `new-line-at-end-of-file`, and `new-lines` are suppressed inside
+  embedded regions. `--fix` skips Markdown files (check-only) and prints a notice.
+  See `docs/markdown.md`.
 - Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding
   detection as files. `-` cannot be combined with other inputs and is not
   compatible with `--fix`. `--stdin-filename <PATH>` (ruff convention) sets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,15 @@ sticking to the quick-status step above.
 - Directories: recursively scan `.yml`/`.yaml` files, honoring git ignore and
   git exclude; does not follow symlinks.
 - Files: parsed as YAML even if the extension is not `.yml`/`.yaml`.
+- Markdown embedding (TOML-only, off by default): a `[markdown]` table with
+  `files` glob patterns makes ryl extract YAML from matching Markdown files —
+  front matter and fenced `yaml`/`yml` blocks (each linted as its own document)
+  — with diagnostics mapped back to the Markdown file. `front-matter` and
+  `fenced-blocks` booleans (default true) select sources. The extractor lives in
+  `src/markdown_embed/` (fenced blocks via `pulldown-cmark`; front matter via a
+  line scan). `document-start`, `document-end`, `new-line-at-end-of-file`, and
+  `new-lines` are suppressed inside embedded regions. `--fix` skips Markdown
+  files (check-only) and prints a notice. See `docs/markdown.md`.
 - Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding
   detection as files. `-` cannot be combined with other inputs and is not
   compatible with `--fix`. `--stdin-filename <PATH>` (ruff convention) sets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1582,7 @@ dependencies = [
  "jsonschema",
  "ordered-float",
  "proptest",
+ "pulldown-cmark",
  "rayon",
  "regex",
  "schemars",
@@ -2045,6 +2057,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-general-category"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ serde_json = "1.0.149"
 unicode-normalization = "0.1"
 encoding_rs = "0.8"
 toml = "1.1.2"
+pulldown-cmark = { version = "0.13.4", default-features = false }
 
 [dev-dependencies]
 jsonschema = "0.46.2"

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ cargo install ryl                   # cargo
   features that have no upstream equivalent: the `[fix]` table,
   `[per-file-ignores]`, and rule options such as
   `allow-double-quotes-for-escaping`.
+- TOML assigns each file a source kind via the `[files]` table
+  (`yaml = [...]`, `markdown = [...]`). The legacy `yaml-files` key is YAML-only;
+  in TOML use `[files].yaml`.
 - YAML embedded in Markdown (front matter and fenced `yaml`/`yml` blocks)
-  can be linted by adding a `[markdown]` table with `files` patterns;
-  diagnostics map back to the Markdown file. It is off by default and
-  check-only (`--fix` does not modify Markdown). See
-  <https://ryl-docs.pages.dev/markdown/>.
+  can be linted by listing globs under `[files].markdown`; diagnostics map back
+  to the Markdown file. It is off by default and check-only (`--fix` does not
+  modify Markdown). See <https://ryl-docs.pages.dev/markdown/>.
 - yamllint-style YAML configuration is also accepted (`.yamllint`,
   `.yamllint.yml`, `.yamllint.yaml`) for drop-in compatibility, including
   the built-in `default`, `relaxed`, and `empty` presets via `extends`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ cargo install ryl                   # cargo
   features that have no upstream equivalent: the `[fix]` table,
   `[per-file-ignores]`, and rule options such as
   `allow-double-quotes-for-escaping`.
+- YAML embedded in Markdown (front matter and fenced `yaml`/`yml` blocks)
+  can be linted by adding a `[markdown]` table with `files` patterns;
+  diagnostics map back to the Markdown file. It is off by default and
+  check-only (`--fix` does not modify Markdown). See
+  <https://ryl-docs.pages.dev/markdown/>.
 - yamllint-style YAML configuration is also accepted (`.yamllint`,
   `.yamllint.yml`, `.yamllint.yaml`) for drop-in compatibility, including
   the built-in `default`, `relaxed`, and `empty` presets via `extends`.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -13,25 +13,40 @@ diagnostic's line and column point back into the original Markdown file.
 
 This is a ryl-only capability, so it is configured exclusively in **TOML**
 (`ryl.toml`, `.ryl.toml`, or `[tool.ryl]` in `pyproject.toml`). The YAML
-(`yamllint`-compatible) configuration has no `markdown` section.
+(`yamllint`-compatible) configuration uses the legacy `yaml-files` key and has no
+markdown support.
 
-## Enabling it
+## Source kinds and the `[files]` table
 
-Markdown linting is **off by default**. Add a `[markdown]` table whose `files`
-patterns select which Markdown files to scan:
+In TOML, ryl assigns every file a **source kind** via the `[files]` table, which
+maps each kind to a list of gitignore-style glob patterns:
+
+```toml
+[files]
+yaml     = ["*.yaml", "*.yml", ".yamllint"]   # default if [files] is omitted
+markdown = ["*.md", "docs/**/*.md"]           # opt-in: enables markdown linting
+```
+
+- `yaml` defaults to `["*.yaml", "*.yml", ".yamllint"]`; setting it replaces the
+  default.
+- `markdown` is empty by default — listing patterns is what **enables** markdown
+  linting (and scopes it, so only matching files are touched).
+- A file that matches **more than one** kind is a hard error (a file has exactly
+  one kind).
+- A file passed **explicitly** that matches no kind is rejected with an error
+  telling you to add a glob; a file found while scanning a directory that matches
+  no kind is simply skipped.
+
+> The legacy `yaml-files` key is **not** valid in TOML — use `[files].yaml`. It
+> remains valid in the yamllint-compatible YAML config.
+
+Markdown behaviour is tuned in a separate `[markdown]` table (both default `true`):
 
 ```toml
 [markdown]
-files = ["*.md", "*.markdown"]
-front-matter = true   # lint the --- ... --- block (default: true)
-fenced-blocks = true  # lint yaml / yml fenced blocks (default: true)
+front-matter  = true   # lint the --- ... --- block
+fenced-blocks = true   # lint yaml / yml fenced blocks
 ```
-
-| Key | Type | Default | Meaning |
-|-----|------|---------|---------|
-| `files` | list of glob patterns | *(empty — disabled)* | Markdown files to scan. Leaving it empty/absent disables Markdown linting. |
-| `front-matter` | bool | `true` | Lint the leading `---` front matter block. |
-| `fenced-blocks` | bool | `true` | Lint fenced `yaml`/`yml` code blocks. |
 
 Set either flag to `false` to lint only the other source.
 
@@ -92,5 +107,7 @@ the hook to pass Markdown files, for example:
       types_or: [yaml, markdown]
 ```
 
-If a Markdown file is passed but `[markdown].files` does not match it, `ryl`
-simply ignores the file.
+pre-commit decides *which* files to pass; `[files]` decides *how* ryl treats each.
+So if the hook passes a `.md` that no `[files]` glob matches, ryl reports an error
+(it was named explicitly) — add a `markdown` glob to `[files]` to lint it, or narrow
+the hook's file filter.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,0 +1,96 @@
+# Linting YAML embedded in Markdown
+
+`ryl` can lint YAML that lives **inside** Markdown documents, in addition to
+standalone `.yaml`/`.yml` files. Two kinds of embedded YAML are recognised:
+
+- **Front matter** — the leading block delimited by `---` … `---` (or a closing
+  `...`) at the very top of the file.
+- **Fenced code blocks** tagged `yaml` or `yml` (including the `{.yaml}`
+  attribute form and `~~~` tilde fences).
+
+Each region is linted as its **own independent YAML document**, and every
+diagnostic's line and column point back into the original Markdown file.
+
+This is a ryl-only capability, so it is configured exclusively in **TOML**
+(`ryl.toml`, `.ryl.toml`, or `[tool.ryl]` in `pyproject.toml`). The YAML
+(`yamllint`-compatible) configuration has no `markdown` section.
+
+## Enabling it
+
+Markdown linting is **off by default**. Add a `[markdown]` table whose `files`
+patterns select which Markdown files to scan:
+
+```toml
+[markdown]
+files = ["*.md", "*.markdown"]
+front-matter = true   # lint the --- ... --- block (default: true)
+fenced-blocks = true  # lint yaml / yml fenced blocks (default: true)
+```
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `files` | list of glob patterns | *(empty — disabled)* | Markdown files to scan. Leaving it empty/absent disables Markdown linting. |
+| `front-matter` | bool | `true` | Lint the leading `---` front matter block. |
+| `fenced-blocks` | bool | `true` | Lint fenced `yaml`/`yml` code blocks. |
+
+Set either flag to `false` to lint only the other source.
+
+## How rules apply
+
+The same rule set and configuration that applies to standalone YAML applies to
+each embedded region. Four file-shape rules are **suppressed** inside embedded
+regions, because a region is not a standalone file:
+
+- `document-start` and `document-end` — the front matter delimiters are not part
+  of the linted content, and code-block fragments rarely carry markers.
+- `new-line-at-end-of-file` and `new-lines` — these are governed by the host
+  Markdown file, not the embedded snippet.
+
+All other rules (indentation, `key-duplicates`, `colons`, `truthy`,
+`line-length`, `trailing-spaces`, …) run normally.
+
+## Example
+
+A document with both a front matter block and a fenced `yaml` block:
+
+````markdown
+---
+title:  Example
+---
+
+# Notes
+
+```yaml
+build:
+  steps:
+    -  run: make
+```
+````
+
+With `colons` enabled, `ryl docs.md` reports the extra space after `title:` on
+line 2 and any spacing problems inside the fenced block on its actual line —
+columns include the block's indentation.
+
+## `--fix`
+
+`--fix` does **not** modify Markdown files; embedded YAML is checked only. When a
+run includes Markdown files, `ryl` prints a one-line note and leaves those files
+untouched while still reporting their diagnostics.
+
+## Use with pre-commit
+
+When `ryl` runs as a pre-commit hook, the hook only sees the file paths
+pre-commit passes to it. The `ryl` hook targets YAML files by default, so to lint
+Markdown you must both (a) enable `[markdown]` in your ryl config and (b) widen
+the hook to pass Markdown files, for example:
+
+```yaml
+- repo: https://github.com/owenlamont/ryl-pre-commit
+  rev: <version>
+  hooks:
+    - id: ryl
+      types_or: [yaml, markdown]
+```
+
+If a Markdown file is passed but `[markdown].files` does not match it, `ryl`
+simply ignores the file.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -50,6 +50,24 @@ fenced-blocks = true   # lint yaml / yml fenced blocks
 
 Set either flag to `false` to lint only the other source.
 
+## Other Markdown-family formats (Quarto, RMarkdown, MDX, …)
+
+The `markdown` kind is not tied to the `.md` extension. Front matter is found with
+a format-agnostic line scan and fenced blocks are located with a CommonMark parser,
+so any Markdown-superset format works — just map its extension to the `markdown`
+kind:
+
+```toml
+[files]
+markdown = ["*.md", "*.markdown", "*.qmd", "*.Rmd", "*.mdx"]
+```
+
+This lints the YAML front matter and fenced `yaml`/`yml` blocks in Quarto (`.qmd`),
+RMarkdown (`.Rmd`), MDX (`.mdx`), and similar documents. Format-specific constructs
+that are not CommonMark (e.g. MDX/JSX, Quarto executable `{python}` chunks) are
+simply ignored — only YAML front matter and `yaml`/`yml` fenced blocks are
+extracted.
+
 ## How rules apply
 
 The same rule set and configuration that applies to standalone YAML applies to
@@ -96,8 +114,8 @@ untouched while still reporting their diagnostics.
 
 When `ryl` runs as a pre-commit hook, the hook only sees the file paths
 pre-commit passes to it. The `ryl` hook targets YAML files by default, so to lint
-Markdown you must both (a) enable `[markdown]` in your ryl config and (b) widen
-the hook to pass Markdown files, for example:
+Markdown you must both (a) add a `markdown` glob under `[files]` in your ryl config
+and (b) widen the hook to pass Markdown files, for example:
 
 ```yaml
 - repo: https://github.com/owenlamont/ryl-pre-commit
@@ -111,3 +129,8 @@ pre-commit decides *which* files to pass; `[files]` decides *how* ryl treats eac
 So if the hook passes a `.md` that no `[files]` glob matches, ryl reports an error
 (it was named explicitly) — add a `markdown` glob to `[files]` to lint it, or narrow
 the hook's file filter.
+
+`ryl` also applies its `ignore` patterns to **explicitly passed** files, not just
+to files found by scanning a directory. So a file pre-commit hands to `ryl` that
+matches `ignore` is skipped — the equivalent of ruff's `force-exclude`, always on,
+with no separate flag to set.

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -1,5 +1,31 @@
 {
   "$defs": {
+    "FilesTable": {
+      "description": "File-to-source-kind glob mapping (ryl-only; TOML). Each kind selects which\nfiles are linted as that kind. A file matching more than one kind is an error.",
+      "properties": {
+        "markdown": {
+          "description": "Glob patterns for markdown files whose embedded YAML is linted.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "yaml": {
+          "description": "Glob patterns for files linted directly as YAML.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "FixRuleName": {
       "description": "A fixable rule name accepted by `fix.unfixable`.",
       "enum": [
@@ -96,22 +122,12 @@
       ]
     },
     "MarkdownTable": {
-      "description": "Markdown embedding settings. ryl-only (TOML); yamllint has no equivalent.",
+      "description": "Markdown embedding behaviour. ryl-only (TOML); yamllint has no equivalent.",
       "properties": {
         "fenced-blocks": {
           "description": "Lint fenced `yaml`/`yml` code blocks. Defaults to `true`.",
           "type": [
             "boolean",
-            "null"
-          ]
-        },
-        "files": {
-          "description": "Glob patterns identifying markdown files to scan for embedded YAML.\nLeaving this empty disables markdown linting.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
             "null"
           ]
         },
@@ -1805,6 +1821,17 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "JSON Schema root for `ryl` TOML configuration.",
   "properties": {
+    "files": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/FilesTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Glob patterns assigning files to source kinds (`yaml`, `markdown`)."
+    },
     "fix": {
       "anyOf": [
         {
@@ -1854,7 +1881,7 @@
           "type": "null"
         }
       ],
-      "description": "Lint YAML embedded in markdown documents (front matter and fenced blocks)."
+      "description": "Behaviour for YAML embedded in markdown (front matter and fenced blocks)."
     },
     "per-file-ignores": {
       "additionalProperties": {
@@ -1879,16 +1906,6 @@
         }
       ],
       "description": "Rule configuration table."
-    },
-    "yaml-files": {
-      "description": "Glob patterns used to identify YAML files while scanning directories.",
-      "items": {
-        "type": "string"
-      },
-      "type": [
-        "array",
-        "null"
-      ]
     }
   },
   "title": "ryl TOML config",

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -1,6 +1,7 @@
 {
   "$defs": {
     "FilesTable": {
+      "additionalProperties": false,
       "description": "File-to-source-kind glob mapping (ryl-only; TOML). Each kind selects which\nfiles are linted as that kind. A file matching more than one kind is an error.",
       "properties": {
         "markdown": {
@@ -122,6 +123,7 @@
       ]
     },
     "MarkdownTable": {
+      "additionalProperties": false,
       "description": "Markdown embedding behaviour. ryl-only (TOML); yamllint has no equivalent.",
       "properties": {
         "fenced-blocks": {

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -95,6 +95,36 @@
         }
       ]
     },
+    "MarkdownTable": {
+      "description": "Markdown embedding settings. ryl-only (TOML); yamllint has no equivalent.",
+      "properties": {
+        "fenced-blocks": {
+          "description": "Lint fenced `yaml`/`yml` code blocks. Defaults to `true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "files": {
+          "description": "Glob patterns identifying markdown files to scan for embedded YAML.\nLeaving this empty disables markdown linting.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "front-matter": {
+          "description": "Lint the leading YAML front matter block. Defaults to `true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "NewLinesType": {
       "enum": [
         "unix",
@@ -1814,6 +1844,17 @@
         "string",
         "null"
       ]
+    },
+    "markdown": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/MarkdownTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Lint YAML embedded in markdown documents (front matter and fenced blocks)."
     },
     "per-file-ignores": {
       "additionalProperties": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,15 @@ use crate::{conf, decoder};
 
 pub use crate::config_schema::RuleLevel;
 
+/// How a file should be linted, as resolved from the `[files]` globs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    /// The whole file is one YAML document.
+    Yaml,
+    /// A markdown file whose embedded YAML (front matter, fenced blocks) is linted.
+    Markdown,
+}
+
 /// Abstraction over environment/filesystem to enable full test coverage.
 /// Minimal environment abstraction used by tests to cover file system and env-var behavior.
 pub trait Env {
@@ -559,7 +568,7 @@ impl YamlLintConfig {
     }
 
     /// Returns true when `path` is a markdown file to scan for embedded YAML.
-    /// Always false when markdown linting is disabled (no `markdown.files`).
+    /// Always false when markdown linting is disabled (no `[files].markdown`).
     #[must_use]
     pub fn is_markdown_candidate(&self, path: &Path, base_dir: &Path) -> bool {
         let Some(matcher) = &self.markdown_matcher else {
@@ -572,6 +581,32 @@ impl YamlLintConfig {
         matcher
             .matched_path_or_any_parents(rel.as_ref(), path.is_dir())
             .is_ignore()
+    }
+
+    /// Resolve which source kind `path` should be linted as, per the `[files]`
+    /// globs. Returns `Ok(None)` when no kind matches, and `Err` when a file
+    /// matches more than one kind (an unresolvable configuration).
+    ///
+    /// # Errors
+    /// Returns `Err` if `path` matches both the `yaml` and `markdown` globs.
+    pub fn source_kind(
+        &self,
+        path: &Path,
+        base_dir: &Path,
+    ) -> Result<Option<SourceKind>, String> {
+        match (
+            self.is_yaml_candidate(path, base_dir),
+            self.is_markdown_candidate(path, base_dir),
+        ) {
+            (true, true) => Err(format!(
+                "{}: matches both `yaml` and `markdown` in [files]; a file may \
+                 belong to only one source kind",
+                path.display()
+            )),
+            (true, false) => Ok(Some(SourceKind::Yaml)),
+            (false, true) => Ok(Some(SourceKind::Markdown)),
+            (false, false) => Ok(None),
+        }
     }
 
     #[must_use]
@@ -663,8 +698,11 @@ impl YamlLintConfig {
             self.yaml_file_patterns = yaml_files;
         }
 
+        if let Some(markdown_files) = normalized.markdown_file_patterns {
+            self.markdown_file_patterns = markdown_files;
+        }
+
         if let Some(markdown) = normalized.markdown {
-            self.markdown_file_patterns = markdown.files;
             if let Some(front_matter) = markdown.front_matter {
                 self.lint_markdown_front_matter = front_matter;
             }
@@ -974,13 +1012,14 @@ fn normalized_config_from_runtime(config: &YamlLintConfig) -> NormalizedConfig {
             .then(|| config.ignore_from_files.clone()),
         per_file_ignores: config.per_file_ignores.clone(),
         yaml_file_patterns: Some(config.yaml_file_patterns.clone()),
-        markdown: (!config.markdown_file_patterns.is_empty()).then(|| {
+        markdown_file_patterns: (!config.markdown_file_patterns.is_empty())
+            .then(|| config.markdown_file_patterns.clone()),
+        markdown: (!config.markdown_file_patterns.is_empty()).then_some(
             NormalizedMarkdown {
-                files: config.markdown_file_patterns.clone(),
                 front_matter: Some(config.lint_markdown_front_matter),
                 fenced_blocks: Some(config.lint_markdown_fenced_blocks),
-            }
-        }),
+            },
+        ),
         locale: config.locale.clone(),
         fix: normalized_fix_config(&config.fix),
         rules: config

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,10 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
 use crate::config_schema::{
     FixRuleName as TomlFixRuleName, FixableRuleSelector as TomlFixableRuleSelector,
-    NormalizedConfig, NormalizedFixConfig, TomlConfig, normalize_toml_config,
-    normalized_config_to_toml_value, parse_toml_config_str, parse_yaml_config,
-    validate_toml_config, yaml_rule_filter_patterns, yaml_rule_level,
+    NormalizedConfig, NormalizedFixConfig, NormalizedMarkdown, TomlConfig,
+    normalize_toml_config, normalized_config_to_toml_value, parse_toml_config_str,
+    parse_yaml_config, validate_toml_config, yaml_rule_filter_patterns,
+    yaml_rule_level,
 };
 use crate::{conf, decoder};
 
@@ -124,6 +125,10 @@ pub struct YamlLintConfig {
     rules: std::collections::BTreeMap<String, RuleConfig>,
     yaml_file_patterns: Vec<String>,
     yaml_matcher: Option<Gitignore>,
+    markdown_file_patterns: Vec<String>,
+    markdown_matcher: Option<Gitignore>,
+    lint_markdown_front_matter: bool,
+    lint_markdown_fenced_blocks: bool,
     locale: Option<String>,
     fix: FixConfig,
 }
@@ -357,6 +362,10 @@ impl Default for YamlLintConfig {
                 .map(|s| (*s).to_string())
                 .collect(),
             yaml_matcher: None,
+            markdown_file_patterns: Vec::new(),
+            markdown_matcher: None,
+            lint_markdown_front_matter: true,
+            lint_markdown_fenced_blocks: true,
             locale: None,
             fix: FixConfig::default(),
         }
@@ -484,6 +493,22 @@ impl YamlLintConfig {
         self.yaml_matcher = builder.build().ok();
     }
 
+    fn build_markdown_matcher(&mut self, base_dir: &Path) {
+        if self.markdown_file_patterns.is_empty() {
+            self.markdown_matcher = None;
+            return;
+        }
+
+        let mut builder = GitignoreBuilder::new(base_dir);
+        builder.allow_unclosed_class(false);
+        for pat in &self.markdown_file_patterns {
+            let normalized = pat.trim_end_matches(['\r']);
+            let _ = builder.add_line(None, normalized);
+        }
+
+        self.markdown_matcher = builder.build().ok();
+    }
+
     /// Returns true when `path` should be ignored according to config patterns.
     /// Matching is performed on the path relative to `base_dir`.
     #[must_use]
@@ -531,6 +556,32 @@ impl YamlLintConfig {
             return matched.is_ignore();
         }
         crate::discover::is_yaml_path(path)
+    }
+
+    /// Returns true when `path` is a markdown file to scan for embedded YAML.
+    /// Always false when markdown linting is disabled (no `markdown.files`).
+    #[must_use]
+    pub fn is_markdown_candidate(&self, path: &Path, base_dir: &Path) -> bool {
+        let Some(matcher) = &self.markdown_matcher else {
+            return false;
+        };
+        let rel: Cow<'_, Path> = path.strip_prefix(base_dir).map_or_else(
+            |_| Cow::Owned(path.file_name().map(PathBuf::from).unwrap_or_default()),
+            Cow::Borrowed,
+        );
+        matcher
+            .matched_path_or_any_parents(rel.as_ref(), path.is_dir())
+            .is_ignore()
+    }
+
+    #[must_use]
+    pub fn markdown_front_matter(&self) -> bool {
+        self.lint_markdown_front_matter
+    }
+
+    #[must_use]
+    pub fn markdown_fenced_blocks(&self) -> bool {
+        self.lint_markdown_fenced_blocks
     }
 
     fn from_yaml_str_with_env(
@@ -612,6 +663,16 @@ impl YamlLintConfig {
             self.yaml_file_patterns = yaml_files;
         }
 
+        if let Some(markdown) = normalized.markdown {
+            self.markdown_file_patterns = markdown.files;
+            if let Some(front_matter) = markdown.front_matter {
+                self.lint_markdown_front_matter = front_matter;
+            }
+            if let Some(fenced_blocks) = markdown.fenced_blocks {
+                self.lint_markdown_fenced_blocks = fenced_blocks;
+            }
+        }
+
         if !normalized.per_file_ignores.is_empty() {
             self.per_file_ignores = normalized.per_file_ignores;
         }
@@ -655,6 +716,7 @@ impl YamlLintConfig {
             build_per_file_ignores(&self.per_file_ignores, base_dir)?;
 
         self.build_yaml_matcher(base_dir);
+        self.build_markdown_matcher(base_dir);
 
         for rule in self.rules.values_mut() {
             rule.build_filter(envx, base_dir)?;
@@ -912,6 +974,13 @@ fn normalized_config_from_runtime(config: &YamlLintConfig) -> NormalizedConfig {
             .then(|| config.ignore_from_files.clone()),
         per_file_ignores: config.per_file_ignores.clone(),
         yaml_file_patterns: Some(config.yaml_file_patterns.clone()),
+        markdown: (!config.markdown_file_patterns.is_empty()).then(|| {
+            NormalizedMarkdown {
+                files: config.markdown_file_patterns.clone(),
+                front_matter: Some(config.lint_markdown_front_matter),
+                fenced_blocks: Some(config.lint_markdown_fenced_blocks),
+            }
+        }),
         locale: config.locale.clone(),
         fix: normalized_fix_config(&config.fix),
         rules: config

--- a/src/config.rs
+++ b/src/config.rs
@@ -486,36 +486,10 @@ impl YamlLintConfig {
         &self.fix
     }
 
-    fn build_yaml_matcher(&mut self, base_dir: &Path) {
-        if self.yaml_file_patterns.is_empty() {
-            self.yaml_matcher = None;
-            return;
-        }
-
-        let mut builder = GitignoreBuilder::new(base_dir);
-        builder.allow_unclosed_class(false);
-        for pat in &self.yaml_file_patterns {
-            let normalized = pat.trim_end_matches(['\r']);
-            let _ = builder.add_line(None, normalized);
-        }
-
-        self.yaml_matcher = builder.build().ok();
-    }
-
-    fn build_markdown_matcher(&mut self, base_dir: &Path) {
-        if self.markdown_file_patterns.is_empty() {
-            self.markdown_matcher = None;
-            return;
-        }
-
-        let mut builder = GitignoreBuilder::new(base_dir);
-        builder.allow_unclosed_class(false);
-        for pat in &self.markdown_file_patterns {
-            let normalized = pat.trim_end_matches(['\r']);
-            let _ = builder.add_line(None, normalized);
-        }
-
-        self.markdown_matcher = builder.build().ok();
+    fn build_file_kind_matchers(&mut self, base_dir: &Path) {
+        self.yaml_matcher = build_glob_matcher(base_dir, &self.yaml_file_patterns);
+        self.markdown_matcher =
+            build_glob_matcher(base_dir, &self.markdown_file_patterns);
     }
 
     /// Returns true when `path` should be ignored according to config patterns.
@@ -753,8 +727,7 @@ impl YamlLintConfig {
         self.per_file_ignore_matchers =
             build_per_file_ignores(&self.per_file_ignores, base_dir)?;
 
-        self.build_yaml_matcher(base_dir);
-        self.build_markdown_matcher(base_dir);
+        self.build_file_kind_matchers(base_dir);
 
         for rule in self.rules.values_mut() {
             rule.build_filter(envx, base_dir)?;
@@ -787,6 +760,19 @@ fn build_rule_filter(
     }
     filter.matcher = matcher;
     Ok(())
+}
+
+fn build_glob_matcher(base_dir: &Path, patterns: &[String]) -> Option<Gitignore> {
+    if patterns.is_empty() {
+        return None;
+    }
+    let mut builder = GitignoreBuilder::new(base_dir);
+    builder.allow_unclosed_class(false);
+    for pat in patterns {
+        let normalized = pat.trim_end_matches(['\r']);
+        let _ = builder.add_line(None, normalized);
+    }
+    builder.build().ok()
 }
 
 fn build_ignore_matcher(

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -20,6 +20,8 @@ pub struct TomlConfig {
     /// Glob patterns used to identify YAML files while scanning directories.
     #[serde(rename = "yaml-files")]
     pub yaml_files: Option<Vec<String>>,
+    /// Lint YAML embedded in markdown documents (front matter and fenced blocks).
+    pub markdown: Option<MarkdownTable>,
     /// Ignore patterns, either as one multi-line string or a list of patterns.
     pub ignore: Option<StringOrVec>,
     /// Paths to files that contain ignore patterns.
@@ -37,6 +39,20 @@ pub struct TomlConfig {
     #[serde(flatten, default)]
     #[schemars(skip)]
     extra: BTreeMap<String, toml::Value>,
+}
+
+/// Markdown embedding settings. ryl-only (TOML); yamllint has no equivalent.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct MarkdownTable {
+    /// Glob patterns identifying markdown files to scan for embedded YAML.
+    /// Leaving this empty disables markdown linting.
+    pub files: Option<Vec<String>>,
+    /// Lint the leading YAML front matter block. Defaults to `true`.
+    #[serde(rename = "front-matter")]
+    pub front_matter: Option<bool>,
+    /// Lint fenced `yaml`/`yml` code blocks. Defaults to `true`.
+    #[serde(rename = "fenced-blocks")]
+    pub fenced_blocks: Option<bool>,
 }
 
 /// JSON Schema root for yamllint-compatible YAML configuration.
@@ -747,9 +763,17 @@ pub struct NormalizedConfig {
     pub ignore_from_files: Option<Vec<String>>,
     pub per_file_ignores: BTreeMap<String, Vec<String>>,
     pub yaml_file_patterns: Option<Vec<String>>,
+    pub markdown: Option<NormalizedMarkdown>,
     pub locale: Option<String>,
     pub fix: Option<NormalizedFixConfig>,
     pub rules: BTreeMap<String, YamlOwned>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NormalizedMarkdown {
+    pub files: Vec<String>,
+    pub front_matter: Option<bool>,
+    pub fenced_blocks: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -17,10 +17,9 @@ pub use serialization::{
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[schemars(title = "ryl TOML config")]
 pub struct TomlConfig {
-    /// Glob patterns used to identify YAML files while scanning directories.
-    #[serde(rename = "yaml-files")]
-    pub yaml_files: Option<Vec<String>>,
-    /// Lint YAML embedded in markdown documents (front matter and fenced blocks).
+    /// Glob patterns assigning files to source kinds (`yaml`, `markdown`).
+    pub files: Option<FilesTable>,
+    /// Behaviour for YAML embedded in markdown (front matter and fenced blocks).
     pub markdown: Option<MarkdownTable>,
     /// Ignore patterns, either as one multi-line string or a list of patterns.
     pub ignore: Option<StringOrVec>,
@@ -41,12 +40,19 @@ pub struct TomlConfig {
     extra: BTreeMap<String, toml::Value>,
 }
 
-/// Markdown embedding settings. ryl-only (TOML); yamllint has no equivalent.
+/// File-to-source-kind glob mapping (ryl-only; TOML). Each kind selects which
+/// files are linted as that kind. A file matching more than one kind is an error.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FilesTable {
+    /// Glob patterns for files linted directly as YAML.
+    pub yaml: Option<Vec<String>>,
+    /// Glob patterns for markdown files whose embedded YAML is linted.
+    pub markdown: Option<Vec<String>>,
+}
+
+/// Markdown embedding behaviour. ryl-only (TOML); yamllint has no equivalent.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct MarkdownTable {
-    /// Glob patterns identifying markdown files to scan for embedded YAML.
-    /// Leaving this empty disables markdown linting.
-    pub files: Option<Vec<String>>,
     /// Lint the leading YAML front matter block. Defaults to `true`.
     #[serde(rename = "front-matter")]
     pub front_matter: Option<bool>,
@@ -712,6 +718,14 @@ pub fn validate_toml_config(config: &TomlConfig) -> Result<(), String> {
         );
     }
 
+    if config.extra.contains_key("yaml-files") {
+        return Err(
+            "invalid config: `yaml-files` is not valid in TOML; use `[files]` with \
+             `yaml = [...]` instead"
+                .to_string(),
+        );
+    }
+
     validate_common_config(
         config.ignore.as_ref(),
         config.ignore_from_file.as_ref(),
@@ -763,6 +777,7 @@ pub struct NormalizedConfig {
     pub ignore_from_files: Option<Vec<String>>,
     pub per_file_ignores: BTreeMap<String, Vec<String>>,
     pub yaml_file_patterns: Option<Vec<String>>,
+    pub markdown_file_patterns: Option<Vec<String>>,
     pub markdown: Option<NormalizedMarkdown>,
     pub locale: Option<String>,
     pub fix: Option<NormalizedFixConfig>,
@@ -771,7 +786,6 @@ pub struct NormalizedConfig {
 
 #[derive(Debug, Clone, Default)]
 pub struct NormalizedMarkdown {
-    pub files: Vec<String>,
     pub front_matter: Option<bool>,
     pub fenced_blocks: Option<bool>,
 }

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -43,6 +43,7 @@ pub struct TomlConfig {
 /// File-to-source-kind glob mapping (ryl-only; TOML). Each kind selects which
 /// files are linted as that kind. A file matching more than one kind is an error.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct FilesTable {
     /// Glob patterns for files linted directly as YAML.
     pub yaml: Option<Vec<String>>,
@@ -52,6 +53,7 @@ pub struct FilesTable {
 
 /// Markdown embedding behaviour. ryl-only (TOML); yamllint has no equivalent.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct MarkdownTable {
     /// Lint the leading YAML front matter block. Defaults to `true`.
     #[serde(rename = "front-matter")]

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -2,8 +2,8 @@ use crate::yaml_dom::{MappingOwned, ScalarOwned, YamlOwned};
 use serde::Serialize;
 
 use super::{
-    FixTable, NormalizedConfig, NormalizedFixConfig, RuleName, RulesTable, StringOrVec,
-    TomlConfig, YamlConfig,
+    FixTable, MarkdownTable, NormalizedConfig, NormalizedFixConfig, NormalizedMarkdown,
+    RuleName, RulesTable, StringOrVec, TomlConfig, YamlConfig,
 };
 
 pub(crate) fn string_or_vec_items(value: &StringOrVec) -> Vec<String> {
@@ -136,6 +136,7 @@ pub fn normalize_toml_config(config: &TomlConfig) -> NormalizedConfig {
             .as_ref()
             .map_or_else(std::collections::BTreeMap::new, normalize_per_file_ignores),
         yaml_file_patterns: config.yaml_files.clone(),
+        markdown: config.markdown.as_ref().map(normalize_markdown_table),
         locale: config.locale.clone(),
         fix: config.fix.as_ref().map(normalize_fix_table),
         rules: config
@@ -145,12 +146,21 @@ pub fn normalize_toml_config(config: &TomlConfig) -> NormalizedConfig {
     }
 }
 
+fn normalize_markdown_table(table: &MarkdownTable) -> NormalizedMarkdown {
+    NormalizedMarkdown {
+        files: table.files.clone().unwrap_or_default(),
+        front_matter: table.front_matter,
+        fenced_blocks: table.fenced_blocks,
+    }
+}
+
 pub fn normalize_yaml_config(config: &YamlConfig) -> NormalizedConfig {
     NormalizedConfig {
         ignore_patterns: config.ignore.as_ref().map(string_or_vec_items),
         ignore_from_files: config.ignore_from_file.as_ref().map(string_or_vec_items),
         per_file_ignores: std::collections::BTreeMap::new(),
         yaml_file_patterns: config.yaml_files.clone(),
+        markdown: None,
         locale: config.locale.clone(),
         fix: None,
         rules: config
@@ -300,6 +310,13 @@ pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value
         insert_string_array(&mut table, "yaml-files", yaml_files);
     }
 
+    if let Some(markdown) = config.markdown.as_ref() {
+        table.insert(
+            "markdown".to_string(),
+            normalized_markdown_to_toml_value(markdown),
+        );
+    }
+
     if let Some(ignore_from_file) = config.ignore_from_files.as_ref() {
         insert_string_array(&mut table, "ignore-from-file", ignore_from_file);
     } else if let Some(ignore) = config.ignore_patterns.as_ref() {
@@ -328,6 +345,20 @@ pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value
         );
     }
 
+    toml::Value::Table(table)
+}
+
+fn normalized_markdown_to_toml_value(markdown: &NormalizedMarkdown) -> toml::Value {
+    let mut table = toml::map::Map::new();
+    insert_string_array(&mut table, "files", &markdown.files);
+    table.insert(
+        "front-matter".to_string(),
+        toml::Value::Boolean(markdown.front_matter.unwrap_or(true)),
+    );
+    table.insert(
+        "fenced-blocks".to_string(),
+        toml::Value::Boolean(markdown.fenced_blocks.unwrap_or(true)),
+    );
     toml::Value::Table(table)
 }
 

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -135,7 +135,11 @@ pub fn normalize_toml_config(config: &TomlConfig) -> NormalizedConfig {
             .per_file_ignores
             .as_ref()
             .map_or_else(std::collections::BTreeMap::new, normalize_per_file_ignores),
-        yaml_file_patterns: config.yaml_files.clone(),
+        yaml_file_patterns: config.files.as_ref().and_then(|files| files.yaml.clone()),
+        markdown_file_patterns: config
+            .files
+            .as_ref()
+            .and_then(|files| files.markdown.clone()),
         markdown: config.markdown.as_ref().map(normalize_markdown_table),
         locale: config.locale.clone(),
         fix: config.fix.as_ref().map(normalize_fix_table),
@@ -148,7 +152,6 @@ pub fn normalize_toml_config(config: &TomlConfig) -> NormalizedConfig {
 
 fn normalize_markdown_table(table: &MarkdownTable) -> NormalizedMarkdown {
     NormalizedMarkdown {
-        files: table.files.clone().unwrap_or_default(),
         front_matter: table.front_matter,
         fenced_blocks: table.fenced_blocks,
     }
@@ -160,6 +163,7 @@ pub fn normalize_yaml_config(config: &YamlConfig) -> NormalizedConfig {
         ignore_from_files: config.ignore_from_file.as_ref().map(string_or_vec_items),
         per_file_ignores: std::collections::BTreeMap::new(),
         yaml_file_patterns: config.yaml_files.clone(),
+        markdown_file_patterns: None,
         markdown: None,
         locale: config.locale.clone(),
         fix: None,
@@ -244,7 +248,8 @@ fn rules_table_to_value<Q: Serialize>(rules: &RulesTable<Q>) -> toml::Value {
 #[must_use]
 pub fn toml_config_to_value(config: &TomlConfig) -> toml::Value {
     let mut table = toml::map::Map::new();
-    insert_serialized(&mut table, "yaml-files", config.yaml_files.as_ref());
+    insert_serialized(&mut table, "files", config.files.as_ref());
+    insert_serialized(&mut table, "markdown", config.markdown.as_ref());
     insert_serialized(&mut table, "ignore", config.ignore.as_ref());
     insert_serialized(
         &mut table,
@@ -306,8 +311,8 @@ fn normalized_rules_to_toml_value(
 pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value {
     let mut table = toml::map::Map::new();
 
-    if let Some(yaml_files) = config.yaml_file_patterns.as_ref() {
-        insert_string_array(&mut table, "yaml-files", yaml_files);
+    if let Some(files) = normalized_files_to_toml_value(config) {
+        table.insert("files".to_string(), files);
     }
 
     if let Some(markdown) = config.markdown.as_ref() {
@@ -348,9 +353,19 @@ pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value
     toml::Value::Table(table)
 }
 
+fn normalized_files_to_toml_value(config: &NormalizedConfig) -> Option<toml::Value> {
+    let mut table = toml::map::Map::new();
+    if let Some(yaml) = config.yaml_file_patterns.as_ref() {
+        insert_string_array(&mut table, "yaml", yaml);
+    }
+    if let Some(markdown) = config.markdown_file_patterns.as_ref() {
+        insert_string_array(&mut table, "markdown", markdown);
+    }
+    (!table.is_empty()).then_some(toml::Value::Table(table))
+}
+
 fn normalized_markdown_to_toml_value(markdown: &NormalizedMarkdown) -> toml::Value {
     let mut table = toml::map::Map::new();
-    insert_string_array(&mut table, "files", &markdown.files);
     table.insert(
         "front-matter".to_string(),
         toml::Value::Boolean(markdown.front_matter.unwrap_or(true)),

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::config::YamlLintConfig;
+use crate::config::{SourceKind, YamlLintConfig};
 use crate::decoder;
 use crate::rules::{
     braces, brackets, commas, comments, comments_indentation, document_end,
@@ -101,11 +101,11 @@ pub fn apply_safe_fixes_in_place(
 ///
 /// Returns an error if any file cannot be read or any fixed contents cannot be written.
 pub fn apply_safe_fixes_to_files(
-    files: &[(PathBuf, PathBuf, YamlLintConfig)],
+    files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
 ) -> Result<FixStats, String> {
     let mut stats = FixStats::default();
-    for (path, base_dir, cfg) in files {
-        if cfg.is_markdown_candidate(path, base_dir) {
+    for (path, base_dir, cfg, kind) in files {
+        if *kind == SourceKind::Markdown {
             continue;
         }
         if apply_safe_fixes_in_place(path, cfg, base_dir)? {

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -105,6 +105,9 @@ pub fn apply_safe_fixes_to_files(
 ) -> Result<FixStats, String> {
     let mut stats = FixStats::default();
     for (path, base_dir, cfg) in files {
+        if cfg.is_markdown_candidate(path, base_dir) {
+            continue;
+        }
         if apply_safe_fixes_in_place(path, cfg, base_dir)? {
             stats.changed_files += 1;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod rules;
 pub mod yaml_dom;
 
 pub use discover::{gather_yaml_from_dir, is_yaml_path};
-pub use lint::{LintProblem, Severity, lint_file, lint_str};
+pub use lint::{LintProblem, Severity, lint_file, lint_markdown_file, lint_str};
 pub use markdown_embed::{
     EmbeddedRegion, MarkdownSources, RegionKind, extract_regions, lint_markdown_str,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,13 @@ pub mod decoder;
 pub mod discover;
 pub mod fix;
 pub mod lint;
+pub mod markdown_embed;
 pub mod migrate;
 pub mod rules;
 pub mod yaml_dom;
 
 pub use discover::{gather_yaml_from_dir, is_yaml_path};
 pub use lint::{LintProblem, Severity, lint_file, lint_str};
+pub use markdown_embed::{
+    EmbeddedRegion, MarkdownSources, RegionKind, extract_regions, lint_markdown_str,
+};

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -59,13 +59,24 @@ pub fn lint_file(
     base_dir: &Path,
 ) -> Result<Vec<LintProblem>, String> {
     let content = decoder::read_file(path)?;
-    if cfg.is_markdown_candidate(path, base_dir) {
-        Ok(crate::markdown_embed::lint_markdown_str(
-            &content, path, cfg, base_dir,
-        ))
-    } else {
-        Ok(lint_str(&content, path, cfg, base_dir))
-    }
+    Ok(lint_str(&content, path, cfg, base_dir))
+}
+
+/// Lint the YAML embedded in a markdown file and return diagnostics whose
+/// positions point back into the markdown document.
+///
+/// # Errors
+///
+/// Returns `Err(String)` when the file cannot be read.
+pub fn lint_markdown_file(
+    path: &Path,
+    cfg: &YamlLintConfig,
+    base_dir: &Path,
+) -> Result<Vec<LintProblem>, String> {
+    let content = decoder::read_file(path)?;
+    Ok(crate::markdown_embed::lint_markdown_str(
+        &content, path, cfg, base_dir,
+    ))
 }
 
 /// Lint YAML content held in memory and return diagnostics in yamllint format

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -59,7 +59,13 @@ pub fn lint_file(
     base_dir: &Path,
 ) -> Result<Vec<LintProblem>, String> {
     let content = decoder::read_file(path)?;
-    Ok(lint_str(&content, path, cfg, base_dir))
+    if cfg.is_markdown_candidate(path, base_dir) {
+        Ok(crate::markdown_embed::lint_markdown_str(
+            &content, path, cfg, base_dir,
+        ))
+    } else {
+        Ok(lint_str(&content, path, cfg, base_dir))
+    }
 }
 
 /// Lint YAML content held in memory and return diagnostics in yamllint format

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,9 @@ use clap::{Parser, ValueEnum};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use ryl::cli_support::resolve_ctx;
-use ryl::config::{ConfigContext, Overrides, YamlLintConfig, discover_config};
+use ryl::config::{
+    ConfigContext, Overrides, SourceKind, YamlLintConfig, discover_config,
+};
 use ryl::config_schema::{schema_string_pretty, yaml_schema_string_pretty};
 use ryl::decoder;
 use ryl::fix::apply_safe_fixes_to_files;
@@ -24,7 +26,7 @@ use ryl::migrate::{
     MigrateOptions, OutputMode as MigrateOutputMode, SourceCleanup, WriteMode,
     migrate_configs,
 };
-use ryl::{LintProblem, Severity, lint_file, lint_str};
+use ryl::{LintProblem, Severity, lint_file, lint_markdown_file, lint_str};
 
 const STDIN_LABEL: &str = "<stdin>";
 
@@ -377,7 +379,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
     // Filter directory candidates via ignores, respecting global vs per-file behavior.
     let mut cache: HashMap<PathBuf, (PathBuf, YamlLintConfig)> = HashMap::new();
     let mut emitted_notices: HashSet<String> = HashSet::new();
-    let mut files: Vec<(PathBuf, PathBuf, YamlLintConfig)> = Vec::new();
+    let mut files: Vec<(PathBuf, PathBuf, YamlLintConfig, SourceKind)> = Vec::new();
     gather_lint_files(
         &candidates,
         &explicit_files,
@@ -400,10 +402,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
 
     let mut initial_problem_count = 0usize;
     if cli.lint.fix.fix {
-        if files
-            .iter()
-            .any(|(path, base_dir, cfg)| cfg.is_markdown_candidate(path, base_dir))
-        {
+        if files.iter().any(|(.., kind)| *kind == SourceKind::Markdown) {
             eprintln!(
                 "note: --fix does not modify markdown files; embedded YAML is checked only"
             );
@@ -466,7 +465,7 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
 
     let outcome = read_and_lint_stdin(&path, &base_dir, &cfg);
 
-    let files = vec![(path, base_dir, cfg)];
+    let files = vec![(path, base_dir, cfg, SourceKind::Yaml)];
     let results = vec![(0usize, outcome)];
 
     let output_format = detect_output_format(cli.format);
@@ -517,12 +516,18 @@ fn resolve_stdin_ctx(
 }
 
 fn lint_files(
-    files: &[(PathBuf, PathBuf, YamlLintConfig)],
+    files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
 ) -> Vec<(usize, Result<Vec<LintProblem>, String>)> {
     let mut results: Vec<(usize, Result<Vec<LintProblem>, String>)> = files
         .par_iter()
         .enumerate()
-        .map(|(idx, (path, base_dir, cfg))| (idx, lint_file(path, cfg, base_dir)))
+        .map(|(idx, (path, base_dir, cfg, kind))| {
+            let result = match kind {
+                SourceKind::Markdown => lint_markdown_file(path, cfg, base_dir),
+                SourceKind::Yaml => lint_file(path, cfg, base_dir),
+            };
+            (idx, result)
+        })
         .collect();
     results.sort_by_key(|(idx, _)| *idx);
     results
@@ -535,7 +540,7 @@ fn gather_lint_files(
     global_cfg: Option<&ConfigContext>,
     cache: &mut HashMap<PathBuf, (PathBuf, YamlLintConfig)>,
     emitted_notices: &mut HashSet<String>,
-    files: &mut Vec<(PathBuf, PathBuf, YamlLintConfig)>,
+    files: &mut Vec<(PathBuf, PathBuf, YamlLintConfig, SourceKind)>,
 ) -> Result<(), String> {
     for f in candidates {
         let (base_dir, cfg, notices) = resolve_ctx(f, global_cfg, cache)?;
@@ -544,11 +549,11 @@ fn gather_lint_files(
                 eprintln!("{notice}");
             }
         }
-        let ignored = cfg.is_file_ignored(f, &base_dir);
-        let lintable = cfg.is_yaml_candidate(f, &base_dir)
-            || cfg.is_markdown_candidate(f, &base_dir);
-        if !ignored && lintable {
-            files.push((f.clone(), base_dir, cfg));
+        if cfg.is_file_ignored(f, &base_dir) {
+            continue;
+        }
+        if let Some(kind) = cfg.source_kind(f, &base_dir)? {
+            files.push((f.clone(), base_dir, cfg, kind));
         }
     }
 
@@ -559,11 +564,18 @@ fn gather_lint_files(
                 eprintln!("{notice}");
             }
         }
-        let ignored = cfg.is_file_ignored(ef, &base_dir);
-        let lintable = cfg.is_yaml_candidate(ef, &base_dir)
-            || cfg.is_markdown_candidate(ef, &base_dir);
-        if !ignored && lintable {
-            files.push((ef.clone(), base_dir, cfg));
+        if cfg.is_file_ignored(ef, &base_dir) {
+            continue;
+        }
+        match cfg.source_kind(ef, &base_dir)? {
+            Some(kind) => files.push((ef.clone(), base_dir, cfg, kind)),
+            None => {
+                return Err(format!(
+                    "{}: no source kind matches; add a matching glob under \
+                     [files].yaml or [files].markdown",
+                    ef.display()
+                ));
+            }
         }
     }
 
@@ -571,7 +583,7 @@ fn gather_lint_files(
 }
 
 fn process_results(
-    files: &[(PathBuf, PathBuf, YamlLintConfig)],
+    files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
     results: Vec<(usize, Result<Vec<LintProblem>, String>)>,
     output_format: OutputFormat,
     no_warnings: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,6 +400,14 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
 
     let mut initial_problem_count = 0usize;
     if cli.lint.fix.fix {
+        if files
+            .iter()
+            .any(|(path, base_dir, cfg)| cfg.is_markdown_candidate(path, base_dir))
+        {
+            eprintln!(
+                "note: --fix does not modify markdown files; embedded YAML is checked only"
+            );
+        }
         let initial_results = lint_files(&files);
         initial_problem_count = count_reported_problems(
             &initial_results,
@@ -537,8 +545,9 @@ fn gather_lint_files(
             }
         }
         let ignored = cfg.is_file_ignored(f, &base_dir);
-        let yaml_ok = cfg.is_yaml_candidate(f, &base_dir);
-        if !ignored && yaml_ok {
+        let lintable = cfg.is_yaml_candidate(f, &base_dir)
+            || cfg.is_markdown_candidate(f, &base_dir);
+        if !ignored && lintable {
             files.push((f.clone(), base_dir, cfg));
         }
     }
@@ -551,8 +560,9 @@ fn gather_lint_files(
             }
         }
         let ignored = cfg.is_file_ignored(ef, &base_dir);
-        let yaml_ok = cfg.is_yaml_candidate(ef, &base_dir);
-        if !ignored && yaml_ok {
+        let lintable = cfg.is_yaml_candidate(ef, &base_dir)
+            || cfg.is_markdown_candidate(ef, &base_dir);
+        if !ignored && lintable {
             files.push((ef.clone(), base_dir, cfg));
         }
     }

--- a/src/markdown_embed/lint.rs
+++ b/src/markdown_embed/lint.rs
@@ -1,0 +1,57 @@
+//! Lint the YAML regions extracted from a markdown document and translate each
+//! diagnostic's position back to the host file.
+
+use std::path::Path;
+
+use super::{MarkdownSources, extract_regions};
+use crate::config::YamlLintConfig;
+use crate::lint::{LintProblem, lint_str};
+use crate::rules::{document_end, document_start, new_line_at_end_of_file, new_lines};
+
+/// File-shape rules suppressed inside embedded regions: a region is not a
+/// standalone file, so "missing document start/end" and file-newline checks do
+/// not apply (the analog of markdown linters skipping their first-line/EOF rules).
+const SUPPRESSED: [&str; 4] = [
+    new_line_at_end_of_file::ID,
+    new_lines::ID,
+    document_start::ID,
+    document_end::ID,
+];
+
+/// Lint every embedded YAML region in `markdown` and return diagnostics whose
+/// line/column point into the original markdown document.
+///
+/// Each region is linted as an independent YAML document. File-shape rules that
+/// only make sense for a standalone file are suppressed (see [`is_suppressed`]).
+#[must_use]
+pub fn lint_markdown_str(
+    markdown: &str,
+    path: &Path,
+    cfg: &YamlLintConfig,
+    base_dir: &Path,
+) -> Vec<LintProblem> {
+    let sources = MarkdownSources {
+        front_matter: cfg.markdown_front_matter(),
+        fenced_blocks: cfg.markdown_fenced_blocks(),
+    };
+
+    let mut problems = Vec::new();
+    for region in extract_regions(markdown, sources) {
+        if region.content.trim().is_empty() {
+            continue;
+        }
+        for mut problem in lint_str(&region.content, path, cfg, base_dir) {
+            if is_suppressed(problem.rule) {
+                continue;
+            }
+            problem.line += region.line_offset;
+            problem.column += region.col_offset;
+            problems.push(problem);
+        }
+    }
+    problems
+}
+
+fn is_suppressed(rule: Option<&str>) -> bool {
+    rule.is_some_and(|id| SUPPRESSED.contains(&id))
+}

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -1,0 +1,150 @@
+//! Extract embeddable YAML regions from markdown so the YAML linter can run on
+//! them and map diagnostics back to the original document.
+//!
+//! Two region kinds are recognised: leading YAML front matter (`---` … `---`/`...`)
+//! and fenced code blocks tagged `yaml`/`yml`. Front matter is found with a small
+//! line scan; fenced blocks are located with `pulldown-cmark`, whose offset
+//! iterator yields each block's byte span and language tag. Only the `yaml`/`yml`
+//! info string (including the `{.yaml}` attribute form) is matched; tags such as
+//! `yaml+jinja` are intentionally ignored.
+
+mod lint;
+
+pub use lint::lint_markdown_str;
+
+use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+
+/// Which embedded YAML sources to extract from a markdown document.
+#[derive(Debug, Clone, Copy)]
+pub struct MarkdownSources {
+    pub front_matter: bool,
+    pub fenced_blocks: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionKind {
+    FrontMatter,
+    FencedBlock,
+}
+
+/// A slice of YAML lifted out of a markdown document, with the offsets needed to
+/// translate region-local diagnostic positions back to the host file.
+#[derive(Debug, Clone)]
+pub struct EmbeddedRegion {
+    pub kind: RegionKind,
+    /// Number of newlines before the region's first content line. Region line 1
+    /// maps to host line `line_offset + 1`.
+    pub line_offset: usize,
+    /// Common leading indent (in characters) stripped from the region. Added back
+    /// to every diagnostic column. Always 0 for front matter.
+    pub col_offset: usize,
+    pub content: String,
+}
+
+#[must_use]
+pub fn extract_regions(
+    markdown: &str,
+    sources: MarkdownSources,
+) -> Vec<EmbeddedRegion> {
+    let mut regions = Vec::new();
+    if sources.front_matter
+        && let Some(region) = front_matter_region(markdown)
+    {
+        regions.push(region);
+    }
+    if sources.fenced_blocks {
+        collect_fenced_blocks(markdown, &mut regions);
+    }
+    regions
+}
+
+fn front_matter_region(markdown: &str) -> Option<EmbeddedRegion> {
+    let first_newline = markdown.find('\n')?;
+    if !is_front_matter_open(&markdown[..first_newline]) {
+        return None;
+    }
+    let content_start = first_newline + 1;
+    let mut cursor = content_start;
+    while cursor < markdown.len() {
+        let line_end = markdown[cursor..]
+            .find('\n')
+            .map_or(markdown.len(), |offset| cursor + offset);
+        if is_front_matter_close(&markdown[cursor..line_end]) {
+            return Some(EmbeddedRegion {
+                kind: RegionKind::FrontMatter,
+                line_offset: markdown[..content_start].matches('\n').count(),
+                col_offset: 0,
+                content: markdown[content_start..cursor].to_string(),
+            });
+        }
+        cursor = line_end + 1;
+    }
+    None
+}
+
+fn is_front_matter_open(line: &str) -> bool {
+    line.trim_end() == "---"
+}
+
+fn is_front_matter_close(line: &str) -> bool {
+    matches!(line.trim_end(), "---" | "...")
+}
+
+fn collect_fenced_blocks(markdown: &str, regions: &mut Vec<EmbeddedRegion>) {
+    let mut active: Option<FenceAccumulator> = None;
+    for (event, range) in Parser::new_ext(markdown, Options::empty()).into_offset_iter()
+    {
+        match event {
+            Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(info))) => {
+                active = is_yaml_info(&info).then(FenceAccumulator::default);
+            }
+            Event::Text(text) => {
+                if let Some(accumulator) = active.as_mut() {
+                    accumulator.first_byte.get_or_insert(range.start);
+                    accumulator.content.push_str(&text);
+                }
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                if let Some(accumulator) = active.take()
+                    && let Some(first_byte) = accumulator.first_byte
+                {
+                    regions.push(EmbeddedRegion {
+                        kind: RegionKind::FencedBlock,
+                        line_offset: markdown[..first_byte].matches('\n').count(),
+                        col_offset: fence_indent(markdown, first_byte),
+                        content: accumulator.content,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Default)]
+struct FenceAccumulator {
+    content: String,
+    first_byte: Option<usize>,
+}
+
+/// Characters of leading indentation pulldown stripped from the fenced block,
+/// i.e. the column of its first content byte. The block's content always sits on
+/// a line after its opening fence, so a preceding newline is guaranteed.
+fn fence_indent(markdown: &str, content_start: usize) -> usize {
+    let line_start = markdown[..content_start]
+        .rfind('\n')
+        .expect("fenced block content follows its opening fence line")
+        + 1;
+    markdown[line_start..content_start].chars().count()
+}
+
+fn is_yaml_info(info: &str) -> bool {
+    let token = info
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_start_matches('{')
+        .trim_end_matches('}')
+        .trim_start_matches('.');
+    token.eq_ignore_ascii_case("yaml") || token.eq_ignore_ascii_case("yml")
+}

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -23,9 +23,9 @@ fn project(
     (dir, file)
 }
 
-const COLONS_AND_DUPES: &str = "markdown = { files = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\nkey-duplicates = \"enable\"\n";
+const COLONS_AND_DUPES: &str = "files = { markdown = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\nkey-duplicates = \"enable\"\n";
 const COLONS_ONLY: &str =
-    "markdown = { files = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\n";
+    "files = { markdown = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\n";
 
 #[test]
 fn front_matter_and_fenced_blocks_map_to_host_positions() {
@@ -59,7 +59,7 @@ fn indented_fenced_block_adds_indent_to_column() {
 
 #[test]
 fn front_matter_only_source_skips_fenced_blocks() {
-    let config = "markdown = { files = [\"*.md\"], fenced-blocks = false }\n[rules]\ncolons = \"enable\"\n";
+    let config = "files = { markdown = [\"*.md\"] }\nmarkdown = { fenced-blocks = false }\n[rules]\ncolons = \"enable\"\n";
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
@@ -72,7 +72,7 @@ fn front_matter_only_source_skips_fenced_blocks() {
 
 #[test]
 fn fenced_blocks_only_source_skips_front_matter() {
-    let config = "markdown = { files = [\"*.md\"], front-matter = false }\n[rules]\ncolons = \"enable\"\n";
+    let config = "files = { markdown = [\"*.md\"] }\nmarkdown = { front-matter = false }\n[rules]\ncolons = \"enable\"\n";
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
@@ -85,7 +85,7 @@ fn fenced_blocks_only_source_skips_front_matter() {
 
 #[test]
 fn file_shape_rules_are_suppressed_in_embedded_regions() {
-    let config = "markdown = { files = [\"*.md\"] }\n[rules]\ndocument-start = \"enable\"\ncolons = \"enable\"\n";
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ndocument-start = \"enable\"\ncolons = \"enable\"\n";
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
@@ -147,7 +147,7 @@ fn attribute_and_tilde_fences_are_linted() {
 #[test]
 fn whitespace_only_front_matter_is_skipped() {
     let config =
-        "markdown = { files = [\"*.md\"] }\n[rules]\ntrailing-spaces = \"enable\"\n";
+        "files = { markdown = [\"*.md\"] }\n[rules]\ntrailing-spaces = \"enable\"\n";
     let body = "---\n   \n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
@@ -158,15 +158,15 @@ fn whitespace_only_front_matter_is_skipped() {
 }
 
 #[test]
-fn markdown_not_linted_without_files_pattern() {
+fn explicit_markdown_without_files_pattern_is_rejected() {
     let config = "[rules]\ncolons = \"enable\"\n";
     let body = "---\na:  1\n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
-    assert_eq!(code, 0, "stderr={err}");
-    assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
+    assert_eq!(code, 2, "expected usage error: {err}");
+    assert!(err.contains("no source kind matches"), "{err}");
 }
 
 #[test]
@@ -198,4 +198,29 @@ fn directory_scan_discovers_markdown() {
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:4"), "{err}");
+}
+
+#[test]
+fn file_matching_two_kinds_is_a_hard_error() {
+    let config = "files = { yaml = [\"*.md\"], markdown = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\n";
+    let body = "---\na:  1\n---\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 2, "expected overlap error: {err}");
+    assert!(err.contains("matches both"), "{err}");
+}
+
+#[test]
+fn directory_scan_overlap_is_a_hard_error() {
+    let config = "files = { yaml = [\"*.md\"], markdown = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\n";
+    let body = "---\na:  1\n---\n";
+    let (dir, _file) = project(config, "doc.md", body);
+
+    let (code, _out, err) =
+        run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(dir.path()));
+
+    assert_eq!(code, 2, "expected overlap error: {err}");
+    assert!(err.contains("matches both"), "{err}");
 }

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -11,15 +11,6 @@ fn run(cmd: &mut Command) -> (i32, String, String) {
     (code, stdout, stderr)
 }
 
-// Force the standard output format so position assertions are deterministic
-// regardless of auto-detection (CI sets GITHUB_ACTIONS, which selects the
-// `::error file=…,line=…,col=…::` GitHub format instead of `line:col`).
-fn ryl() -> Command {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_ryl"));
-    cmd.arg("--format").arg("standard");
-    cmd
-}
-
 fn project(
     config: &str,
     name: &str,
@@ -41,12 +32,12 @@ fn front_matter_and_fenced_blocks_map_to_host_positions() {
     let body = "---\ntitle:  hello\nduplicate: 1\nduplicate: 2\n---\n\n```yaml\nfoo:  bar\n```\n";
     let (_dir, file) = project(COLONS_AND_DUPES, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
-    assert!(err.contains("2:8") && err.contains("(colons)"), "{err}");
+    assert!(err.contains("2:8") && err.contains("colons"), "{err}");
     assert!(
-        err.contains("4:1") && err.contains("(key-duplicates)"),
+        err.contains("4:1") && err.contains("key-duplicates"),
         "{err}"
     );
     assert!(err.contains("8:6"), "fenced block colon position: {err}");
@@ -57,7 +48,7 @@ fn indented_fenced_block_adds_indent_to_column() {
     let body = "-  item\n\n   ```yaml\n   key:  value\n   ```\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(
@@ -72,7 +63,7 @@ fn front_matter_only_source_skips_fenced_blocks() {
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:4"), "front matter linted: {err}");
@@ -85,7 +76,7 @@ fn fenced_blocks_only_source_skips_front_matter() {
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("6:4"), "fenced block linted: {err}");
@@ -98,12 +89,12 @@ fn file_shape_rules_are_suppressed_in_embedded_regions() {
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
-    assert!(err.contains("(colons)"), "{err}");
+    assert!(err.contains("colons"), "{err}");
     assert!(
-        !err.contains("(document-start)"),
+        !err.contains("document-start"),
         "document-start must be suppressed: {err}"
     );
 }
@@ -113,7 +104,7 @@ fn crlf_markdown_maps_positions() {
     let body = "# t\r\n\r\n```yaml\r\nfoo:  bar\r\n```\r\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("4:6"), "{err}");
@@ -124,7 +115,7 @@ fn multibyte_front_matter_columns_pass_through() {
     let body = "---\ncaf\u{e9}:  x\n---\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:8"), "{err}");
@@ -135,7 +126,7 @@ fn non_yaml_fenced_block_is_ignored() {
     let body = "# t\n\n```python\nx =  1\n```\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, out, err) = run(ryl().arg(&file));
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 0, "stderr={err}");
     assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
@@ -146,7 +137,7 @@ fn attribute_and_tilde_fences_are_linted() {
     let body = "```{.yaml}\na:  1\n```\n\n~~~yml\nb:  2\n~~~\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:4"), "attribute fence: {err}");
@@ -160,7 +151,7 @@ fn whitespace_only_front_matter_is_skipped() {
     let body = "---\n   \n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, out, err) = run(ryl().arg(&file));
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 0, "stderr={err}");
     assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
@@ -172,7 +163,7 @@ fn explicit_markdown_without_files_pattern_is_rejected() {
     let body = "---\na:  1\n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 2, "expected usage error: {err}");
     assert!(err.contains("no source kind matches"), "{err}");
@@ -183,7 +174,9 @@ fn fix_skips_markdown_with_notice() {
     let body = "---\na:  1\n---\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg("--fix").arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--fix")
+        .arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("does not modify markdown files"), "{err}");
@@ -200,7 +193,8 @@ fn directory_scan_discovers_markdown() {
     let body = "---\na:  1\n---\n";
     let (dir, _file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(dir.path()));
+    let (code, _out, err) =
+        run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(dir.path()));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:4"), "{err}");
@@ -212,7 +206,7 @@ fn file_matching_two_kinds_is_a_hard_error() {
     let body = "---\na:  1\n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(&file));
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 2, "expected overlap error: {err}");
     assert!(err.contains("matches both"), "{err}");
@@ -224,7 +218,8 @@ fn directory_scan_overlap_is_a_hard_error() {
     let body = "---\na:  1\n---\n";
     let (dir, _file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(ryl().arg(dir.path()));
+    let (code, _out, err) =
+        run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(dir.path()));
 
     assert_eq!(code, 2, "expected overlap error: {err}");
     assert!(err.contains("matches both"), "{err}");

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -1,0 +1,201 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+fn project(
+    config: &str,
+    name: &str,
+    body: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".ryl.toml"), config).unwrap();
+    let file = dir.path().join(name);
+    fs::write(&file, body).unwrap();
+    (dir, file)
+}
+
+const COLONS_AND_DUPES: &str = "markdown = { files = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\nkey-duplicates = \"enable\"\n";
+const COLONS_ONLY: &str =
+    "markdown = { files = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\n";
+
+#[test]
+fn front_matter_and_fenced_blocks_map_to_host_positions() {
+    let body = "---\ntitle:  hello\nduplicate: 1\nduplicate: 2\n---\n\n```yaml\nfoo:  bar\n```\n";
+    let (_dir, file) = project(COLONS_AND_DUPES, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("2:8") && err.contains("(colons)"), "{err}");
+    assert!(
+        err.contains("4:1") && err.contains("(key-duplicates)"),
+        "{err}"
+    );
+    assert!(err.contains("8:6"), "fenced block colon position: {err}");
+}
+
+#[test]
+fn indented_fenced_block_adds_indent_to_column() {
+    let body = "-  item\n\n   ```yaml\n   key:  value\n   ```\n";
+    let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(
+        err.contains("4:9"),
+        "indent should shift column to 9: {err}"
+    );
+}
+
+#[test]
+fn front_matter_only_source_skips_fenced_blocks() {
+    let config = "markdown = { files = [\"*.md\"], fenced-blocks = false }\n[rules]\ncolons = \"enable\"\n";
+    let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("2:4"), "front matter linted: {err}");
+    assert!(!err.contains("6:4"), "fenced block must be skipped: {err}");
+}
+
+#[test]
+fn fenced_blocks_only_source_skips_front_matter() {
+    let config = "markdown = { files = [\"*.md\"], front-matter = false }\n[rules]\ncolons = \"enable\"\n";
+    let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("6:4"), "fenced block linted: {err}");
+    assert!(!err.contains("2:4"), "front matter must be skipped: {err}");
+}
+
+#[test]
+fn file_shape_rules_are_suppressed_in_embedded_regions() {
+    let config = "markdown = { files = [\"*.md\"] }\n[rules]\ndocument-start = \"enable\"\ncolons = \"enable\"\n";
+    let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("(colons)"), "{err}");
+    assert!(
+        !err.contains("(document-start)"),
+        "document-start must be suppressed: {err}"
+    );
+}
+
+#[test]
+fn crlf_markdown_maps_positions() {
+    let body = "# t\r\n\r\n```yaml\r\nfoo:  bar\r\n```\r\n";
+    let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("4:6"), "{err}");
+}
+
+#[test]
+fn multibyte_front_matter_columns_pass_through() {
+    let body = "---\ncaf\u{e9}:  x\n---\n";
+    let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("2:8"), "{err}");
+}
+
+#[test]
+fn non_yaml_fenced_block_is_ignored() {
+    let body = "# t\n\n```python\nx =  1\n```\n";
+    let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
+
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
+}
+
+#[test]
+fn attribute_and_tilde_fences_are_linted() {
+    let body = "```{.yaml}\na:  1\n```\n\n~~~yml\nb:  2\n~~~\n";
+    let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("2:4"), "attribute fence: {err}");
+    assert!(err.contains("6:4"), "tilde fence: {err}");
+}
+
+#[test]
+fn whitespace_only_front_matter_is_skipped() {
+    let config =
+        "markdown = { files = [\"*.md\"] }\n[rules]\ntrailing-spaces = \"enable\"\n";
+    let body = "---\n   \n---\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
+}
+
+#[test]
+fn markdown_not_linted_without_files_pattern() {
+    let config = "[rules]\ncolons = \"enable\"\n";
+    let body = "---\na:  1\n---\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
+}
+
+#[test]
+fn fix_skips_markdown_with_notice() {
+    let body = "---\na:  1\n---\n";
+    let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--fix")
+        .arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("does not modify markdown files"), "{err}");
+    assert!(err.contains("(0 fixed, 1 remaining)"), "{err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        body,
+        "file must be unchanged"
+    );
+}
+
+#[test]
+fn directory_scan_discovers_markdown() {
+    let body = "---\na:  1\n---\n";
+    let (dir, _file) = project(COLONS_ONLY, "doc.md", body);
+
+    let (code, _out, err) =
+        run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(dir.path()));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("2:4"), "{err}");
+}

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -11,6 +11,15 @@ fn run(cmd: &mut Command) -> (i32, String, String) {
     (code, stdout, stderr)
 }
 
+// Force the standard output format so position assertions are deterministic
+// regardless of auto-detection (CI sets GITHUB_ACTIONS, which selects the
+// `::error file=…,line=…,col=…::` GitHub format instead of `line:col`).
+fn ryl() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_ryl"));
+    cmd.arg("--format").arg("standard");
+    cmd
+}
+
 fn project(
     config: &str,
     name: &str,
@@ -32,7 +41,7 @@ fn front_matter_and_fenced_blocks_map_to_host_positions() {
     let body = "---\ntitle:  hello\nduplicate: 1\nduplicate: 2\n---\n\n```yaml\nfoo:  bar\n```\n";
     let (_dir, file) = project(COLONS_AND_DUPES, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:8") && err.contains("(colons)"), "{err}");
@@ -48,7 +57,7 @@ fn indented_fenced_block_adds_indent_to_column() {
     let body = "-  item\n\n   ```yaml\n   key:  value\n   ```\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(
@@ -63,7 +72,7 @@ fn front_matter_only_source_skips_fenced_blocks() {
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:4"), "front matter linted: {err}");
@@ -76,7 +85,7 @@ fn fenced_blocks_only_source_skips_front_matter() {
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("6:4"), "fenced block linted: {err}");
@@ -89,7 +98,7 @@ fn file_shape_rules_are_suppressed_in_embedded_regions() {
     let body = "---\na:  1\n---\n\n```yaml\nb:  2\n```\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("(colons)"), "{err}");
@@ -104,7 +113,7 @@ fn crlf_markdown_maps_positions() {
     let body = "# t\r\n\r\n```yaml\r\nfoo:  bar\r\n```\r\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("4:6"), "{err}");
@@ -115,7 +124,7 @@ fn multibyte_front_matter_columns_pass_through() {
     let body = "---\ncaf\u{e9}:  x\n---\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:8"), "{err}");
@@ -126,7 +135,7 @@ fn non_yaml_fenced_block_is_ignored() {
     let body = "# t\n\n```python\nx =  1\n```\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 0, "stderr={err}");
     assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
@@ -137,7 +146,7 @@ fn attribute_and_tilde_fences_are_linted() {
     let body = "```{.yaml}\na:  1\n```\n\n~~~yml\nb:  2\n~~~\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:4"), "attribute fence: {err}");
@@ -151,7 +160,7 @@ fn whitespace_only_front_matter_is_skipped() {
     let body = "---\n   \n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 0, "stderr={err}");
     assert!(out.is_empty() && err.is_empty(), "out={out} err={err}");
@@ -163,7 +172,7 @@ fn explicit_markdown_without_files_pattern_is_rejected() {
     let body = "---\na:  1\n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 2, "expected usage error: {err}");
     assert!(err.contains("no source kind matches"), "{err}");
@@ -174,9 +183,7 @@ fn fix_skips_markdown_with_notice() {
     let body = "---\na:  1\n---\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
-        .arg("--fix")
-        .arg(&file));
+    let (code, _out, err) = run(ryl().arg("--fix").arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("does not modify markdown files"), "{err}");
@@ -193,8 +200,7 @@ fn directory_scan_discovers_markdown() {
     let body = "---\na:  1\n---\n";
     let (dir, _file) = project(COLONS_ONLY, "doc.md", body);
 
-    let (code, _out, err) =
-        run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(dir.path()));
+    let (code, _out, err) = run(ryl().arg(dir.path()));
 
     assert_eq!(code, 1, "stderr={err}");
     assert!(err.contains("2:4"), "{err}");
@@ -206,7 +212,7 @@ fn file_matching_two_kinds_is_a_hard_error() {
     let body = "---\na:  1\n---\n";
     let (_dir, file) = project(config, "doc.md", body);
 
-    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+    let (code, _out, err) = run(ryl().arg(&file));
 
     assert_eq!(code, 2, "expected overlap error: {err}");
     assert!(err.contains("matches both"), "{err}");
@@ -218,8 +224,7 @@ fn directory_scan_overlap_is_a_hard_error() {
     let body = "---\na:  1\n---\n";
     let (dir, _file) = project(config, "doc.md", body);
 
-    let (code, _out, err) =
-        run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(dir.path()));
+    let (code, _out, err) = run(ryl().arg(dir.path()));
 
     assert_eq!(code, 2, "expected overlap error: {err}");
     assert!(err.contains("matches both"), "{err}");

--- a/tests/cli_toml_config.rs
+++ b/tests/cli_toml_config.rs
@@ -20,7 +20,7 @@ fn project_toml_overrides_yaml_and_emits_single_warning() {
     fs::write(root.join("dir/b.yaml"), "b: 2\n").unwrap();
     fs::write(
         root.join(".ryl.toml"),
-        "yaml-files = ['**/a.yaml', '**/b.yaml']\n[rules]\nanchors = 'disable'\n",
+        "files = { yaml = ['**/a.yaml', '**/b.yaml'] }\n[rules]\nanchors = 'disable'\n",
     )
     .unwrap();
     fs::write(root.join(".yamllint"), "yaml-files: ['**/a.yaml']\n").unwrap();

--- a/tests/config_markdown.rs
+++ b/tests/config_markdown.rs
@@ -1,0 +1,62 @@
+mod common;
+
+use std::path::PathBuf;
+
+use ryl::config::{Overrides, discover_config_with};
+
+fn config_from_toml(body: &str) -> ryl::config::YamlLintConfig {
+    let path = PathBuf::from("/repo/.ryl.toml");
+    let env = common::fake_env::FakeEnv::new().with_file(path.clone(), body);
+    discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(path),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("toml config should parse")
+    .config
+}
+
+#[test]
+fn markdown_sources_default_to_enabled() {
+    let cfg = config_from_toml("markdown = { files = [\"*.md\"] }\n");
+    assert!(cfg.markdown_front_matter());
+    assert!(cfg.markdown_fenced_blocks());
+}
+
+#[test]
+fn markdown_source_toggles_are_applied() {
+    let cfg = config_from_toml(
+        "markdown = { files = [\"*.md\"], front-matter = false, fenced-blocks = true }\n",
+    );
+    assert!(!cfg.markdown_front_matter());
+    assert!(cfg.markdown_fenced_blocks());
+}
+
+#[test]
+fn markdown_candidate_matches_only_with_files_pattern() {
+    let base = PathBuf::from("/repo");
+    let doc = PathBuf::from("/repo/readme.md");
+
+    let enabled = config_from_toml("markdown = { files = [\"*.md\"] }\n");
+    assert!(enabled.is_markdown_candidate(&doc, &base));
+    let outside_base = PathBuf::from("/elsewhere/notes.md");
+    assert!(enabled.is_markdown_candidate(&outside_base, &base));
+
+    let disabled = config_from_toml("[rules]\ncolons = \"enable\"\n");
+    assert!(!disabled.is_markdown_candidate(&doc, &base));
+}
+
+#[test]
+fn to_toml_string_round_trips_markdown_settings() {
+    let cfg =
+        config_from_toml("markdown = { files = [\"*.md\"], front-matter = false }\n");
+    let rendered = cfg.to_toml_string();
+
+    assert!(rendered.contains("[markdown]"), "{rendered}");
+    assert!(rendered.contains("files"), "{rendered}");
+    assert!(rendered.contains("front-matter = false"), "{rendered}");
+    assert!(rendered.contains("fenced-blocks = true"), "{rendered}");
+}

--- a/tests/config_markdown.rs
+++ b/tests/config_markdown.rs
@@ -82,3 +82,24 @@ fn yaml_files_key_is_rejected_in_toml() {
         "{err}"
     );
 }
+
+#[test]
+fn unknown_keys_in_files_and_markdown_tables_are_rejected() {
+    let path = PathBuf::from("/repo/.ryl.toml");
+    for body in [
+        "[files]\nyml = [\"*.md\"]\n",
+        "[markdown]\nfrontmatter = false\n",
+    ] {
+        let env = common::fake_env::FakeEnv::new().with_file(path.clone(), body);
+        let err = discover_config_with(
+            &[],
+            &Overrides {
+                config_file: Some(path.clone()),
+                config_data: None,
+            },
+            &env,
+        )
+        .expect_err("typo'd key must be rejected");
+        assert!(!err.is_empty(), "expected an error for: {body}");
+    }
+}

--- a/tests/config_markdown.rs
+++ b/tests/config_markdown.rs
@@ -21,7 +21,7 @@ fn config_from_toml(body: &str) -> ryl::config::YamlLintConfig {
 
 #[test]
 fn markdown_sources_default_to_enabled() {
-    let cfg = config_from_toml("markdown = { files = [\"*.md\"] }\n");
+    let cfg = config_from_toml("files = { markdown = [\"*.md\"] }\n");
     assert!(cfg.markdown_front_matter());
     assert!(cfg.markdown_fenced_blocks());
 }
@@ -29,7 +29,7 @@ fn markdown_sources_default_to_enabled() {
 #[test]
 fn markdown_source_toggles_are_applied() {
     let cfg = config_from_toml(
-        "markdown = { files = [\"*.md\"], front-matter = false, fenced-blocks = true }\n",
+        "files = { markdown = [\"*.md\"] }\nmarkdown = { front-matter = false, fenced-blocks = true }\n",
     );
     assert!(!cfg.markdown_front_matter());
     assert!(cfg.markdown_fenced_blocks());
@@ -40,7 +40,7 @@ fn markdown_candidate_matches_only_with_files_pattern() {
     let base = PathBuf::from("/repo");
     let doc = PathBuf::from("/repo/readme.md");
 
-    let enabled = config_from_toml("markdown = { files = [\"*.md\"] }\n");
+    let enabled = config_from_toml("files = { markdown = [\"*.md\"] }\n");
     assert!(enabled.is_markdown_candidate(&doc, &base));
     let outside_base = PathBuf::from("/elsewhere/notes.md");
     assert!(enabled.is_markdown_candidate(&outside_base, &base));
@@ -51,12 +51,34 @@ fn markdown_candidate_matches_only_with_files_pattern() {
 
 #[test]
 fn to_toml_string_round_trips_markdown_settings() {
-    let cfg =
-        config_from_toml("markdown = { files = [\"*.md\"], front-matter = false }\n");
+    let cfg = config_from_toml(
+        "files = { markdown = [\"*.md\"] }\nmarkdown = { front-matter = false }\n",
+    );
     let rendered = cfg.to_toml_string();
 
+    assert!(rendered.contains("[files]"), "{rendered}");
+    assert!(rendered.contains("markdown = [\"*.md\"]"), "{rendered}");
     assert!(rendered.contains("[markdown]"), "{rendered}");
-    assert!(rendered.contains("files"), "{rendered}");
     assert!(rendered.contains("front-matter = false"), "{rendered}");
     assert!(rendered.contains("fenced-blocks = true"), "{rendered}");
+}
+
+#[test]
+fn yaml_files_key_is_rejected_in_toml() {
+    let path = PathBuf::from("/repo/.ryl.toml");
+    let env = common::fake_env::FakeEnv::new()
+        .with_file(path.clone(), "yaml-files = [\"*.yaml\"]\n");
+    let err = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(path),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect_err("yaml-files in TOML must be rejected");
+    assert!(
+        err.contains("yaml-files") && err.contains("[files]"),
+        "{err}"
+    );
 }

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -704,7 +704,7 @@ fn normalize_toml_config_flattens_top_level_fields_and_rules() {
     let parsed = parse_toml_config_str(
         r#"
 ignore = "vendor/**"
-yaml-files = ["*.yaml"]
+files = { yaml = ["*.yaml"] }
 
 [fix]
 unfixable = ["comments"]

--- a/tests/config_to_toml.rs
+++ b/tests/config_to_toml.rs
@@ -149,7 +149,8 @@ fn to_toml_includes_fix_policy() {
     .unwrap();
 
     let toml = ctx.config.to_toml_string();
-    assert!(toml.contains("yaml-files = ["));
+    assert!(toml.contains("[files]"));
+    assert!(toml.contains("yaml = ["));
     assert!(toml.contains("[fix]"));
     assert!(toml.contains("fixable = ["));
     assert!(toml.contains("\"ALL\""));

--- a/tests/config_toml_discovery.rs
+++ b/tests/config_toml_discovery.rs
@@ -56,7 +56,7 @@ fn exact_typed_toml_preserves_runtime_matchers_and_rule_settings() {
     let cfg = PathBuf::from("/repo/.ryl.toml");
     let env = FakeEnv::new().with_cwd(PathBuf::from("/repo")).with_file(
         cfg.clone(),
-        "yaml-files = ['configs/**/*.yaml']\nignore = ['vendor/**']\nlocale = 'en_US.UTF-8'\n[rules]\ndocument-start = 'disable'\n[rules.comments]\nlevel = 'warning'\nrequire-starting-space = true\nignore = ['generated/**']\n",
+        "files = { yaml = ['configs/**/*.yaml'] }\nignore = ['vendor/**']\nlocale = 'en_US.UTF-8'\n[rules]\ndocument-start = 'disable'\n[rules.comments]\nlevel = 'warning'\nrequire-starting-space = true\nignore = ['generated/**']\n",
     );
     let ctx = discover_config_with(
         &[],

--- a/tests/fix_engine.rs
+++ b/tests/fix_engine.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use ryl::config::{Overrides, YamlLintConfig, discover_config};
+use ryl::config::{Overrides, SourceKind, YamlLintConfig, discover_config};
 use ryl::fix::{
     apply_safe_fixes, apply_safe_fixes_in_place, apply_safe_fixes_to_files,
 };
@@ -155,8 +155,18 @@ fn apply_safe_fixes_to_files_updates_each_entry() {
     fs::write(&second, "alpha: beta").unwrap();
     let cfg = config("rules:\n  comments: enable\n  new-line-at-end-of-file: enable\n");
     let files = vec![
-        (first.clone(), dir.path().to_path_buf(), cfg.clone()),
-        (second.clone(), dir.path().to_path_buf(), cfg),
+        (
+            first.clone(),
+            dir.path().to_path_buf(),
+            cfg.clone(),
+            SourceKind::Yaml,
+        ),
+        (
+            second.clone(),
+            dir.path().to_path_buf(),
+            cfg,
+            SourceKind::Yaml,
+        ),
     ];
 
     let stats = apply_safe_fixes_to_files(&files).expect("fixes succeed");

--- a/tests/main_yaml_ok_filtering.rs
+++ b/tests/main_yaml_ok_filtering.rs
@@ -12,7 +12,7 @@ fn run(cmd: &mut Command) -> (i32, String, String) {
 }
 
 #[test]
-fn yaml_files_filtering_excludes_dir_and_explicit() {
+fn yaml_files_filtering_excludes_dir_files() {
     let td = tempdir().unwrap();
     let root = td.path();
     fs::write(root.join("a.yaml"), "a: 1\n").unwrap();
@@ -23,8 +23,22 @@ fn yaml_files_filtering_excludes_dir_and_explicit() {
         .arg("--list-files")
         .arg("-d")
         .arg("yaml-files: ['*.none']\n")
-        .arg(root)
-        .arg(root.join("a.yaml")));
+        .arg(root));
     assert_eq!(code, 0, "expected success: {err}");
     assert!(out.trim().is_empty(), "expected no files listed: {out}");
+}
+
+#[test]
+fn explicit_file_not_matching_any_kind_is_rejected() {
+    let td = tempdir().unwrap();
+    let root = td.path();
+    fs::write(root.join("a.yaml"), "a: 1\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _out, err) = run(Command::new(exe)
+        .arg("-d")
+        .arg("yaml-files: ['*.none']\n")
+        .arg(root.join("a.yaml")));
+    assert_eq!(code, 2, "expected usage error: {err}");
+    assert!(err.contains("no source kind matches"), "{err}");
 }

--- a/tests/markdown_embed.rs
+++ b/tests/markdown_embed.rs
@@ -1,4 +1,5 @@
-use ryl::{MarkdownSources, RegionKind, extract_regions};
+use ryl::config::YamlLintConfig;
+use ryl::{MarkdownSources, RegionKind, extract_regions, lint_markdown_file};
 
 const BOTH: MarkdownSources = MarkdownSources {
     front_matter: true,
@@ -82,4 +83,16 @@ fn yaml_language_tag_variants_are_recognised() {
         assert_eq!(regions.len(), 1, "fence {fence} should be extracted");
         assert_eq!(regions[0].content, "a: 1\n");
     }
+}
+
+#[test]
+fn lint_markdown_file_reports_read_error() {
+    let cfg = YamlLintConfig::default();
+    let err = lint_markdown_file(
+        std::path::Path::new("/no/such/file.md"),
+        &cfg,
+        std::path::Path::new("/"),
+    )
+    .expect_err("missing markdown file should error");
+    assert!(err.contains("failed to read"), "{err}");
 }

--- a/tests/markdown_embed.rs
+++ b/tests/markdown_embed.rs
@@ -1,0 +1,85 @@
+use ryl::{MarkdownSources, RegionKind, extract_regions};
+
+const BOTH: MarkdownSources = MarkdownSources {
+    front_matter: true,
+    fenced_blocks: true,
+};
+
+#[test]
+fn extracts_front_matter_and_fenced_block_with_offsets() {
+    let doc = "---\na: 1\n---\n\n```yaml\nb: 2\n```\n";
+    let regions = extract_regions(doc, BOTH);
+
+    assert_eq!(regions.len(), 2);
+    assert_eq!(regions[0].kind, RegionKind::FrontMatter);
+    assert_eq!(regions[0].line_offset, 1);
+    assert_eq!(regions[0].col_offset, 0);
+    assert_eq!(regions[0].content, "a: 1\n");
+    assert_eq!(regions[1].kind, RegionKind::FencedBlock);
+    assert_eq!(regions[1].line_offset, 5);
+    assert_eq!(regions[1].col_offset, 0);
+    assert_eq!(regions[1].content, "b: 2\n");
+}
+
+#[test]
+fn indented_block_reports_stripped_indent_as_col_offset() {
+    let regions = extract_regions("-  x\n\n   ```yaml\n   k: v\n   ```\n", BOTH);
+
+    assert_eq!(regions.len(), 1);
+    assert_eq!(regions[0].kind, RegionKind::FencedBlock);
+    assert_eq!(regions[0].line_offset, 3);
+    assert_eq!(regions[0].col_offset, 3);
+    assert_eq!(regions[0].content, "k: v\n");
+}
+
+#[test]
+fn source_toggles_select_region_kinds() {
+    let doc = "---\na: 1\n---\n\n```yaml\nb: 2\n```\n";
+
+    let front_only = extract_regions(
+        doc,
+        MarkdownSources {
+            front_matter: true,
+            fenced_blocks: false,
+        },
+    );
+    assert_eq!(front_only.len(), 1);
+    assert_eq!(front_only[0].kind, RegionKind::FrontMatter);
+
+    let fenced_only = extract_regions(
+        doc,
+        MarkdownSources {
+            front_matter: false,
+            fenced_blocks: true,
+        },
+    );
+    assert_eq!(fenced_only.len(), 1);
+    assert_eq!(fenced_only[0].kind, RegionKind::FencedBlock);
+}
+
+#[test]
+fn front_matter_requires_a_closing_delimiter() {
+    assert!(extract_regions("---\na: 1\n", BOTH).is_empty());
+    assert!(extract_regions("not front matter", BOTH).is_empty());
+
+    let dots = extract_regions("---\na: 1\n...\n", BOTH);
+    assert_eq!(dots.len(), 1);
+    assert_eq!(dots[0].content, "a: 1\n");
+}
+
+#[test]
+fn empty_or_unlabelled_blocks_produce_no_regions() {
+    assert!(extract_regions("```yaml\n```\n", BOTH).is_empty());
+    assert!(extract_regions("```\nplain\n```\n", BOTH).is_empty());
+    assert!(extract_regions("```python\nx = 1\n```\n", BOTH).is_empty());
+}
+
+#[test]
+fn yaml_language_tag_variants_are_recognised() {
+    for fence in ["```yaml", "```yml", "```YAML", "```{.yaml}"] {
+        let doc = format!("{fence}\na: 1\n```\n");
+        let regions = extract_regions(&doc, BOTH);
+        assert_eq!(regions.len(), 1, "fence {fence} should be extracted");
+        assert_eq!(regions[0].content, "a: 1\n");
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -21,6 +21,7 @@ nav = [
   { "Rules" = "rules.md" },
   { "Configuration" = [
     { "Presets" = "config-presets.md" },
+    { "YAML in Markdown" = "markdown.md" },
   ]},
   { "YAML version compatibility" = "yaml-version.md" },
 ]


### PR DESCRIPTION
## What

Lint YAML that is **embedded in Markdown** — leading `---` … `---`/`...` front
matter and fenced ` ```yaml `/` ```yml ` blocks (including `{.yaml}` attribute and
`~~~` fences). Each region is linted as its own YAML document and diagnostics are
remapped back to the Markdown file's line/column. Closes #222.

Also reshapes the TOML config onto a unified `[files]` source-kind model.

## Config: `[files]` source kinds (breaking TOML change)

TOML now assigns each file a source kind via a `[files]` table of glob lists:

```toml
[files]
yaml     = ["*.yaml", "*.yml", ".yamllint"]   # default if [files] omitted
markdown = ["*.md", "docs/**/*.md"]           # opt-in: enables markdown linting

[markdown]            # behaviour only
front-matter  = true
fenced-blocks = true
```

- `yaml` defaults to `*.yaml`/`*.yml`/`.yamllint`; setting it replaces the default.
- `markdown` is empty by default — listing globs is what **enables** (and scopes)
  markdown linting. Works for any Markdown-family format (`.qmd`, `.Rmd`, `.mdx`,
  `.markdown`).
- A file matching **two** kinds is a hard error. An **explicitly-passed** file
  matching no kind is rejected with a migration hint; a directory-scanned file
  matching no kind is skipped.
- **`yaml-files` is rejected in TOML** (use `[files].yaml`) — it remains valid in
  the legacy yamllint-compatible YAML config. `ryl --migrate-configs` converts it.

## Behaviour

- Front matter + each fenced block linted independently; `document-start`,
  `document-end`, `new-line-at-end-of-file`, `new-lines` are suppressed inside
  embedded regions (a region is not a standalone file).
- **Check-only**: `--fix` skips Markdown files with a notice (write-back tracked in
  #236).
- Fenced blocks located via `pulldown-cmark`; front matter via a small line scan.

## Use with pre-commit

The published `ryl` hook targets YAML by default; to lint Markdown, add a
`[files].markdown` glob **and** widen the hook (`types_or: [yaml, markdown]`).

## Breaking changes

- TOML `yaml-files` → `[files].yaml` (errors with a hint if still used).
- Explicitly-passed files that match no `[files]` kind are now rejected (exit 2)
  rather than silently linted as YAML.

## Verification

`prek run --all-files` clean; `coverage-missing.sh` reports zero uncovered
regions; docs site builds; dogfooded against an older ryl (which ignores the new
keys and falls back to matching defaults). Reviewed via `/code-review` (xhigh) and
Codex; resulting hardening (`deny_unknown_fields` on the new tables, matcher
dedup) included.

## Follow-ups

- #236 — `--fix` write-back for embedded YAML + lint embedded YAML from stdin.
