### PR TITLE
Property tests for rule checkers + char-column fix (closes #239)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,34 @@ Failing inputs are persisted at `tests/proptest-regressions/property_safe_fix.tx
 and replayed first on every run. That file is committed to git so the regression
 follows the codebase, not the developer's machine.
 
+### Property Tests For Rule Checkers
+
+`tests/property_check.rs` property-tests the **detection** path: it runs every
+rule's `check()` (including the unfixable rules above) over generated YAML and
+asserts two oracle-free invariants — `check()` never panics, and every reported
+violation has an in-bounds, **character-aligned** span (`1 <= line <=
+line_count`, `1 <= column <= chars_on_line + 1`). This is the fast,
+yamllint-free complement to the slow `tests/yamllint_compat_*` differential
+suite; it targets ryl's historically fragile byte<->char offset arithmetic
+(issue #232) rather than semantic correctness.
+
+Layout mirrors the safe-fix suite: `property_check/strategy.rs` generates
+documents biased toward triggering every rule (truthy words, octal/float
+scalars, duplicate/unordered keys, flow spacing, anchors, over-long lines, odd
+indentation, trailing spaces) interleaved with multibyte characters and mixed
+LF/CRLF endings (never a bare `\r`, so line counting always agrees with the
+rules). `property_check/harness.rs` holds the trigger-all config (rule options
+are tuned so each rule actually emits), the per-rule `check()` dispatch, and the
+bounds invariant.
+
+When you add a new rule, extend `collect_spans` in `harness.rs` to call its
+`check()` and add a `(rule-id, triggering-input)` row to `RULE_TRIGGERS` in
+`property_check.rs`. The deterministic `each_rule_triggers_and_reports_in_bounds_spans`
+test asserts each rule fires on its crafted input, so the property assertions
+cannot silently pass vacuously if the generator drifts. Failing inputs persist
+to the committed `tests/proptest-regressions/property_check.txt`. Run with
+`cargo test --test property_check`.
+
 ### Rules Without A Safe `--fix`
 
 These rules are intentionally not part of `SAFE_FIX_RULES`. Each entry is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,10 @@ indentation, trailing spaces) interleaved with multibyte characters and mixed
 LF/CRLF endings (never a bare `\r`, so line counting always agrees with the
 rules). `property_check/harness.rs` holds the trigger-all config (rule options
 are tuned so each rule actually emits), the per-rule `check()` dispatch, and the
-bounds invariant.
+bounds invariant. The dispatch calls each `check()` directly rather than
+`lint_str` on purpose: `lint_str` discards every rule's spans in favour of the
+syntax error when a document fails to parse, but this suite must still bounds-check
+the spans rules emit on input that fails to parse.
 
 When you add a new rule, extend `collect_spans` in `harness.rs` to call its
 `check()` and add a `(rule-id, triggering-input)` row to `RULE_TRIGGERS` in

--- a/src/rules/colons.rs
+++ b/src/rules/colons.rs
@@ -140,8 +140,7 @@ fn evaluate_colon(
         if !skip_after_check && cfg.max_spaces_before >= 0 {
             let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
             if spaces_i64 > cfg.max_spaces_before {
-                let colon_byte = chars[colon_idx].0;
-                let (line, column) = line_and_column(line_starts, colon_byte);
+                let (line, column) = line_and_column(line_starts, colon_idx);
                 let highlight_column = column.saturating_sub(1).max(1);
                 violations.push(Violation {
                     line,
@@ -162,8 +161,7 @@ fn evaluate_colon(
         }
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
         if spaces_i64 > cfg.max_spaces_after {
-            let next_byte = chars[next_char].0;
-            let (line, column) = line_and_column(line_starts, next_byte);
+            let (line, column) = line_and_column(line_starts, next_char);
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {
                 line,
@@ -188,8 +186,7 @@ fn evaluate_question_mark(
     {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
         if spaces_i64 > cfg.max_spaces_after {
-            let next_byte = chars[next_char].0;
-            let (line, column) = line_and_column(line_starts, next_byte);
+            let (line, column) = line_and_column(line_starts, next_char);
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {
                 line,

--- a/src/rules/colons.rs
+++ b/src/rules/colons.rs
@@ -2,7 +2,7 @@ use crate::config::YamlLintConfig;
 use crate::rules::support::punctuation::{
     build_line_starts, collect_scalar_ranges, line_and_column, skip_comment,
 };
-use crate::rules::support::span_utils::containing_scalar_range;
+use crate::rules::support::span_utils::{CharPos, containing_scalar_range};
 
 pub const ID: &str = "colons";
 const TOO_MANY_BEFORE: &str = "too many spaces before colon";
@@ -82,7 +82,7 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
 
     let scalar_ranges = collect_scalar_ranges(buffer);
     let chars: Vec<(usize, char)> = buffer.char_indices().collect();
-    let line_starts = build_line_starts(buffer);
+    let line_starts = build_line_starts(&chars);
 
     let mut scalar_idx = 0usize;
     let mut idx = 0usize;
@@ -121,7 +121,7 @@ fn evaluate_colon(
     violations: &mut Vec<Violation>,
     chars: &[(usize, char)],
     colon_idx: usize,
-    line_starts: &[usize],
+    line_starts: &[CharPos],
 ) {
     let mut skip_after_check = false;
 
@@ -140,7 +140,8 @@ fn evaluate_colon(
         if !skip_after_check && cfg.max_spaces_before >= 0 {
             let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
             if spaces_i64 > cfg.max_spaces_before {
-                let (line, column) = line_and_column(line_starts, colon_idx);
+                let (line, column) =
+                    line_and_column(line_starts, CharPos::new(colon_idx));
                 let highlight_column = column.saturating_sub(1).max(1);
                 violations.push(Violation {
                     line,
@@ -161,7 +162,7 @@ fn evaluate_colon(
         }
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
         if spaces_i64 > cfg.max_spaces_after {
-            let (line, column) = line_and_column(line_starts, next_char);
+            let (line, column) = line_and_column(line_starts, CharPos::new(next_char));
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {
                 line,
@@ -177,7 +178,7 @@ fn evaluate_question_mark(
     violations: &mut Vec<Violation>,
     chars: &[(usize, char)],
     question_idx: usize,
-    line_starts: &[usize],
+    line_starts: &[CharPos],
 ) {
     if cfg.max_spaces_after >= 0
         && is_explicit_question_mark(chars, question_idx)
@@ -186,7 +187,7 @@ fn evaluate_question_mark(
     {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
         if spaces_i64 > cfg.max_spaces_after {
-            let (line, column) = line_and_column(line_starts, next_char);
+            let (line, column) = line_and_column(line_starts, CharPos::new(next_char));
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {
                 line,
@@ -337,7 +338,7 @@ pub fn coverage_is_sequence_indicator(chars: &[(usize, char)], idx: usize) -> bo
 pub fn coverage_evaluate_question_mark(buffer: &str, cfg: &Config) -> Vec<Violation> {
     let chars: Vec<(usize, char)> = buffer.char_indices().collect();
     let mut violations = Vec::new();
-    let line_starts = build_line_starts(buffer);
+    let line_starts = build_line_starts(&chars);
     if let Some((idx, _)) = chars.iter().enumerate().find(|(_, (_, ch))| *ch == '?') {
         evaluate_question_mark(cfg, &mut violations, &chars, idx, &line_starts);
     } else {

--- a/src/rules/commas.rs
+++ b/src/rules/commas.rs
@@ -4,7 +4,7 @@ use crate::rules::support::punctuation::{
     template_double_curly_end,
 };
 use crate::rules::support::span_utils::{
-    BytePos, apply_replacements, containing_scalar_range,
+    BytePos, CharPos, apply_replacements, containing_scalar_range,
 };
 
 pub const ID: &str = "commas";
@@ -104,7 +104,7 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
 
     let scalar_ranges = collect_scalar_ranges(buffer);
     let chars: Vec<(usize, char)> = buffer.char_indices().collect();
-    let line_starts = build_line_starts(buffer);
+    let line_starts = build_line_starts(&chars);
 
     let mut violations = Vec::new();
     let mut contexts: Vec<FlowKind> = Vec::new();
@@ -203,7 +203,7 @@ fn evaluate_comma(
     violations: &mut Vec<Violation>,
     chars: &[(usize, char)],
     comma_idx: usize,
-    line_starts: &[usize],
+    line_starts: &[CharPos],
 ) {
     if let BeforeResult::SameLine { spaces, .. } =
         compute_spaces_before(chars, comma_idx)
@@ -211,7 +211,7 @@ fn evaluate_comma(
     {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
         if spaces_i64 > cfg.max_spaces_before {
-            let (line, column) = line_and_column(line_starts, comma_idx);
+            let (line, column) = line_and_column(line_starts, CharPos::new(comma_idx));
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {
                 line,
@@ -225,7 +225,7 @@ fn evaluate_comma(
         compute_spaces_after(chars, comma_idx)
     {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
-        let (line, column) = line_and_column(line_starts, next_char);
+        let (line, column) = line_and_column(line_starts, CharPos::new(next_char));
         if cfg.max_spaces_after >= 0 && spaces_i64 > cfg.max_spaces_after {
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {

--- a/src/rules/commas.rs
+++ b/src/rules/commas.rs
@@ -211,8 +211,7 @@ fn evaluate_comma(
     {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
         if spaces_i64 > cfg.max_spaces_before {
-            let comma_byte = chars[comma_idx].0;
-            let (line, column) = line_and_column(line_starts, comma_byte);
+            let (line, column) = line_and_column(line_starts, comma_idx);
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {
                 line,
@@ -226,8 +225,7 @@ fn evaluate_comma(
         compute_spaces_after(chars, comma_idx)
     {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
-        let next_byte = chars[next_char].0;
-        let (line, column) = line_and_column(line_starts, next_byte);
+        let (line, column) = line_and_column(line_starts, next_char);
         if cfg.max_spaces_after >= 0 && spaces_i64 > cfg.max_spaces_after {
             let highlight_column = column.saturating_sub(1).max(1);
             violations.push(Violation {

--- a/src/rules/support/flow_collection.rs
+++ b/src/rules/support/flow_collection.rs
@@ -467,8 +467,7 @@ fn handle_open(
     stack: &mut Vec<CollectionState>,
     violations: &mut Vec<Violation>,
 ) {
-    let open_byte = chars[idx].0;
-    let (line, column) = line_and_column(line_starts, open_byte);
+    let (line, column) = line_and_column(line_starts, idx);
     let next_significant = next_significant_index(chars, idx);
 
     let mut skip_open_check = false;
@@ -503,8 +502,7 @@ fn handle_open(
         && let AfterResult::SameLine { spaces, next_idx } =
             compute_spaces_after_open(chars, idx)
     {
-        let next_byte = chars[next_idx].0;
-        let (line, next_column) = line_and_column(line_starts, next_byte);
+        let (line, next_column) = line_and_column(line_starts, next_idx);
         if state.is_empty && chars[next_idx].1 == desc.close {
             record_after_spacing(
                 cfg.effective_min_empty(),
@@ -591,8 +589,7 @@ fn handle_close(
 
     if let Some((spaces, _start_idx)) = compute_spaces_before_close(chars, idx) {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
-        let close_byte = chars[idx].0;
-        let (line, close_column) = line_and_column(line_starts, close_byte);
+        let (line, close_column) = line_and_column(line_starts, idx);
         if cfg.max_spaces_inside() >= 0 && spaces_i64 > cfg.max_spaces_inside() {
             let highlight = close_column.saturating_sub(1).max(1);
             violations.push(Violation {

--- a/src/rules/support/flow_collection.rs
+++ b/src/rules/support/flow_collection.rs
@@ -307,7 +307,7 @@ pub fn check(
     let scalar_ranges = collector.into_sorted();
 
     let chars: Vec<(usize, char)> = buffer.char_indices().collect();
-    let line_starts = build_line_starts(buffer);
+    let line_starts = build_line_starts(&chars);
 
     let mut range_idx = 0usize;
     let mut idx = 0usize;
@@ -463,11 +463,11 @@ fn handle_open(
     desc: &FlowCollectionDescriptor,
     chars: &[(usize, char)],
     idx: usize,
-    line_starts: &[usize],
+    line_starts: &[CharPos],
     stack: &mut Vec<CollectionState>,
     violations: &mut Vec<Violation>,
 ) {
-    let (line, column) = line_and_column(line_starts, idx);
+    let (line, column) = line_and_column(line_starts, CharPos::new(idx));
     let next_significant = next_significant_index(chars, idx);
 
     let mut skip_open_check = false;
@@ -502,7 +502,7 @@ fn handle_open(
         && let AfterResult::SameLine { spaces, next_idx } =
             compute_spaces_after_open(chars, idx)
     {
-        let (line, next_column) = line_and_column(line_starts, next_idx);
+        let (line, next_column) = line_and_column(line_starts, CharPos::new(next_idx));
         if state.is_empty && chars[next_idx].1 == desc.close {
             record_after_spacing(
                 cfg.effective_min_empty(),
@@ -575,7 +575,7 @@ fn handle_close(
     desc: &FlowCollectionDescriptor,
     chars: &[(usize, char)],
     idx: usize,
-    line_starts: &[usize],
+    line_starts: &[CharPos],
     stack: &mut Vec<CollectionState>,
     violations: &mut Vec<Violation>,
 ) {
@@ -589,7 +589,7 @@ fn handle_close(
 
     if let Some((spaces, _start_idx)) = compute_spaces_before_close(chars, idx) {
         let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
-        let (line, close_column) = line_and_column(line_starts, idx);
+        let (line, close_column) = line_and_column(line_starts, CharPos::new(idx));
         if cfg.max_spaces_inside() >= 0 && spaces_i64 > cfg.max_spaces_inside() {
             let highlight = close_column.saturating_sub(1).max(1);
             violations.push(Violation {

--- a/src/rules/support/punctuation.rs
+++ b/src/rules/support/punctuation.rs
@@ -29,37 +29,41 @@ pub(crate) fn skip_comment(chars: &[(usize, char)], mut idx: usize) -> usize {
     idx
 }
 
-/// Character indices (not byte offsets) at which each line begins, so columns
-/// derived from them are 1-indexed character counts that match yamllint on
-/// multibyte lines (issue #232).
-pub(crate) fn build_line_starts(buffer: &str) -> Vec<usize> {
-    let mut starts = vec![0];
-    let mut chars = buffer.chars().peekable();
-    let mut char_idx = 0usize;
-    while let Some(ch) = chars.next() {
-        char_idx += 1;
-        match ch {
-            '\n' => starts.push(char_idx),
-            '\r' => {
-                if chars.peek() == Some(&'\n') {
-                    chars.next();
-                    char_idx += 1;
-                }
-                starts.push(char_idx);
+/// `CharPos` (not byte offset) at which each line begins, so columns derived
+/// from them are 1-indexed character counts that match yamllint on multibyte
+/// lines (issue #232). Takes the caller's existing `char_indices()` slice so
+/// the buffer is not decoded a second time.
+pub(crate) fn build_line_starts(chars: &[(usize, char)]) -> Vec<CharPos> {
+    let mut starts = vec![CharPos::new(0)];
+    let mut idx = 0usize;
+    while idx < chars.len() {
+        match chars[idx].1 {
+            '\n' => {
+                starts.push(CharPos::new(idx + 1));
+                idx += 1;
             }
-            _ => {}
+            '\r' => {
+                if chars.get(idx + 1).is_some_and(|(_, ch)| *ch == '\n') {
+                    starts.push(CharPos::new(idx + 2));
+                    idx += 2;
+                } else {
+                    starts.push(CharPos::new(idx + 1));
+                    idx += 1;
+                }
+            }
+            _ => idx += 1,
         }
     }
 
     starts
 }
 
-/// Resolve a character index into a 1-indexed `(line, column)` pair. `char_idx`
-/// must be a character index (e.g. an index into `char_indices()`), never a
-/// byte offset, so the column counts characters rather than bytes (issue #232).
+/// Resolve a `CharPos` into a 1-indexed `(line, column)` pair. Taking a
+/// `CharPos` (rather than a raw `usize`) makes passing a byte offset a compile
+/// error, so the column always counts characters rather than bytes (issue #232).
 pub(crate) fn line_and_column(
-    line_starts: &[usize],
-    char_idx: usize,
+    line_starts: &[CharPos],
+    char_idx: CharPos,
 ) -> (usize, usize) {
     let mut left = 0usize;
     let mut right = line_starts.len();
@@ -74,7 +78,7 @@ pub(crate) fn line_and_column(
     }
 
     let line_start = line_starts[left];
-    (left + 1, char_idx - line_start + 1)
+    (left + 1, char_idx.get() - line_start.get() + 1)
 }
 
 pub(crate) fn template_double_curly_end(

--- a/src/rules/support/punctuation.rs
+++ b/src/rules/support/punctuation.rs
@@ -29,44 +29,44 @@ pub(crate) fn skip_comment(chars: &[(usize, char)], mut idx: usize) -> usize {
     idx
 }
 
+/// Character indices (not byte offsets) at which each line begins, so columns
+/// derived from them are 1-indexed character counts that match yamllint on
+/// multibyte lines (issue #232).
 pub(crate) fn build_line_starts(buffer: &str) -> Vec<usize> {
-    let mut starts = Vec::new();
-    starts.push(0);
-
-    let bytes = buffer.as_bytes();
-    let mut idx = 0usize;
-    while idx < bytes.len() {
-        match bytes[idx] {
-            b'\n' => {
-                starts.push(idx + 1);
-                idx += 1;
-            }
-            b'\r' => {
-                if idx + 1 < bytes.len() && bytes[idx + 1] == b'\n' {
-                    starts.push(idx + 2);
-                    idx += 2;
-                } else {
-                    starts.push(idx + 1);
-                    idx += 1;
+    let mut starts = vec![0];
+    let mut chars = buffer.chars().peekable();
+    let mut char_idx = 0usize;
+    while let Some(ch) = chars.next() {
+        char_idx += 1;
+        match ch {
+            '\n' => starts.push(char_idx),
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                    char_idx += 1;
                 }
+                starts.push(char_idx);
             }
-            _ => idx += 1,
+            _ => {}
         }
     }
 
     starts
 }
 
+/// Resolve a character index into a 1-indexed `(line, column)` pair. `char_idx`
+/// must be a character index (e.g. an index into `char_indices()`), never a
+/// byte offset, so the column counts characters rather than bytes (issue #232).
 pub(crate) fn line_and_column(
     line_starts: &[usize],
-    byte_idx: usize,
+    char_idx: usize,
 ) -> (usize, usize) {
     let mut left = 0usize;
     let mut right = line_starts.len();
 
     while left + 1 < right {
         let mid = usize::midpoint(left, right);
-        if line_starts[mid] <= byte_idx {
+        if line_starts[mid] <= char_idx {
             left = mid;
         } else {
             right = mid;
@@ -74,7 +74,7 @@ pub(crate) fn line_and_column(
     }
 
     let line_start = line_starts[left];
-    (left + 1, byte_idx - line_start + 1)
+    (left + 1, char_idx - line_start + 1)
 }
 
 pub(crate) fn template_double_curly_end(

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -118,7 +118,7 @@ fn multibyte_front_matter_columns_pass_through() {
     let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
 
     assert_eq!(code, 1, "stderr={err}");
-    assert!(err.contains("2:8"), "{err}");
+    assert!(err.contains("2:7"), "{err}");
 }
 
 #[test]

--- a/tests/colons_rule.rs
+++ b/tests/colons_rule.rs
@@ -312,3 +312,16 @@ fn coverage_check_handles_comment_crlf() {
     let result = colons::check("# heading\r\nkey: value\n", &cfg);
     assert!(result.is_empty());
 }
+
+#[test]
+fn columns_count_characters_not_bytes_with_multibyte_key() {
+    let cfg = Config::new_for_tests(0, 1);
+    let points = violation_points("ééé :  1\n", cfg);
+    assert_eq!(
+        points,
+        vec![
+            (1, 4, "too many spaces before colon".to_string()),
+            (1, 7, "too many spaces after colon".to_string()),
+        ]
+    );
+}

--- a/tests/flow_collection_rule_behavior.rs
+++ b/tests/flow_collection_rule_behavior.rs
@@ -354,3 +354,40 @@ fn brackets_fix_returns_none_for_multiline_collection() {
     let fixed = brackets::fix("seq: [\n  1,\n  2\n]\n", &cfg);
     assert_eq!(fixed, None);
 }
+
+#[test]
+fn brace_columns_count_characters_not_bytes() {
+    let defaults = BracesConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    assert_hits(
+        &defaults,
+        "{ééé: 1 }\n",
+        braces::check,
+        vec![BracesViolation {
+            line: 1,
+            column: 8,
+            message: "too many spaces inside braces".to_string(),
+        }],
+    );
+}
+
+#[test]
+fn bracket_columns_count_characters_not_bytes() {
+    let defaults = BracketsConfig::new_for_tests(Forbid::None, 0, 0, -1, -1);
+    assert_hits(
+        &defaults,
+        "[ 世界 ]\n",
+        brackets::check,
+        vec![
+            BracketsViolation {
+                line: 1,
+                column: 2,
+                message: "too many spaces inside brackets".to_string(),
+            },
+            BracketsViolation {
+                line: 1,
+                column: 5,
+                message: "too many spaces inside brackets".to_string(),
+            },
+        ],
+    );
+}

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -1,0 +1,109 @@
+//! Property-based robustness tests for the rule `check()` functions.
+//!
+//! Two oracle-free invariants are asserted for every rule on arbitrary
+//! generated YAML:
+//!  1. **No panic** — `check()` is total (satisfied implicitly when the test
+//!     body completes).
+//!  2. **In-bounds, char-aligned spans** — every reported violation has
+//!     `1 <= line <= line_count` and `1 <= column <= chars_on_line + 1`,
+//!     measured in characters (issue #232's classic failure modes).
+//!
+//! This complements `tests/property_safe_fix.rs` (the fix path) and the
+//! slow `tests/yamllint_compat_*` differential suite (semantic correctness):
+//! it is a fast, yamllint-free safety/bounds layer.
+//!
+//! Submodules:
+//!  * `strategy` — the triggering YAML generator.
+//!  * `harness` — the trigger-all config, per-rule dispatch, and the bounds
+//!    invariant. Deterministic siblings below pin one triggering input per
+//!    rule (so the property assertions cannot silently pass vacuously if the
+//!    generator drifts) plus the multibyte flow-punctuation regressions that
+//!    guard the issue-#232 char-column fix.
+
+#[path = "property_check/harness.rs"]
+mod harness;
+#[path = "property_check/strategy.rs"]
+mod strategy;
+
+use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+
+use harness::{check_spans_in_bounds, collect_spans, trigger_all_config};
+use strategy::arb_document;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 512,
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "tests/proptest-regressions/property_check.txt",
+        ))),
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn rule_checks_never_panic_and_report_in_bounds_spans(document in arb_document()) {
+        let content = document.render();
+        let spans = collect_spans(&content, trigger_all_config());
+        if let Err(message) = check_spans_in_bounds(&content, &spans) {
+            return Err(TestCaseError::fail(message));
+        }
+    }
+}
+
+const RULE_TRIGGERS: &[(&str, &str)] = &[
+    ("anchors", "a: *missing\n"),
+    ("braces", "a: { b: 1 }\n"),
+    ("brackets", "a: [ 1 ]\n"),
+    ("colons", "a :  b\n"),
+    ("commas", "a: [1 ,2]\n"),
+    ("comments", "a: 1\n#bad\n"),
+    ("comments-indentation", "a: 1\n   # over-indented\nb: 2\n"),
+    ("document-end", "a: 1\n"),
+    ("document-start", "a: 1\n"),
+    ("empty-lines", "a: 1\n\n\n\nb: 2\n"),
+    ("empty-values", "a:\n"),
+    ("float-values", "a: .5\n"),
+    ("hyphens", "a:\n  -  x\n"),
+    ("indentation", "a:\n   b: 1\n"),
+    ("key-duplicates", "a: 1\na: 2\n"),
+    ("key-ordering", "b: 1\na: 2\n"),
+    ("line-length", "a: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"),
+    ("new-line-at-end-of-file", "a: 1"),
+    ("new-lines", "a: 1\r\n"),
+    ("octal-values", "a: 010\n"),
+    ("quoted-strings", "a: 'plain'\n"),
+    ("trailing-spaces", "a: 1   \n"),
+    ("truthy", "a: Yes\n"),
+];
+
+#[test]
+fn each_rule_triggers_and_reports_in_bounds_spans() {
+    for (rule, input) in RULE_TRIGGERS {
+        let spans = collect_spans(input, trigger_all_config());
+        assert!(
+            spans.iter().any(|span| span.rule == *rule),
+            "expected rule `{rule}` to fire on {input:?}, collected {spans:?}"
+        );
+        check_spans_in_bounds(input, &spans).unwrap_or_else(|message| {
+            panic!("crafted trigger for `{rule}`: {message}")
+        });
+    }
+}
+
+#[test]
+fn multibyte_flow_punctuation_spans_stay_in_bounds() {
+    let inputs = [
+        "{ééé: 1 }\n",
+        "ééé :  1\n",
+        "[ééé , a]\n",
+        "[ 世界 ]\n",
+        "k🦀: { å:  1 }\n",
+        "a:\r\n  - 世\r\n  -  🦀\r\n",
+    ];
+    for input in inputs {
+        let spans = collect_spans(input, trigger_all_config());
+        check_spans_in_bounds(input, &spans).unwrap_or_else(|message| {
+            panic!("multibyte regression (issue #232): {message}")
+        });
+    }
+}

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -1,25 +1,3 @@
-//! Property-based robustness tests for the rule `check()` functions.
-//!
-//! Two oracle-free invariants are asserted for every rule on arbitrary
-//! generated YAML:
-//!  1. **No panic** — `check()` is total (satisfied implicitly when the test
-//!     body completes).
-//!  2. **In-bounds, char-aligned spans** — every reported violation has
-//!     `1 <= line <= line_count` and `1 <= column <= chars_on_line + 1`,
-//!     measured in characters (issue #232's classic failure modes).
-//!
-//! This complements `tests/property_safe_fix.rs` (the fix path) and the
-//! slow `tests/yamllint_compat_*` differential suite (semantic correctness):
-//! it is a fast, yamllint-free safety/bounds layer.
-//!
-//! Submodules:
-//!  * `strategy` — the triggering YAML generator.
-//!  * `harness` — the trigger-all config, per-rule dispatch, and the bounds
-//!    invariant. Deterministic siblings below pin one triggering input per
-//!    rule (so the property assertions cannot silently pass vacuously if the
-//!    generator drifts) plus the multibyte flow-punctuation regressions that
-//!    guard the issue-#232 char-column fix.
-
 #[path = "property_check/harness.rs"]
 mod harness;
 #[path = "property_check/strategy.rs"]

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -1,7 +1,3 @@
-//! Shared machinery for the rule-checker property suite: the trigger-all
-//! config, the per-rule `check()` dispatch, and the two oracle-free
-//! invariants (no panic, in-bounds char-aligned spans).
-
 use std::sync::LazyLock;
 
 use ryl::config::YamlLintConfig;
@@ -14,10 +10,6 @@ pub struct Span {
     pub column: usize,
 }
 
-// Options are chosen so every rule actually emits on triggering input rather
-// than passing vacuously: float-values/anchors/octal-values need their
-// forbid-* flags on, line-length is tightened, quoted-strings runs in
-// only-when-needed mode, and new-lines expects unix endings.
 const TRIGGER_ALL_RULES: &str = "rules:
   anchors:
     forbid-undeclared-aliases: true
@@ -81,10 +73,6 @@ macro_rules! collect_standard {
     }};
 }
 
-/// Run every rule's `check()` over `content` and return each reported
-/// violation's position. Driving the checks directly (rather than `lint_str`)
-/// keeps the spans of rules that fire on input that fails to parse, which
-/// `lint_str` discards in favour of the syntax error.
 #[must_use]
 pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     let mut spans = Vec::new();
@@ -137,9 +125,6 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     spans
 }
 
-/// Per-line character counts (terminator excluded). The count matches the
-/// line count every rule derives because the generator never emits a bare
-/// `\r`, so `\n` alone delimits lines.
 #[must_use]
 pub fn line_char_lengths(content: &str) -> Vec<usize> {
     content
@@ -148,13 +133,6 @@ pub fn line_char_lengths(content: &str) -> Vec<usize> {
         .collect()
 }
 
-/// Assert each span lands inside the document: `1 <= line <= line_count` and
-/// `1 <= column <= chars_on_line + 1` (columns are 1-indexed character
-/// counts, and a rule may legitimately point one past the last character).
-///
-/// # Errors
-///
-/// Returns the offending span description when an invariant is violated.
 pub fn check_spans_in_bounds(content: &str, spans: &[Span]) -> Result<(), String> {
     let lengths = line_char_lengths(content);
     for span in spans {

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -1,0 +1,178 @@
+//! Shared machinery for the rule-checker property suite: the trigger-all
+//! config, the per-rule `check()` dispatch, and the two oracle-free
+//! invariants (no panic, in-bounds char-aligned spans).
+
+use std::sync::LazyLock;
+
+use ryl::config::YamlLintConfig;
+use ryl::rules::{new_line_at_end_of_file, new_lines, trailing_spaces};
+
+#[derive(Debug, Clone)]
+pub struct Span {
+    pub rule: &'static str,
+    pub line: usize,
+    pub column: usize,
+}
+
+// Options are chosen so every rule actually emits on triggering input rather
+// than passing vacuously: float-values/anchors/octal-values need their
+// forbid-* flags on, line-length is tightened, quoted-strings runs in
+// only-when-needed mode, and new-lines expects unix endings.
+const TRIGGER_ALL_RULES: &str = "rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments: enable
+  comments-indentation: enable
+  document-end: enable
+  document-start: enable
+  empty-lines: enable
+  empty-values: enable
+  float-values:
+    require-numeral-before-decimal: true
+    forbid-scientific-notation: true
+    forbid-nan: true
+    forbid-inf: true
+  hyphens: enable
+  indentation:
+    spaces: 2
+    indent-sequences: true
+  key-duplicates: enable
+  key-ordering: enable
+  line-length:
+    max: 20
+    allow-non-breakable-words: false
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  octal-values: enable
+  quoted-strings:
+    quote-type: single
+    required: only-when-needed
+  trailing-spaces: enable
+  truthy: enable
+";
+
+#[must_use]
+pub fn trigger_all_config() -> &'static YamlLintConfig {
+    static CONFIG: LazyLock<YamlLintConfig> = LazyLock::new(|| {
+        YamlLintConfig::from_yaml_str(TRIGGER_ALL_RULES)
+            .expect("property-check trigger config must parse")
+    });
+    &CONFIG
+}
+
+macro_rules! collect_standard {
+    ($spans:ident, $cfg:expr, $content:expr, $module:path) => {{
+        use $module as rule;
+        let resolved = rule::Config::resolve($cfg);
+        for violation in rule::check($content, &resolved) {
+            $spans.push(Span {
+                rule: rule::ID,
+                line: violation.line,
+                column: violation.column,
+            });
+        }
+    }};
+}
+
+/// Run every rule's `check()` over `content` and return each reported
+/// violation's position. Driving the checks directly (rather than `lint_str`)
+/// keeps the spans of rules that fire on input that fails to parse, which
+/// `lint_str` discards in favour of the syntax error.
+#[must_use]
+pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_standard!(spans, cfg, content, ryl::rules::anchors);
+    collect_standard!(spans, cfg, content, ryl::rules::braces);
+    collect_standard!(spans, cfg, content, ryl::rules::brackets);
+    collect_standard!(spans, cfg, content, ryl::rules::colons);
+    collect_standard!(spans, cfg, content, ryl::rules::commas);
+    collect_standard!(spans, cfg, content, ryl::rules::comments);
+    collect_standard!(spans, cfg, content, ryl::rules::comments_indentation);
+    collect_standard!(spans, cfg, content, ryl::rules::document_end);
+    collect_standard!(spans, cfg, content, ryl::rules::document_start);
+    collect_standard!(spans, cfg, content, ryl::rules::empty_lines);
+    collect_standard!(spans, cfg, content, ryl::rules::empty_values);
+    collect_standard!(spans, cfg, content, ryl::rules::float_values);
+    collect_standard!(spans, cfg, content, ryl::rules::hyphens);
+    collect_standard!(spans, cfg, content, ryl::rules::indentation);
+    collect_standard!(spans, cfg, content, ryl::rules::key_duplicates);
+    collect_standard!(spans, cfg, content, ryl::rules::key_ordering);
+    collect_standard!(spans, cfg, content, ryl::rules::line_length);
+    collect_standard!(spans, cfg, content, ryl::rules::octal_values);
+    collect_standard!(spans, cfg, content, ryl::rules::quoted_strings);
+    collect_standard!(spans, cfg, content, ryl::rules::truthy);
+
+    if let Some(violation) = new_line_at_end_of_file::check(content) {
+        spans.push(Span {
+            rule: new_line_at_end_of_file::ID,
+            line: violation.line,
+            column: violation.column,
+        });
+    }
+    let new_lines_cfg = new_lines::Config::resolve(cfg);
+    if let Some(violation) =
+        new_lines::check(content, new_lines_cfg, new_lines::platform_newline())
+    {
+        spans.push(Span {
+            rule: new_lines::ID,
+            line: violation.line,
+            column: violation.column,
+        });
+    }
+    for violation in trailing_spaces::check(content) {
+        spans.push(Span {
+            rule: trailing_spaces::ID,
+            line: violation.line,
+            column: violation.column,
+        });
+    }
+
+    spans
+}
+
+/// Per-line character counts (terminator excluded). The count matches the
+/// line count every rule derives because the generator never emits a bare
+/// `\r`, so `\n` alone delimits lines.
+#[must_use]
+pub fn line_char_lengths(content: &str) -> Vec<usize> {
+    content
+        .split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line).chars().count())
+        .collect()
+}
+
+/// Assert each span lands inside the document: `1 <= line <= line_count` and
+/// `1 <= column <= chars_on_line + 1` (columns are 1-indexed character
+/// counts, and a rule may legitimately point one past the last character).
+///
+/// # Errors
+///
+/// Returns the offending span description when an invariant is violated.
+pub fn check_spans_in_bounds(content: &str, spans: &[Span]) -> Result<(), String> {
+    let lengths = line_char_lengths(content);
+    for span in spans {
+        if span.line < 1 || span.line > lengths.len() {
+            return Err(format!(
+                "rule `{}` reported line {} outside 1..={} for input {content:?}",
+                span.rule,
+                span.line,
+                lengths.len()
+            ));
+        }
+        let max_column = lengths[span.line - 1] + 1;
+        if span.column < 1 || span.column > max_column {
+            return Err(format!(
+                "rule `{}` reported column {} outside 1..={} on line {} for input {content:?}",
+                span.rule, span.column, max_column, span.line
+            ));
+        }
+    }
+    Ok(())
+}

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -1,13 +1,3 @@
-//! Proptest generator for the rule-checker robustness suite.
-//!
-//! It renders small YAML documents biased toward triggering every rule
-//! (truthy words, octal/float scalars, duplicate and unordered keys, flow
-//! spacing, anchors, over-long lines, odd indentation, trailing spaces,
-//! oddly-indented comments), interleaved with multibyte characters and mixed
-//! LF/CRLF line endings so the byte<->char offset math inside each `check()`
-//! is exercised. Bare `\r` is never emitted so a generated document's line
-//! boundaries always agree with every rule's line counting.
-
 use proptest::prelude::*;
 
 #[derive(Debug, Clone, Copy)]

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -1,0 +1,268 @@
+//! Proptest generator for the rule-checker robustness suite.
+//!
+//! It renders small YAML documents biased toward triggering every rule
+//! (truthy words, octal/float scalars, duplicate and unordered keys, flow
+//! spacing, anchors, over-long lines, odd indentation, trailing spaces,
+//! oddly-indented comments), interleaved with multibyte characters and mixed
+//! LF/CRLF line endings so the byte<->char offset math inside each `check()`
+//! is exercised. Bare `\r` is never emitted so a generated document's line
+//! boundaries always agree with every rule's line counting.
+
+use proptest::prelude::*;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Newline {
+    Lf,
+    Crlf,
+}
+
+impl Newline {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Lf => "\n",
+            Self::Crlf => "\r\n",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Line {
+    Entry {
+        indent: u8,
+        key: String,
+        spaces_before_colon: u8,
+        spaces_after_colon: u8,
+        value: String,
+        comment: Option<(u8, String)>,
+        trailing_spaces: u8,
+    },
+    SeqItem {
+        indent: u8,
+        spaces_after_dash: u8,
+        value: String,
+        trailing_spaces: u8,
+    },
+    Comment {
+        indent: u8,
+        spaces_after_hash: u8,
+        text: String,
+    },
+    DocumentStart,
+    DocumentEnd,
+    Blank {
+        spaces: u8,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct Document {
+    pub lines: Vec<(Line, Newline)>,
+    pub has_final_newline: bool,
+}
+
+fn push_spaces(out: &mut String, count: u8) {
+    for _ in 0..count {
+        out.push(' ');
+    }
+}
+
+impl Line {
+    fn render(&self, out: &mut String) {
+        match self {
+            Self::Entry {
+                indent,
+                key,
+                spaces_before_colon,
+                spaces_after_colon,
+                value,
+                comment,
+                trailing_spaces,
+            } => {
+                push_spaces(out, *indent);
+                out.push_str(key);
+                push_spaces(out, *spaces_before_colon);
+                out.push(':');
+                push_spaces(out, *spaces_after_colon);
+                out.push_str(value);
+                if let Some((spaces_after_hash, text)) = comment {
+                    out.push_str("  #");
+                    push_spaces(out, *spaces_after_hash);
+                    out.push_str(text);
+                }
+                push_spaces(out, *trailing_spaces);
+            }
+            Self::SeqItem {
+                indent,
+                spaces_after_dash,
+                value,
+                trailing_spaces,
+            } => {
+                push_spaces(out, *indent);
+                out.push('-');
+                push_spaces(out, *spaces_after_dash);
+                out.push_str(value);
+                push_spaces(out, *trailing_spaces);
+            }
+            Self::Comment {
+                indent,
+                spaces_after_hash,
+                text,
+            } => {
+                push_spaces(out, *indent);
+                out.push('#');
+                push_spaces(out, *spaces_after_hash);
+                out.push_str(text);
+            }
+            Self::DocumentStart => out.push_str("---"),
+            Self::DocumentEnd => out.push_str("..."),
+            Self::Blank { spaces } => push_spaces(out, *spaces),
+        }
+    }
+}
+
+impl Document {
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        let last = self.lines.len().saturating_sub(1);
+        for (index, (line, newline)) in self.lines.iter().enumerate() {
+            line.render(&mut out);
+            if index < last || self.has_final_newline {
+                out.push_str(newline.as_str());
+            }
+        }
+        out
+    }
+}
+
+fn arb_multibyte() -> impl Strategy<Value = char> {
+    prop_oneof![Just('é'), Just('—'), Just('世'), Just('🦀'), Just('å')]
+}
+
+fn arb_key() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("a".to_string()),
+        Just("b".to_string()),
+        Just("c".to_string()),
+        Just("dup".to_string()),
+        Just("café".to_string()),
+        Just("Yes".to_string()),
+        Just("On".to_string()),
+        arb_multibyte().prop_map(|ch| format!("k{ch}")),
+    ]
+}
+
+fn arb_value() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        Just("value".to_string()),
+        Just("Yes".to_string()),
+        Just("No".to_string()),
+        Just("Off".to_string()),
+        Just("True".to_string()),
+        Just("010".to_string()),
+        Just("0o17".to_string()),
+        Just("0.5".to_string()),
+        Just(".5".to_string()),
+        Just("1e3".to_string()),
+        Just(".inf".to_string()),
+        Just(".nan".to_string()),
+        Just("'plain'".to_string()),
+        Just("\"plain\"".to_string()),
+        Just("[a , b]".to_string()),
+        Just("{ a: 1 }".to_string()),
+        Just("[ ]".to_string()),
+        Just("{}".to_string()),
+        Just("&anchor value".to_string()),
+        Just("*anchor".to_string()),
+        Just("x".repeat(40)),
+        Just("word ".repeat(8)),
+        arb_multibyte().prop_map(|ch| format!("v{ch}")),
+    ]
+}
+
+fn arb_text() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("note".to_string()),
+        Just(String::new()),
+        arb_multibyte().prop_map(|ch| format!("c{ch}")),
+    ]
+}
+
+fn arb_entry() -> impl Strategy<Value = Line> {
+    (
+        0u8..=4,
+        arb_key(),
+        0u8..=2,
+        0u8..=3,
+        arb_value(),
+        prop::option::of((0u8..=2, arb_text())),
+        0u8..=3,
+    )
+        .prop_map(
+            |(
+                indent,
+                key,
+                spaces_before_colon,
+                spaces_after_colon,
+                value,
+                comment,
+                trailing_spaces,
+            )| Line::Entry {
+                indent,
+                key,
+                spaces_before_colon,
+                spaces_after_colon,
+                value,
+                comment,
+                trailing_spaces,
+            },
+        )
+}
+
+fn arb_seq_item() -> impl Strategy<Value = Line> {
+    (0u8..=4, 0u8..=3, arb_value(), 0u8..=3).prop_map(
+        |(indent, spaces_after_dash, value, trailing_spaces)| Line::SeqItem {
+            indent,
+            spaces_after_dash,
+            value,
+            trailing_spaces,
+        },
+    )
+}
+
+fn arb_comment() -> impl Strategy<Value = Line> {
+    (0u8..=4, 0u8..=2, arb_text()).prop_map(|(indent, spaces_after_hash, text)| {
+        Line::Comment {
+            indent,
+            spaces_after_hash,
+            text,
+        }
+    })
+}
+
+fn arb_line() -> impl Strategy<Value = Line> {
+    prop_oneof![
+        10 => arb_entry(),
+        3 => arb_seq_item(),
+        2 => arb_comment(),
+        1 => Just(Line::DocumentStart),
+        1 => Just(Line::DocumentEnd),
+        2 => (0u8..=3).prop_map(|spaces| Line::Blank { spaces }),
+    ]
+}
+
+fn arb_newline() -> impl Strategy<Value = Newline> {
+    prop_oneof![Just(Newline::Lf), Just(Newline::Crlf)]
+}
+
+pub fn arb_document() -> impl Strategy<Value = Document> {
+    (
+        prop::collection::vec((arb_line(), arb_newline()), 1..=8),
+        any::<bool>(),
+    )
+        .prop_map(|(lines, has_final_newline)| Document {
+            lines,
+            has_final_newline,
+        })
+}

--- a/tests/proptest-regressions/property_check.txt
+++ b/tests/proptest-regressions/property_check.txt
@@ -1,0 +1,6 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.

--- a/tests/rule_commas.rs
+++ b/tests/rule_commas.rs
@@ -255,3 +255,16 @@ fn fix_ignores_commas_inside_double_curly_templates() {
     let fixed = commas::fix("value: {{ foo(1,2) }}\n", &cfg);
     assert_eq!(fixed, None);
 }
+
+#[test]
+fn column_counts_characters_not_bytes_before_comma() {
+    let diagnostics = commas::check("[ééé , a]\n", &defaults());
+    assert_eq!(
+        diagnostics,
+        vec![Violation {
+            line: 1,
+            column: 5,
+            message: "too many spaces before comma".to_string(),
+        }]
+    );
+}


### PR DESCRIPTION
## Summary

Implements #239: a fast, yamllint-free property suite over every rule's `check()`, and fixes the byte-vs-char column bug it surfaced.

### New property suite (`tests/property_check.rs` + `property_check/{strategy,harness}.rs`)

Asserts two oracle-free invariants for **every** rule (including the unfixable ones with no `--fix`):

1. **No panic** — `check()` is total on any generated input.
2. **In-bounds, char-aligned spans** — every violation has `1 ≤ line ≤ line_count` and `1 ≤ column ≤ chars_on_line + 1`, measured in **characters**.

The generator is biased toward triggering every rule (truthy words, octal/float scalars, duplicate/unordered keys, flow spacing, anchors, over-long lines, odd indentation, trailing spaces, oddly-indented comments), laced with multibyte chars (`é — 世 🦀 å`) and mixed LF/CRLF endings to stress the byte↔char offset math. A deterministic `RULE_TRIGGERS` table pins one triggering input per rule so the property assertions can't pass vacuously if the generator drifts (verified: all 23 rules fire across a 4000-doc sample; invariant holds across 30k cases). Complements `tests/property_safe_fix.rs` (fix path) and the slow `tests/yamllint_compat_*` differential suite (semantic correctness).

### Bug it found and fixed (#232-class)

`build_line_starts`/`line_and_column` in `src/rules/support/punctuation.rs` were **byte**-based, so **commas / colons / braces / brackets** reported byte columns that overshot yamllint's character columns on multibyte lines — e.g. `{éé: 1 }` gave `1:9` vs yamllint's `1:7`. Made the helpers char-based and updated all call sites; the other rules already use char-based positions (`granit Marker::col()` / `chars().count()`), so only these four needed it.

- Corrected `tests/cli_markdown_embed.rs` (`2:8`→`2:7`), which had baked in the byte bug.
- Added exact-column regression tests to the colons/commas/flow rule test files (validated against real yamllint).

### Review-driven follow-up (2nd commit)

- Typed the column helper with the `CharPos` newtype (#232): `line_and_column` now takes `CharPos`, so passing a bare `chars[idx].0` byte offset — the mistake that caused the bug — is a **compile error**.
- `build_line_starts` now scans the caller's existing `char_indices()` slice instead of re-decoding, removing a redundant UTF-8 pass per `check()`.

## Verification

- `prek run --all-files`: all hooks pass.
- Full suite: 1107 tests pass.
- Coverage: zero missed lines/regions.
- `src/` net change is small (the fix simplified call sites); growth is the test suite.
- Codex review + a multi-angle `/code-review`: no correctness defects.

Closes #239.