### PR TITLE
Markdown embedding follow-ups: `--fix` write-back + stdin + `--markdown` (closes #236)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,33 @@ cannot silently pass vacuously if the generator drifts. Failing inputs persist
 to the committed `tests/proptest-regressions/property_check.txt`. Run with
 `cargo test --test property_check`.
 
+### Property Tests For Markdown `--fix`
+
+`tests/property_markdown_fix.rs` property-tests `fix::fix_markdown_str` — the
+write-back of safe fixes into YAML embedded in Markdown. It reuses the safe-fix
+YAML generator via `#[path]` (`property_safe_fix/{ast,strategy,config}.rs`) and
+wraps generated `Document`s into a Markdown host (`property_markdown_fix/wrap.rs`):
+optional front matter plus prose-separated fenced `yaml`/`yml` blocks at varied
+indent (0–3), fence char, info string, and LF/CRLF. The invariants are
+oracle-free and run across the same config matrix as the safe-fix suite:
+
+1. **Host preservation** — every byte outside the embedded regions is identical
+   after `--fix`, and region count/kinds are stable (the anti-corruption check).
+2. **Parse preservation** — each region's parsed YAML value is unchanged.
+3. **Region correctness** — each region is either left untouched or rewritten to
+   exactly `apply_safe_fixes_filtered(content, …, suppressed_rules(kind))` (markdown
+   path ≡ direct path, modulo re-indent/newline).
+4. **Idempotence** — feeding the fixed output back through `fix_markdown_str`
+   yields no further change.
+
+Deterministic siblings pin a known-dirty front-matter + indented-block document, a
+CRLF block, and a ragged-indent block (asserting the guard skips it), so the random
+invariants cannot pass vacuously. Failing inputs persist to the committed
+`tests/proptest-regressions/property_markdown_fix.txt`. Run with
+`cargo test --test property_markdown_fix`. The new write-back rules already live in
+`SAFE_FIX_RULES`; this suite needs extension only if the Markdown extractor/wrapper
+grows new region shapes (add a `wrap.rs` variant and a deterministic sibling).
+
 ### Rules Without A Safe `--fix`
 
 These rules are intentionally not part of `SAFE_FIX_RULES`. Each entry is the
@@ -384,21 +411,30 @@ sticking to the quick-status step above.
   file matching two kinds is a hard error. `yaml-files` is rejected in TOML (use
   `[files].yaml`); it remains valid in the legacy YAML config.
 - Markdown embedding (off by default; enabled by listing `[files].markdown`
+  globs, or for one run with the `--markdown` flag which injects default markdown
   globs): ryl extracts front matter and fenced `yaml`/`yml` blocks (each linted as
   its own document), mapping diagnostics back to the Markdown file. The
   `[markdown]` table's `front-matter`/`fenced-blocks` booleans (default true)
   select sources. The extractor lives in `src/markdown_embed/` (fenced blocks via
-  `pulldown-cmark`; front matter via a line scan). `document-start`,
-  `document-end`, `new-line-at-end-of-file`, and `new-lines` are suppressed inside
-  embedded regions. `--fix` skips Markdown files (check-only) and prints a notice.
-  See `docs/markdown.md`.
+  `pulldown-cmark`; front matter via a line scan); each `EmbeddedRegion` carries the
+  raw source `raw_span` used by write-back and the per-line column remap.
+  `document-start`, `document-end`, `new-line-at-end-of-file`, and `new-lines` are
+  suppressed inside embedded regions via `fix::suppressed_rules(kind)` (shared by
+  the check and fix paths). `--fix` writes safe fixes back into the Markdown
+  (`fix::fix_markdown_str`): it re-indents to the fence column, preserves CRLF, and
+  only rewrites a region whose fixed YAML can be re-indented to reproduce the
+  original bytes exactly (the reconstruct-and-verify guard) — ragged/tab/other
+  non-round-trippable regions are reported but left untouched, so write-back cannot
+  corrupt a document. See `docs/markdown.md`.
 - Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding
   detection as files. `-` cannot be combined with other inputs and is not
   compatible with `--fix`. `--stdin-filename <PATH>` (ruff convention) sets
   the diagnostic label, anchors project-config discovery at the given path's
-  parent, and runs `yaml-files`, per-file-ignore, and per-rule `ignore`
-  matching against that path. Omitting `--stdin-filename` labels diagnostics
-  as `<stdin>`, anchors config discovery at CWD, and skips all path-based
-  filtering (`yaml-files`, per-file-ignores, per-rule `ignore`) so every
-  enabled rule runs against the input.
+  parent, resolves the source kind from `[files]` (so a `markdown`-matching path
+  is linted as embedded YAML), and runs `yaml-files`, per-file-ignore, and per-rule
+  `ignore` matching against that path. Omitting `--stdin-filename` labels
+  diagnostics as `<stdin>`, anchors config discovery at CWD, and skips all
+  path-based filtering (`yaml-files`, per-file-ignores, per-rule `ignore`) so every
+  enabled rule runs against the input; pass `--markdown` to lint that input as
+  Markdown rather than plain YAML.
 - Exit codes: `0` (ok/none), `1` (invalid YAML), `2` (usage error).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -403,11 +403,11 @@ sticking to the quick-status step above.
   `document-start`, `document-end`, `new-line-at-end-of-file`, and `new-lines` are
   suppressed inside embedded regions via `fix::suppressed_rules(kind)` (shared by
   the check and fix paths). `--fix` writes safe fixes back into the Markdown
-  (`fix::fix_markdown_str`): it re-indents to the fence column, preserves CRLF, and
-  only rewrites a region whose fixed YAML can be re-indented to reproduce the
-  original bytes exactly (the reconstruct-and-verify guard) — ragged/tab/other
-  non-round-trippable regions are reported but left untouched, so write-back cannot
-  corrupt a document. See `docs/markdown.md`.
+  (`fix::fix_markdown_str`): it re-applies each line's stripped prefix (spaces, a
+  blockquote `> `, or a tab), preserves CRLF, and only rewrites a region when that
+  reproduces the original bytes exactly (the reconstruct-and-verify guard) — a
+  region whose lines lack a single shared prefix (ragged) is reported but left
+  untouched, so write-back cannot corrupt a document. See `docs/markdown.md`.
 - Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding
   detection as files. `-` cannot be combined with other inputs and is not
   compatible with `--fix`. `--stdin-filename <PATH>` (ruff convention) sets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,12 @@ ryl is a CLI tool for linting yaml files
 
 ## Automated Tests
 
-- Don't use comments in tests, use meaningful function names, and variable names to
-  convey the test purpose.
+- Convey a test's purpose with meaningful function and variable names, and convey
+  what each check verifies with assertion messages. Comments in tests follow the
+  same bar as the rest of the codebase (see Coding Standards): keep them minimal and
+  reserve them for genuinely non-obvious trade-offs, opaque mechanics, or
+  module/harness orientation (e.g. a `//!` header describing a property suite's
+  invariants and reuse) — never to narrate what a self-evident test already says.
 - Every line of code has a maintenance cost, so don't add tests that don't meaningfully
   increase code coverage. Aim for full branch coverage but also minimise the tests code
   lines to src code lines ratio.
@@ -179,28 +183,19 @@ to the committed `tests/proptest-regressions/property_check.txt`. Run with
 
 `tests/property_markdown_fix.rs` property-tests `fix::fix_markdown_str` — the
 write-back of safe fixes into YAML embedded in Markdown. It reuses the safe-fix
-YAML generator via `#[path]` (`property_safe_fix/{ast,strategy,config}.rs`) and
-wraps generated `Document`s into a Markdown host (`property_markdown_fix/wrap.rs`):
-optional front matter plus prose-separated fenced `yaml`/`yml` blocks at varied
-indent (0–3), fence char, info string, and LF/CRLF. The invariants are
-oracle-free and run across the same config matrix as the safe-fix suite:
+generator via `#[path]` (`property_safe_fix/{ast,strategy,config}.rs`), wraps the
+generated `Document`s into a Markdown host (`property_markdown_fix/wrap.rs`), and
+asserts four oracle-free invariants across the safe-fix config matrix: host bytes
+outside regions stay byte-identical (with region count/kinds stable), each region's
+parsed value is preserved, each region is either untouched or rewritten to exactly
+its `apply_safe_fixes_filtered` form, and the operation is idempotent. Deterministic
+siblings pin known-dirty / CRLF / ragged / fence-crossing-front-matter cases so the
+random invariants cannot pass vacuously.
 
-1. **Host preservation** — every byte outside the embedded regions is identical
-   after `--fix`, and region count/kinds are stable (the anti-corruption check).
-2. **Parse preservation** — each region's parsed YAML value is unchanged.
-3. **Region correctness** — each region is either left untouched or rewritten to
-   exactly `apply_safe_fixes_filtered(content, …, suppressed_rules(kind))` (markdown
-   path ≡ direct path, modulo re-indent/newline).
-4. **Idempotence** — feeding the fixed output back through `fix_markdown_str`
-   yields no further change.
-
-Deterministic siblings pin a known-dirty front-matter + indented-block document, a
-CRLF block, and a ragged-indent block (asserting the guard skips it), so the random
-invariants cannot pass vacuously. Failing inputs persist to the committed
-`tests/proptest-regressions/property_markdown_fix.txt`. Run with
-`cargo test --test property_markdown_fix`. The new write-back rules already live in
-`SAFE_FIX_RULES`; this suite needs extension only if the Markdown extractor/wrapper
-grows new region shapes (add a `wrap.rs` variant and a deterministic sibling).
+Extend this suite only when the Markdown extractor/wrapper grows new region shapes:
+add a `wrap.rs` variant and a deterministic sibling. Failing inputs persist to the
+committed `tests/proptest-regressions/property_markdown_fix.txt`; run with
+`cargo test --test property_markdown_fix`.
 
 ### Rules Without A Safe `--fix`
 
@@ -271,21 +266,6 @@ hunting through scattered tips:
    on the problematic lines.
 8. If cached coverage lingers, clear `target/llvm-cov-target` and rerun.
 
-## Code Size Workflow
-
-After finishing feature work, use this order before committing:
-
-1. Run `prek run --all-files` and rerun it until all automatic fixes have stabilised.
-2. Run `./scripts/coverage-missing.sh` (Unix) or
-   `pwsh ./scripts/coverage-missing.ps1` (Windows) and keep iterating until coverage
-   is back to 100%.
-3. If the coverage command fails for reasons unrelated to uncovered lines, run the
-   affected tests manually, fix them, then rerun the coverage command.
-4. Once lint, tests, and coverage are green, inspect code size with
-   `uv run scripts/source_size.py --compare-to <branch-or-ref>`.
-5. If the growth looks high for the functionality added, look for ways to reduce code
-   size or make the implementation DRYer before committing.
-
 ### Coverage-Friendly Rust Idioms
 
 - Guard invariants with `expect` (or an early `return Err(...)`) when the
@@ -328,7 +308,9 @@ sticking to the quick-status step above.
   helpers in `crate::rules::span_utils` instead of reinventing byte/char conversions.
   When writing tests, prefer inputs like `"café"` or `"å"` to ensure coverage of
   character vs byte offset logic.
-- Use meaningful function and variable names in tests—comments are discouraged.
+- Lean on meaningful function/variable names and assertion messages to make tests
+  self-documenting; add a comment only where it explains a non-obvious trade-off or
+  opaque mechanic that names cannot (the standard minimal-comment bar applies).
 - `#[cfg(test)]` modules inside `src/` is forbidden; add coverage through integration
   tests in `tests/` so LLVM regions stay unique.
 - CLI/system tests that drive `env!("CARGO_BIN_EXE_ryl")` run under CI's environment,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -639,9 +639,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd_cesu8"
@@ -2547,18 +2547,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -127,13 +127,15 @@ also be turned on for a single run from the command line:
 
 - `--markdown` enables Markdown linting using default globs (`*.md`, `*.markdown`,
   `*.mdx`, `*.qmd`, `*.Rmd`) without editing config. It is a no-op when
-  `[files].markdown` is already set.
-- Reading from stdin honours the source kind: `ryl - --stdin-filename doc.md` lints
-  the piped bytes as Markdown when `doc.md` matches the `markdown` globs (front
-  matter and fenced blocks are extracted exactly as for a file on disk). Without
-  `--stdin-filename`, pass `--markdown` to treat the piped bytes as Markdown
-  (otherwise stdin is linted as plain YAML). As with files, `--fix` is not supported
-  when reading from stdin.
+  `[files].markdown` is already set, and its injected globs **win** over the `yaml`
+  globs for an overlapping file (so the flag never aborts a run whose `yaml` globs
+  happen to match a Markdown extension). When linting stdin, `--markdown` forces the
+  input to be treated as Markdown regardless of `--stdin-filename`.
+- Reading from stdin otherwise honours the source kind: `ryl - --stdin-filename
+  doc.md` lints the piped bytes as Markdown when `doc.md` matches the `markdown`
+  globs (front matter and fenced blocks are extracted exactly as for a file on
+  disk). Without `--stdin-filename` and without `--markdown`, stdin is linted as
+  plain YAML. As with files, `--fix` is not supported when reading from stdin.
 
 ## Use with pre-commit
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -28,7 +28,13 @@ markdown = ["*.md", "docs/**/*.md"]           # opt-in: enables markdown linting
 ```
 
 - `yaml` defaults to `["*.yaml", "*.yml", ".yamllint"]`; setting it replaces the
-  default.
+  default. Add patterns for YAML stored under less-common names or extensions — for
+  example Citation File Format (`*.cff`), clang's `.clang-format` / `.clang-tidy`,
+  or Common Workflow Language (`*.cwl`):
+  `yaml = ["*.yaml", "*.yml", "*.cff", ".clang-format", "*.cwl"]`. Globs match exact
+  filenames and extensionless dotfiles too. (Avoid pointing it at templated
+  pseudo-YAML such as SaltStack `*.sls` or `*.yaml.j2`, which embed Jinja and are not
+  valid standalone YAML.)
 - `markdown` is empty by default — listing patterns is what **enables** markdown
   linting (and scopes it, so only matching files are touched).
 - A file that matches **more than one** kind is a hard error (a file has exactly
@@ -54,19 +60,48 @@ Set either flag to `false` to lint only the other source.
 
 The `markdown` kind is not tied to the `.md` extension. Front matter is found with
 a format-agnostic line scan and fenced blocks are located with a CommonMark parser,
-so any Markdown-superset format works — just map its extension to the `markdown`
-kind:
+so any Markdown-superset format works — map its extension(s) to the `markdown` kind:
 
 ```toml
 [files]
 markdown = ["*.md", "*.markdown", "*.qmd", "*.Rmd", "*.mdx"]
 ```
 
+Or, for a one-off run without editing config, pass `--markdown`, which enables the
+`markdown` kind with those default globs:
+
+```sh
+ryl --markdown docs/        # scan a tree for *.md/*.markdown/*.qmd/*.Rmd/*.mdx
+ryl --markdown report.qmd   # a single Quarto document
+cat SKILL.md | ryl --markdown -   # from stdin (e.g. an editor / pre-commit)
+```
+
 This lints the YAML front matter and fenced `yaml`/`yml` blocks in Quarto (`.qmd`),
 RMarkdown (`.Rmd`), MDX (`.mdx`), and similar documents. Format-specific constructs
-that are not CommonMark (e.g. MDX/JSX, Quarto executable `{python}` chunks) are
-simply ignored — only YAML front matter and `yaml`/`yml` fenced blocks are
+that are not CommonMark (e.g. MDX/JSX, Quarto/RMarkdown executable `{r}`/`{python}`
+chunks) are ignored — only YAML front matter and `yaml`/`yml` fenced blocks are
 extracted.
+
+In practice Quarto and RMarkdown keep their YAML almost entirely in **front matter**
+(their code chunks are ` ```{r} `/` ```{python} `, not ` ```yaml `), so linting them
+mostly exercises the front-matter path. For example, `ryl --markdown report.qmd`
+checks the leading block of:
+
+````qmd
+---
+title: "Quarterly Report"
+format:
+  html:
+    toc:  true
+---
+
+## Section
+````
+
+and reports the extra space after `toc:` at its real line and column inside the
+`.qmd` file. The same applies to **agent skill files**: a `SKILL.md` is YAML front
+matter (`name`, `description`) plus prose, so `ryl --markdown SKILL.md` (or a
+`markdown = ["**/SKILL.md"]` glob) lints that block.
 
 ## How rules apply
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -142,18 +142,19 @@ columns include the block's indentation.
 ## `--fix`
 
 `--fix` applies the same safe fixes to each embedded region and writes the result
-back into the Markdown document, re-indenting fixed YAML to its fence column and
-preserving the document's line endings (CRLF stays CRLF). The four file-shape rules
-suppressed in check mode are also excluded from fixing, so a fragment never gains a
-`---`/`...` marker or a trailing newline.
+back into the Markdown document, re-applying whatever prefix the parser stripped
+from each line — leading spaces, a blockquote `> `, or a tab — and preserving the
+document's line endings (CRLF stays CRLF). The four file-shape rules suppressed in
+check mode are also excluded from fixing, so a fragment never gains a `---`/`...`
+marker or a trailing newline.
 
-Write-back is **conservative by construction**: ryl only rewrites a region when its
-fixed YAML can be re-indented to reproduce the region's original bytes exactly. A
-region it cannot reproduce — ragged indentation (content lines indented less than
-the fence), tab indentation, or other non-uniform layouts — is left **byte-for-byte
-untouched** while still being reported. This guarantees `--fix` can never corrupt a
-Markdown document: the worst case is that an unusual region is reported but not
-auto-fixed.
+Write-back is **conservative by construction**: ryl only rewrites a region when
+re-applying that prefix reproduces the region's original bytes exactly. A region it
+cannot reproduce — one whose lines do not share a single prefix (ragged indentation
+where content lines are indented less than the fence, or other non-uniform layouts)
+— is left **byte-for-byte untouched** while still being reported. This guarantees
+`--fix` can never corrupt a Markdown document: the worst case is that an unusual
+region is reported but not auto-fixed.
 
 ## Linting Markdown from stdin and the CLI
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -106,9 +106,34 @@ columns include the block's indentation.
 
 ## `--fix`
 
-`--fix` does **not** modify Markdown files; embedded YAML is checked only. When a
-run includes Markdown files, `ryl` prints a one-line note and leaves those files
-untouched while still reporting their diagnostics.
+`--fix` applies the same safe fixes to each embedded region and writes the result
+back into the Markdown document, re-indenting fixed YAML to its fence column and
+preserving the document's line endings (CRLF stays CRLF). The four file-shape rules
+suppressed in check mode are also excluded from fixing, so a fragment never gains a
+`---`/`...` marker or a trailing newline.
+
+Write-back is **conservative by construction**: ryl only rewrites a region when its
+fixed YAML can be re-indented to reproduce the region's original bytes exactly. A
+region it cannot reproduce — ragged indentation (content lines indented less than
+the fence), tab indentation, or other non-uniform layouts — is left **byte-for-byte
+untouched** while still being reported. This guarantees `--fix` can never corrupt a
+Markdown document: the worst case is that an unusual region is reported but not
+auto-fixed.
+
+## Linting Markdown from stdin and the CLI
+
+Markdown linting is normally enabled by listing `[files].markdown` globs, but it can
+also be turned on for a single run from the command line:
+
+- `--markdown` enables Markdown linting using default globs (`*.md`, `*.markdown`,
+  `*.mdx`, `*.qmd`, `*.Rmd`) without editing config. It is a no-op when
+  `[files].markdown` is already set.
+- Reading from stdin honours the source kind: `ryl - --stdin-filename doc.md` lints
+  the piped bytes as Markdown when `doc.md` matches the `markdown` globs (front
+  matter and fenced blocks are extracted exactly as for a file on disk). Without
+  `--stdin-filename`, pass `--markdown` to treat the piped bytes as Markdown
+  (otherwise stdin is linted as plain YAML). As with files, `--fix` is not supported
+  when reading from stdin.
 
 ## Use with pre-commit
 

--- a/img/benchmark-5x5-5runs.svg
+++ b/img/benchmark-5x5-5runs.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-18T23:20:02.966670</dc:date>
+    <dc:date>2026-05-31T11:21:40.794219</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 65.633182 357.54
 L 65.633182 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
@@ -104,7 +104,7 @@ z
      <g id="line2d_3">
       <path d="M 119.166136 357.54
 L 119.166136 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
@@ -153,7 +153,7 @@ z
      <g id="line2d_5">
       <path d="M 172.699091 357.54
 L 172.699091 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
@@ -189,7 +189,7 @@ z
      <g id="line2d_7">
       <path d="M 226.232045 357.54
 L 226.232045 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
@@ -231,7 +231,7 @@ z
      <g id="line2d_9">
       <path d="M 279.765 357.54
 L 279.765 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
@@ -278,7 +278,7 @@ z
      <g id="line2d_11">
       <path d="M 333.297955 357.54
 L 333.297955 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
@@ -305,7 +305,7 @@ z
      <g id="line2d_13">
       <path d="M 386.830909 357.54
 L 386.830909 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
@@ -361,7 +361,7 @@ z
      <g id="line2d_15">
       <path d="M 440.363864 357.54
 L 440.363864 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_8">
@@ -408,7 +408,7 @@ z
      <g id="line2d_17">
       <path d="M 493.896818 357.54
 L 493.896818 50.64
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_18"/>
      <g id="text_9">
@@ -747,14 +747,14 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 44.22 344.243444
-L 515.31 344.243444
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 344.198029
+L 515.31 344.198029
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_20"/>
      <g id="text_11">
       <!-- 0.0 -->
-      <g style="fill: #262626" transform="translate(24.816875 348.042662) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 347.997248) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794
 L 1344 794
@@ -772,14 +772,14 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 44.22 283.532381
-L 515.31 283.532381
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 283.289669
+L 515.31 283.289669
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_22"/>
      <g id="text_12">
       <!-- 0.5 -->
-      <g style="fill: #262626" transform="translate(24.816875 287.3316) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 287.088887) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
@@ -788,14 +788,14 @@ L 515.31 283.532381
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 44.22 222.821319
-L 515.31 222.821319
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 222.381308
+L 515.31 222.381308
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_24"/>
      <g id="text_13">
       <!-- 1.0 -->
-      <g style="fill: #262626" transform="translate(24.816875 226.620537) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 226.180527) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
@@ -804,14 +804,14 @@ L 515.31 222.821319
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 44.22 162.110256
-L 515.31 162.110256
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 161.472948
+L 515.31 161.472948
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_26"/>
      <g id="text_14">
       <!-- 1.5 -->
-      <g style="fill: #262626" transform="translate(24.816875 165.909475) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 165.272167) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
@@ -820,14 +820,14 @@ L 515.31 162.110256
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 44.22 101.399194
-L 515.31 101.399194
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 100.564587
+L 515.31 100.564587
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_28"/>
      <g id="text_15">
       <!-- 2.0 -->
-      <g style="fill: #262626" transform="translate(24.816875 105.198412) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 104.363806) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
@@ -1012,118 +1012,118 @@ z
    </g>
    <g id="FillBetweenPolyCollection_1">
     <defs>
-     <path id="mbfcd7944fd" d="M 65.633182 -52.441362
+     <path id="md9a63995a7" d="M 65.633182 -52.533119
 L 65.633182 -52.41
-L 172.699091 -52.509078
-L 279.765 -52.62921
-L 386.830909 -52.754647
-L 493.896818 -52.885417
-L 493.896818 -52.964156
-L 493.896818 -52.964156
-L 386.830909 -52.862404
-L 279.765 -52.720766
-L 172.699091 -52.590042
-L 65.633182 -52.441362
+L 172.699091 -52.459202
+L 279.765 -52.571938
+L 386.830909 -52.663265
+L 493.896818 -52.755785
+L 493.896818 -52.787149
+L 493.896818 -52.787149
+L 386.830909 -52.769039
+L 279.765 -52.686094
+L 172.699091 -52.548908
+L 65.633182 -52.533119
 z
 " style="stroke: #a6cee4; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#mbfcd7944fd" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#md9a63995a7" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_2">
     <defs>
-     <path id="me2da78e8be" d="M 65.633182 -52.623293
-L 65.633182 -52.484507
-L 172.699091 -52.688924
-L 279.765 -52.859797
-L 386.830909 -53.096744
-L 493.896818 -53.313781
-L 493.896818 -53.50399
-L 493.896818 -53.50399
-L 386.830909 -53.312518
-L 279.765 -52.901779
-L 172.699091 -52.750583
-L 65.633182 -52.623293
+     <path id="mb3530a9b3d" d="M 65.633182 -52.495297
+L 65.633182 -52.454444
+L 172.699091 -52.714139
+L 279.765 -52.818549
+L 386.830909 -53.036496
+L 493.896818 -53.208964
+L 493.896818 -53.260741
+L 493.896818 -53.260741
+L 386.830909 -53.070424
+L 279.765 -52.85874
+L 172.699091 -52.754657
+L 65.633182 -52.495297
 z
 " style="stroke: #6aaed6; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#me2da78e8be" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#mb3530a9b3d" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_3">
     <defs>
-     <path id="ma2f31d9fae" d="M 65.633182 -52.75334
-L 65.633182 -52.628642
-L 172.699091 -52.870276
-L 279.765 -53.321353
-L 386.830909 -53.473612
-L 493.896818 -53.947105
-L 493.896818 -54.141892
-L 493.896818 -54.141892
-L 386.830909 -53.483173
-L 279.765 -53.409856
-L 172.699091 -53.105235
-L 65.633182 -52.75334
+     <path id="m17d667fb6c" d="M 65.633182 -52.585756
+L 65.633182 -52.558285
+L 172.699091 -52.899091
+L 279.765 -53.115605
+L 386.830909 -53.542944
+L 493.896818 -53.634922
+L 493.896818 -53.707364
+L 493.896818 -53.707364
+L 386.830909 -53.593234
+L 279.765 -53.221285
+L 172.699091 -52.934647
+L 65.633182 -52.585756
 z
 " style="stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#ma2f31d9fae" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#m17d667fb6c" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_4">
     <defs>
-     <path id="m02fb1e8ae9" d="M 65.633182 -52.842307
-L 65.633182 -52.791378
-L 172.699091 -53.141922
-L 279.765 -53.604935
-L 386.830909 -53.84782
-L 493.896818 -54.284171
-L 493.896818 -54.77066
-L 493.896818 -54.77066
-L 386.830909 -54.155403
-L 279.765 -53.841021
-L 172.699091 -53.269544
-L 65.633182 -52.842307
+     <path id="mce8dbf758c" d="M 65.633182 -52.825042
+L 65.633182 -52.72379
+L 172.699091 -53.166312
+L 279.765 -53.514845
+L 386.830909 -53.927323
+L 493.896818 -54.445142
+L 493.896818 -54.505278
+L 493.896818 -54.505278
+L 386.830909 -54.000295
+L 279.765 -53.572128
+L 172.699091 -53.191574
+L 65.633182 -52.825042
 z
 " style="stroke: #1764ab; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#m02fb1e8ae9" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#mce8dbf758c" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_5">
     <defs>
-     <path id="m8b2ea78a05" d="M 65.633182 -53.070607
-L 65.633182 -52.912889
-L 172.699091 -53.275562
-L 279.765 -53.8639
-L 386.830909 -54.323
-L 493.896818 -54.483751
-L 493.896818 -54.807349
-L 493.896818 -54.807349
-L 386.830909 -54.56142
-L 279.765 -54.03337
-L 172.699091 -53.302516
-L 65.633182 -53.070607
+     <path id="mf96da72052" d="M 65.633182 -52.89396
+L 65.633182 -52.767268
+L 172.699091 -53.242421
+L 279.765 -53.623796
+L 386.830909 -54.093459
+L 493.896818 -54.638065
+L 493.896818 -54.80114
+L 493.896818 -54.80114
+L 386.830909 -54.166553
+L 279.765 -53.801682
+L 172.699091 -53.354811
+L 65.633182 -52.89396
 z
 " style="stroke: #083c7d; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#m8b2ea78a05" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#mf96da72052" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="line2d_29">
-    <path d="M 65.633182 343.574319
-L 172.699091 343.45044
-L 279.765 343.325012
-L 386.830909 343.191475
-L 493.896818 343.075213
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.52844
+L 172.699091 343.495945
+L 279.765 343.370984
+L 386.830909 343.283848
+L 493.896818 343.228533
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m9036e5f7ac" d="M 0 3
+     <path id="m41e44083d9" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1135,23 +1135,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #a6cee4"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#m9036e5f7ac" x="65.633182" y="343.574319" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="172.699091" y="343.45044" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="279.765" y="343.325012" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="386.830909" y="343.191475" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="493.896818" y="343.075213" style="fill: #a6cee4; stroke: #a6cee4"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#m41e44083d9" x="65.633182" y="343.52844" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="172.699091" y="343.495945" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="279.765" y="343.370984" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="386.830909" y="343.283848" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="493.896818" y="343.228533" style="fill: #a6cee4; stroke: #a6cee4"/>
     </g>
    </g>
    <g id="line2d_30">
-    <path d="M 65.633182 343.4461
-L 172.699091 343.280247
-L 279.765 343.119212
-L 386.830909 342.795369
-L 493.896818 342.591115
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.525129
+L 172.699091 343.265602
+L 279.765 343.161356
+L 386.830909 342.94654
+L 493.896818 342.765148
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="mf3aa38ca99" d="M 0 3
+     <path id="me10bdc34f0" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1163,23 +1163,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #6aaed6"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#mf3aa38ca99" x="65.633182" y="343.4461" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="172.699091" y="343.280247" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="279.765" y="343.119212" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="386.830909" y="342.795369" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="493.896818" y="342.591115" style="fill: #6aaed6; stroke: #6aaed6"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#me10bdc34f0" x="65.633182" y="343.525129" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="172.699091" y="343.265602" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="279.765" y="343.161356" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="386.830909" y="342.94654" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="493.896818" y="342.765148" style="fill: #6aaed6; stroke: #6aaed6"/>
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 65.633182 343.309009
-L 172.699091 343.012244
-L 279.765 342.634395
-L 386.830909 342.521608
-L 493.896818 341.955501
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.42798
+L 172.699091 343.083131
+L 279.765 342.831555
+L 386.830909 342.431911
+L 493.896818 342.328857
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="mc11a2cac7e" d="M 0 3
+     <path id="m15b5684f0d" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1191,23 +1191,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #3b8bc2"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#mc11a2cac7e" x="65.633182" y="343.309009" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="172.699091" y="343.012244" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="279.765" y="342.634395" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="386.830909" y="342.521608" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="493.896818" y="341.955501" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#m15b5684f0d" x="65.633182" y="343.42798" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="172.699091" y="343.083131" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="279.765" y="342.831555" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="386.830909" y="342.431911" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="493.896818" y="342.328857" style="fill: #3b8bc2; stroke: #3b8bc2"/>
     </g>
    </g>
    <g id="line2d_32">
-    <path d="M 65.633182 343.183158
-L 172.699091 342.794267
-L 279.765 342.277022
-L 386.830909 341.998389
-L 493.896818 341.472585
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.225584
+L 172.699091 342.821057
+L 279.765 342.456514
+L 386.830909 342.036191
+L 493.896818 341.52479
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m728df1a6f0" d="M 0 3
+     <path id="m9a16f8171c" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1219,23 +1219,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1764ab"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#m728df1a6f0" x="65.633182" y="343.183158" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="172.699091" y="342.794267" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="279.765" y="342.277022" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="386.830909" y="341.998389" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="493.896818" y="341.472585" style="fill: #1764ab; stroke: #1764ab"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#m9a16f8171c" x="65.633182" y="343.225584" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="172.699091" y="342.821057" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="279.765" y="342.456514" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="386.830909" y="342.036191" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="493.896818" y="341.52479" style="fill: #1764ab; stroke: #1764ab"/>
     </g>
    </g>
    <g id="line2d_33">
-    <path d="M 65.633182 343.008252
-L 172.699091 342.710961
-L 279.765 342.051365
-L 386.830909 341.55779
-L 493.896818 341.35445
-" clip-path="url(#p4d31e6bb7f)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.169386
+L 172.699091 342.701384
+L 279.765 342.287261
+L 386.830909 341.869994
+L 493.896818 341.280397
+" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m16dc673f68" d="M 0 3
+     <path id="m83ffa9e9bd" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1247,12 +1247,12 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #083c7d"/>
     </defs>
-    <g clip-path="url(#p4d31e6bb7f)">
-     <use xlink:href="#m16dc673f68" x="65.633182" y="343.008252" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="172.699091" y="342.710961" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="279.765" y="342.051365" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="386.830909" y="341.55779" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="493.896818" y="341.35445" style="fill: #083c7d; stroke: #083c7d"/>
+    <g clip-path="url(#pf7f0328271)">
+     <use xlink:href="#m83ffa9e9bd" x="65.633182" y="343.169386" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="172.699091" y="342.701384" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="279.765" y="342.287261" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="386.830909" y="341.869994" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="493.896818" y="341.280397" style="fill: #083c7d; stroke: #083c7d"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1276,8 +1276,8 @@ L 515.31 50.64
 " style="fill: none; stroke: #cccccc; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_17">
-    <!-- ryl 0.9.1 -->
-    <g style="fill: #262626" transform="translate(254.907187 44.64) scale(0.12 -0.12)">
+    <!-- ryl 0.11.0 -->
+    <g style="fill: #262626" transform="translate(251.089687 44.64) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325
 Q 1816 -950 1584 -1140
@@ -1303,9 +1303,10 @@ z
      <use xlink:href="#DejaVuSans-20" transform="translate(128.076172 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(159.863281 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(223.486328 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(255.273438 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(318.896484 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(350.683594 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(255.273438 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(318.896484 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(382.519531 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(414.306641 0)"/>
     </g>
    </g>
   </g>
@@ -1323,7 +1324,7 @@ z
      <g id="line2d_34">
       <path d="M 547.523182 357.54
 L 547.523182 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_35"/>
      <g id="text_18">
@@ -1338,7 +1339,7 @@ L 547.523182 50.64
      <g id="line2d_36">
       <path d="M 601.056136 357.54
 L 601.056136 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_37"/>
      <g id="text_19">
@@ -1353,7 +1354,7 @@ L 601.056136 50.64
      <g id="line2d_38">
       <path d="M 654.589091 357.54
 L 654.589091 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_39"/>
      <g id="text_20">
@@ -1368,7 +1369,7 @@ L 654.589091 50.64
      <g id="line2d_40">
       <path d="M 708.122045 357.54
 L 708.122045 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_41"/>
      <g id="text_21">
@@ -1383,7 +1384,7 @@ L 708.122045 50.64
      <g id="line2d_42">
       <path d="M 761.655 357.54
 L 761.655 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_43"/>
      <g id="text_22">
@@ -1398,7 +1399,7 @@ L 761.655 50.64
      <g id="line2d_44">
       <path d="M 815.187955 357.54
 L 815.187955 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_45"/>
      <g id="text_23">
@@ -1413,7 +1414,7 @@ L 815.187955 50.64
      <g id="line2d_46">
       <path d="M 868.720909 357.54
 L 868.720909 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_47"/>
      <g id="text_24">
@@ -1428,7 +1429,7 @@ L 868.720909 50.64
      <g id="line2d_48">
       <path d="M 922.253864 357.54
 L 922.253864 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_49"/>
      <g id="text_25">
@@ -1443,7 +1444,7 @@ L 922.253864 50.64
      <g id="line2d_50">
       <path d="M 975.786818 357.54
 L 975.786818 50.64
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_51"/>
      <g id="text_26">
@@ -1484,223 +1485,223 @@ L 975.786818 50.64
    <g id="matplotlib.axis_4">
     <g id="ytick_6">
      <g id="line2d_52">
-      <path d="M 526.11 344.243444
-L 997.2 344.243444
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 344.198029
+L 997.2 344.198029
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_53"/>
     </g>
     <g id="ytick_7">
      <g id="line2d_54">
-      <path d="M 526.11 283.532381
-L 997.2 283.532381
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 283.289669
+L 997.2 283.289669
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_55"/>
     </g>
     <g id="ytick_8">
      <g id="line2d_56">
-      <path d="M 526.11 222.821319
-L 997.2 222.821319
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 222.381308
+L 997.2 222.381308
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_57"/>
     </g>
     <g id="ytick_9">
      <g id="line2d_58">
-      <path d="M 526.11 162.110256
-L 997.2 162.110256
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 161.472948
+L 997.2 161.472948
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_59"/>
     </g>
     <g id="ytick_10">
      <g id="line2d_60">
-      <path d="M 526.11 101.399194
-L 997.2 101.399194
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 100.564587
+L 997.2 100.564587
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_61"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_6">
     <defs>
-     <path id="mae94900e46" d="M 547.523182 -69.03648
-L 547.523182 -68.080662
-L 654.589091 -74.755576
-L 761.655 -81.50243
-L 868.720909 -89.696944
-L 975.786818 -94.700331
-L 975.786818 -96.794134
-L 975.786818 -96.794134
-L 868.720909 -94.713559
-L 761.655 -83.251645
-L 654.589091 -76.264041
-L 547.523182 -69.03648
+     <path id="m283474c111" d="M 547.523182 -67.502057
+L 547.523182 -67.223115
+L 654.589091 -73.64916
+L 761.655 -80.259693
+L 868.720909 -86.871177
+L 975.786818 -93.266448
+L 975.786818 -93.647786
+L 975.786818 -93.647786
+L 868.720909 -87.48533
+L 761.655 -80.60386
+L 654.589091 -74.06225
+L 547.523182 -67.502057
 z
 " style="stroke: #a6cee4; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#mae94900e46" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m283474c111" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_7">
     <defs>
-     <path id="maad441a3cc" d="M 547.523182 -81.731092
-L 547.523182 -79.928261
-L 654.589091 -98.41491
-L 761.655 -119.013137
-L 868.720909 -137.948125
-L 975.786818 -157.593514
-L 975.786818 -162.272421
-L 975.786818 -162.272421
-L 868.720909 -142.900273
-L 761.655 -120.642471
-L 654.589091 -102.13507
-L 547.523182 -81.731092
+     <path id="m7acd664db4" d="M 547.523182 -80.13164
+L 547.523182 -78.85665
+L 654.589091 -96.710355
+L 761.655 -115.09823
+L 868.720909 -132.76269
+L 975.786818 -150.747719
+L 975.786818 -152.272864
+L 975.786818 -152.272864
+L 868.720909 -133.632405
+L 761.655 -116.11069
+L 654.589091 -97.607173
+L 547.523182 -80.13164
 z
 " style="stroke: #6aaed6; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#maad441a3cc" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m7acd664db4" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_8">
     <defs>
-     <path id="ma466a26576" d="M 547.523182 -93.423994
-L 547.523182 -91.87693
-L 654.589091 -123.531352
-L 761.655 -153.474723
-L 868.720909 -183.478554
-L 975.786818 -216.694924
-L 975.786818 -220.559257
-L 975.786818 -220.559257
-L 868.720909 -188.010307
-L 761.655 -157.357397
-L 654.589091 -127.048548
-L 547.523182 -93.423994
+     <path id="m881ac0bebb" d="M 547.523182 -91.268951
+L 547.523182 -90.35644
+L 654.589091 -119.496266
+L 761.655 -148.549358
+L 868.720909 -177.952965
+L 975.786818 -207.79135
+L 975.786818 -210.487656
+L 975.786818 -210.487656
+L 868.720909 -180.032803
+L 761.655 -150.721108
+L 654.589091 -121.01629
+L 547.523182 -91.268951
 z
 " style="stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#ma466a26576" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m881ac0bebb" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_9">
     <defs>
-     <path id="m6f69a048a8" d="M 547.523182 -110.473777
-L 547.523182 -106.685793
-L 654.589091 -147.203662
-L 761.655 -193.553623
-L 868.720909 -238.387277
-L 975.786818 -277.307105
-L 975.786818 -289.543098
-L 975.786818 -289.543098
-L 868.720909 -240.080949
-L 761.655 -196.002868
-L 654.589091 -151.041754
-L 547.523182 -110.473777
+     <path id="m3a1a05e78e" d="M 547.523182 -102.984276
+L 547.523182 -101.781527
+L 654.589091 -142.510671
+L 761.655 -184.050058
+L 868.720909 -223.886507
+L 975.786818 -264.915192
+L 975.786818 -269.181646
+L 975.786818 -269.181646
+L 868.720909 -227.411072
+L 761.655 -186.519558
+L 654.589091 -144.277125
+L 547.523182 -102.984276
 z
 " style="stroke: #1764ab; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#m6f69a048a8" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m3a1a05e78e" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_10">
     <defs>
-     <path id="m70b11445ef" d="M 547.523182 -120.904701
-L 547.523182 -116.561083
-L 654.589091 -173.721555
-L 761.655 -229.758986
-L 868.720909 -273.686516
-L 975.786818 -328.23454
+     <path id="m15969badb3" d="M 547.523182 -113.652859
+L 547.523182 -113.182527
+L 654.589091 -166.086202
+L 761.655 -218.520346
+L 868.720909 -270.78465
+L 975.786818 -322.120019
 L 975.786818 -331.41
 L 975.786818 -331.41
-L 868.720909 -280.701604
-L 761.655 -231.50935
-L 654.589091 -177.880772
-L 547.523182 -120.904701
+L 868.720909 -276.834891
+L 761.655 -221.091892
+L 654.589091 -166.640048
+L 547.523182 -113.652859
 z
 " style="stroke: #083c7d; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#m70b11445ef" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m15969badb3" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="line2d_62">
-    <path d="M 547.523182 327.441429
-L 654.589091 320.490192
-L 761.655 313.622963
-L 868.720909 303.794749
-L 975.786818 300.252767
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#m9036e5f7ac" x="547.523182" y="327.441429" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="654.589091" y="320.490192" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="761.655" y="313.622963" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="868.720909" y="303.794749" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m9036e5f7ac" x="975.786818" y="300.252767" style="fill: #a6cee4; stroke: #a6cee4"/>
+    <path d="M 547.523182 328.637414
+L 654.589091 322.144295
+L 761.655 315.568224
+L 868.720909 308.821747
+L 975.786818 302.542883
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m41e44083d9" x="547.523182" y="328.637414" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="654.589091" y="322.144295" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="761.655" y="315.568224" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="868.720909" y="308.821747" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m41e44083d9" x="975.786818" y="302.542883" style="fill: #a6cee4; stroke: #a6cee4"/>
     </g>
    </g>
    <g id="line2d_63">
-    <path d="M 547.523182 315.170323
-L 654.589091 295.72501
-L 761.655 276.172196
-L 868.720909 255.575801
-L 975.786818 236.067033
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#mf3aa38ca99" x="547.523182" y="315.170323" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="654.589091" y="295.72501" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="761.655" y="276.172196" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="868.720909" y="255.575801" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mf3aa38ca99" x="975.786818" y="236.067033" style="fill: #6aaed6; stroke: #6aaed6"/>
+    <path d="M 547.523182 316.505855
+L 654.589091 298.841236
+L 761.655 280.39554
+L 868.720909 262.802453
+L 975.786818 244.489708
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#me10bdc34f0" x="547.523182" y="316.505855" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="654.589091" y="298.841236" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="761.655" y="280.39554" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="868.720909" y="262.802453" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#me10bdc34f0" x="975.786818" y="244.489708" style="fill: #6aaed6; stroke: #6aaed6"/>
     </g>
    </g>
    <g id="line2d_64">
-    <path d="M 547.523182 303.349538
-L 654.589091 270.71005
-L 761.655 240.58394
-L 868.720909 210.25557
-L 975.786818 177.372909
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#mc11a2cac7e" x="547.523182" y="303.349538" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="654.589091" y="270.71005" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="761.655" y="240.58394" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="868.720909" y="210.25557" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#mc11a2cac7e" x="975.786818" y="177.372909" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+    <path d="M 547.523182 305.187305
+L 654.589091 275.743722
+L 761.655 246.364767
+L 868.720909 217.007116
+L 975.786818 186.860497
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m15b5684f0d" x="547.523182" y="305.187305" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="654.589091" y="275.743722" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="761.655" y="246.364767" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="868.720909" y="217.007116" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m15b5684f0d" x="975.786818" y="186.860497" style="fill: #3b8bc2; stroke: #3b8bc2"/>
     </g>
    </g>
    <g id="line2d_65">
-    <path d="M 547.523182 287.420215
-L 654.589091 246.877292
-L 761.655 201.221755
-L 868.720909 156.765887
-L 975.786818 112.574899
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#m728df1a6f0" x="547.523182" y="287.420215" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="654.589091" y="246.877292" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="761.655" y="201.221755" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="868.720909" y="156.765887" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m728df1a6f0" x="975.786818" y="112.574899" style="fill: #1764ab; stroke: #1764ab"/>
+    <path d="M 547.523182 293.617099
+L 654.589091 252.606102
+L 761.655 210.715192
+L 868.720909 170.35121
+L 975.786818 128.951581
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m9a16f8171c" x="547.523182" y="293.617099" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="654.589091" y="252.606102" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="761.655" y="210.715192" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="868.720909" y="170.35121" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m9a16f8171c" x="975.786818" y="128.951581" style="fill: #1764ab; stroke: #1764ab"/>
     </g>
    </g>
    <g id="line2d_66">
-    <path d="M 547.523182 277.267108
-L 654.589091 220.198836
-L 761.655 165.365832
-L 868.720909 118.80594
-L 975.786818 66.17773
-" clip-path="url(#pe5625fd74f)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pe5625fd74f)">
-     <use xlink:href="#m16dc673f68" x="547.523182" y="277.267108" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="654.589091" y="220.198836" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="761.655" y="165.365832" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="868.720909" y="118.80594" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m16dc673f68" x="975.786818" y="66.17773" style="fill: #083c7d; stroke: #083c7d"/>
+    <path d="M 547.523182 282.582307
+L 654.589091 229.636875
+L 761.655 176.193881
+L 868.720909 122.19023
+L 975.786818 69.23499
+" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pfb2959b8e0)">
+     <use xlink:href="#m83ffa9e9bd" x="547.523182" y="282.582307" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="654.589091" y="229.636875" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="761.655" y="176.193881" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="868.720909" y="122.19023" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m83ffa9e9bd" x="975.786818" y="69.23499" style="fill: #083c7d; stroke: #083c7d"/>
     </g>
    </g>
    <g id="patch_8">
@@ -1792,7 +1793,7 @@ L 545.11 78.416563
 L 555.11 78.416563
 " style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m9036e5f7ac" x="545.11" y="78.416563" style="fill: #a6cee4; stroke: #a6cee4"/>
+      <use xlink:href="#m41e44083d9" x="545.11" y="78.416563" style="fill: #a6cee4; stroke: #a6cee4"/>
      </g>
     </g>
     <g id="text_30">
@@ -1859,7 +1860,7 @@ L 545.11 93.094688
 L 555.11 93.094688
 " style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#mf3aa38ca99" x="545.11" y="93.094688" style="fill: #6aaed6; stroke: #6aaed6"/>
+      <use xlink:href="#me10bdc34f0" x="545.11" y="93.094688" style="fill: #6aaed6; stroke: #6aaed6"/>
      </g>
     </g>
     <g id="text_31">
@@ -1878,7 +1879,7 @@ L 545.11 107.772813
 L 555.11 107.772813
 " style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#mc11a2cac7e" x="545.11" y="107.772813" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+      <use xlink:href="#m15b5684f0d" x="545.11" y="107.772813" style="fill: #3b8bc2; stroke: #3b8bc2"/>
      </g>
     </g>
     <g id="text_32">
@@ -1897,7 +1898,7 @@ L 545.11 122.450938
 L 555.11 122.450938
 " style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m728df1a6f0" x="545.11" y="122.450938" style="fill: #1764ab; stroke: #1764ab"/>
+      <use xlink:href="#m9a16f8171c" x="545.11" y="122.450938" style="fill: #1764ab; stroke: #1764ab"/>
      </g>
     </g>
     <g id="text_33">
@@ -1916,7 +1917,7 @@ L 545.11 137.129063
 L 555.11 137.129063
 " style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m16dc673f68" x="545.11" y="137.129063" style="fill: #083c7d; stroke: #083c7d"/>
+      <use xlink:href="#m83ffa9e9bd" x="545.11" y="137.129063" style="fill: #083c7d; stroke: #083c7d"/>
      </g>
     </g>
     <g id="text_34">
@@ -2049,10 +2050,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p4d31e6bb7f">
+  <clipPath id="pf7f0328271">
    <rect x="44.22" y="50.64" width="471.09" height="306.9"/>
   </clipPath>
-  <clipPath id="pe5625fd74f">
+  <clipPath id="pfb2959b8e0">
    <rect x="526.11" y="50.64" width="471.09" height="306.9"/>
   </clipPath>
  </defs>

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.10.2"
+  "version": "0.11.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.10.2"
+version = "0.11.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/cli_support.rs
+++ b/src/cli_support.rs
@@ -14,8 +14,12 @@ use crate::config::{ConfigContext, YamlLintConfig, discover_per_file};
 pub fn resolve_ctx<S: BuildHasher>(
     path: &Path,
     global_cfg: Option<&ConfigContext>,
+    markdown: bool,
     cache: &mut HashMap<PathBuf, (PathBuf, YamlLintConfig), S>,
 ) -> Result<(PathBuf, YamlLintConfig, Vec<String>), String> {
+    // The global config is markdown-enabled once by the caller, so per-file clones
+    // here inherit the built matcher; only freshly-discovered configs need enabling
+    // (done before caching, so the matcher is built once per directory).
     if let Some(gc) = global_cfg {
         return Ok((gc.base_dir.clone(), gc.config.clone(), Vec::new()));
     }
@@ -26,7 +30,11 @@ pub fn resolve_ctx<S: BuildHasher>(
         return Ok((pair.0, pair.1, Vec::new()));
     }
     let ctx = discover_per_file(path)?;
-    let pair = (ctx.base_dir.clone(), ctx.config);
+    let mut cfg = ctx.config;
+    if markdown {
+        cfg.enable_default_markdown(&ctx.base_dir);
+    }
+    let pair = (ctx.base_dir.clone(), cfg);
     let notices = ctx.notices;
     cache.insert(start, pair.clone());
     Ok((pair.0, pair.1, notices))

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,10 @@ pub struct YamlLintConfig {
     yaml_matcher: Option<Gitignore>,
     markdown_file_patterns: Vec<String>,
     markdown_matcher: Option<Gitignore>,
+    /// Set when the `--markdown` flag injected the default markdown globs; lets
+    /// markdown win over yaml for an overlapping file instead of hard-erroring, so
+    /// the flag can't break a run whose yaml globs happen to match `.md`.
+    markdown_from_flag: bool,
     lint_markdown_front_matter: bool,
     lint_markdown_fenced_blocks: bool,
     locale: Option<String>,
@@ -375,6 +379,7 @@ impl Default for YamlLintConfig {
             yaml_matcher: None,
             markdown_file_patterns: Vec::new(),
             markdown_matcher: None,
+            markdown_from_flag: false,
             lint_markdown_front_matter: true,
             lint_markdown_fenced_blocks: true,
             locale: None,
@@ -574,6 +579,9 @@ impl YamlLintConfig {
             self.is_yaml_candidate(path, base_dir),
             self.is_markdown_candidate(path, base_dir),
         ) {
+            // `--markdown` injected the markdown globs, so honour the explicit
+            // request: treat an overlapping file as markdown rather than aborting.
+            (true, true) if self.markdown_from_flag => Ok(Some(SourceKind::Markdown)),
             (true, true) => Err(format!(
                 "{}: matches both `yaml` and `markdown` in [files]; a file may \
                  belong to only one source kind",
@@ -597,6 +605,7 @@ impl YamlLintConfig {
                 .collect();
             self.markdown_matcher =
                 build_glob_matcher(base_dir, &self.markdown_file_patterns);
+            self.markdown_from_flag = true;
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,8 @@ pub struct YamlLintConfig {
 }
 
 const DEFAULT_YAML_FILE_PATTERNS: [&str; 3] = ["*.yaml", "*.yml", ".yamllint"];
+const DEFAULT_MARKDOWN_FILE_PATTERNS: [&str; 5] =
+    ["*.md", "*.markdown", "*.mdx", "*.qmd", "*.Rmd"];
 
 #[derive(Debug, Clone, Default)]
 struct RuleFilter {
@@ -580,6 +582,21 @@ impl YamlLintConfig {
             (true, false) => Ok(Some(SourceKind::Yaml)),
             (false, true) => Ok(Some(SourceKind::Markdown)),
             (false, false) => Ok(None),
+        }
+    }
+
+    /// Enable markdown linting with default globs (`*.md`, `*.markdown`, `*.mdx`,
+    /// `*.qmd`, `*.Rmd`) when none are configured. Backs the `--markdown` CLI flag
+    /// so embedded YAML can be linted without editing config. A no-op when
+    /// `[files].markdown` already lists globs.
+    pub fn enable_default_markdown(&mut self, base_dir: &Path) {
+        if self.markdown_file_patterns.is_empty() {
+            self.markdown_file_patterns = DEFAULT_MARKDOWN_FILE_PATTERNS
+                .iter()
+                .map(|pattern| (*pattern).to_string())
+                .collect();
+            self.markdown_matcher =
+                build_glob_matcher(base_dir, &self.markdown_file_patterns);
         }
     }
 

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -252,80 +252,93 @@ pub fn apply_safe_fixes_filtered(
     base_dir: &Path,
     skip: &[&str],
 ) -> String {
-    let mut content = input.to_string();
-    let run = |content: String, rule: RuleFix, fix: &dyn Fn(&str) -> Option<String>| {
-        apply_rule_fix(content, rule, cfg, path, base_dir, skip, fix)
+    let ctx = FixContext {
+        cfg,
+        path,
+        base_dir,
+        skip,
     };
-
-    content = run(content, NEW_LINES_FIX, &|buffer: &str| {
+    let mut content = input.to_string();
+    content = ctx.apply(content, NEW_LINES_FIX, |buffer| {
         new_lines::fix(
             buffer,
             new_lines::Config::resolve(cfg),
             new_lines::platform_newline(),
         )
     });
-    content = run(content, COMMENTS_FIX, &|buffer: &str| {
+    content = ctx.apply(content, COMMENTS_FIX, |buffer| {
         comments::fix(buffer, &comments::Config::resolve(cfg))
     });
-    content = run(content, COMMENTS_INDENTATION_FIX, &|buffer: &str| {
+    content = ctx.apply(content, COMMENTS_INDENTATION_FIX, |buffer| {
         comments_indentation::fix(buffer, &comments_indentation::Config::resolve(cfg))
     });
-    content = run(content, COMMAS_FIX, &|buffer: &str| {
+    content = ctx.apply(content, COMMAS_FIX, |buffer| {
         commas::fix(buffer, &commas::Config::resolve(cfg))
     });
-    content = run(content, BRACES_FIX, &|buffer: &str| {
+    content = ctx.apply(content, BRACES_FIX, |buffer| {
         braces::fix(buffer, &braces::Config::resolve(cfg))
     });
-    content = run(content, BRACKETS_FIX, &|buffer: &str| {
+    content = ctx.apply(content, BRACKETS_FIX, |buffer| {
         brackets::fix(buffer, &brackets::Config::resolve(cfg))
     });
-    content = run(content, FINAL_NEWLINE_FIX, &|buffer: &str| {
+    content = ctx.apply(content, FINAL_NEWLINE_FIX, |buffer| {
         let newline = target_newline(buffer, cfg, path, base_dir);
         new_line_at_end_of_file::fix(buffer, newline.as_str())
     });
-    content = run(content, QUOTED_STRINGS_FIX, &|buffer: &str| {
+    content = ctx.apply(content, QUOTED_STRINGS_FIX, |buffer| {
         quoted_strings::fix(buffer, &quoted_strings::Config::resolve(cfg))
     });
-    content = run(content, TRAILING_SPACES_FIX, &trailing_spaces::fix);
-    content = run(content, DOCUMENT_START_FIX, &|buffer: &str| {
+    content = ctx.apply(content, TRAILING_SPACES_FIX, trailing_spaces::fix);
+    content = ctx.apply(content, DOCUMENT_START_FIX, |buffer| {
         document_start::fix(buffer, &document_start::Config::resolve(cfg))
     });
-    content = run(content, DOCUMENT_END_FIX, &|buffer: &str| {
+    content = ctx.apply(content, DOCUMENT_END_FIX, |buffer| {
         document_end::fix(buffer, &document_end::Config::resolve(cfg))
     });
-    content = run(content, EMPTY_LINES_FIX, &|buffer: &str| {
+    content = ctx.apply(content, EMPTY_LINES_FIX, |buffer| {
         empty_lines::fix(buffer, &empty_lines::Config::resolve(cfg))
     });
 
     content
 }
 
-fn apply_rule_fix(
-    content: String,
-    rule: RuleFix,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-    skip: &[&str],
-    fix: &dyn Fn(&str) -> Option<String>,
-) -> String {
-    if skip.contains(&rule.rule) || !rule_enabled(rule, cfg, path, base_dir) {
-        return content;
-    }
+/// Shared arguments for a sequence of rule fixes, bundled so each per-rule call
+/// site stays short. `apply` is generic over the fix closure — a method can be,
+/// where a capturing closure cannot — so there is no dynamic dispatch.
+struct FixContext<'a> {
+    cfg: &'a YamlLintConfig,
+    path: &'a Path,
+    base_dir: &'a Path,
+    skip: &'a [&'a str],
+}
 
-    // Run the rule's fix to a fixed point. A single pass is not enough for
-    // rules like quoted-strings where one fix exposes a follow-up diagnostic
-    // (e.g. converting double quotes to single quotes leaves a now-redundant
-    // pair that must be removed); without convergence here, the CLI's single
-    // --fix invocation would leave the output non-idempotent. Well-behaved
-    // fix functions signal completion by returning None, so the loop exits
-    // after at most one extra no-op call per rule.
-    let mut current = content;
-    for _ in 0..RULE_FIX_MAX_ITERATIONS {
-        let Some(next) = fix(&current) else { break };
-        current = next;
+impl FixContext<'_> {
+    fn apply(
+        &self,
+        content: String,
+        rule: RuleFix,
+        fix: impl Fn(&str) -> Option<String>,
+    ) -> String {
+        if self.skip.contains(&rule.rule)
+            || !rule_enabled(rule, self.cfg, self.path, self.base_dir)
+        {
+            return content;
+        }
+
+        // Run the rule's fix to a fixed point. A single pass is not enough for
+        // rules like quoted-strings where one fix exposes a follow-up diagnostic
+        // (e.g. converting double quotes to single quotes leaves a now-redundant
+        // pair that must be removed); without convergence here, the CLI's single
+        // --fix invocation would leave the output non-idempotent. Well-behaved
+        // fix functions signal completion by returning None, so the loop exits
+        // after at most one extra no-op call per rule.
+        let mut current = content;
+        for _ in 0..RULE_FIX_MAX_ITERATIONS {
+            let Some(next) = fix(&current) else { break };
+            current = next;
+        }
+        current
     }
-    current
 }
 
 fn rule_enabled(

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::{SourceKind, YamlLintConfig};
 use crate::decoder;
+use crate::markdown_embed::{MarkdownSources, RegionKind, extract_regions};
 use crate::rules::{
     braces, brackets, commas, comments, comments_indentation, document_end,
     document_start, empty_lines, new_line_at_end_of_file, new_lines, quoted_strings,
@@ -9,6 +10,35 @@ use crate::rules::{
 };
 
 const RULE_FIX_MAX_ITERATIONS: usize = 8;
+
+/// File-shape rules suppressed inside embedded markdown regions, per region kind:
+/// a region is not a standalone file, so "missing document start/end" and the
+/// file-newline checks do not apply, and `--fix` must never inject `---`/`...` or a
+/// trailing newline into a fragment. Front matter and fenced blocks suppress the
+/// same four rules today; the per-kind signature lets them diverge without a
+/// refactor. The single source is shared by the check path ([`lint_markdown_str`])
+/// and the fix path, so the two cannot drift.
+const FRONT_MATTER_SUPPRESSED: [&str; 4] = [
+    document_start::ID,
+    document_end::ID,
+    new_line_at_end_of_file::ID,
+    new_lines::ID,
+];
+const FENCED_BLOCK_SUPPRESSED: [&str; 4] = [
+    document_start::ID,
+    document_end::ID,
+    new_line_at_end_of_file::ID,
+    new_lines::ID,
+];
+
+/// Rules suppressed inside an embedded region of the given kind.
+#[must_use]
+pub fn suppressed_rules(kind: RegionKind) -> &'static [&'static str] {
+    match kind {
+        RegionKind::FrontMatter => &FRONT_MATTER_SUPPRESSED,
+        RegionKind::FencedBlock => &FENCED_BLOCK_SUPPRESSED,
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixSafety {
@@ -105,14 +135,125 @@ pub fn apply_safe_fixes_to_files(
 ) -> Result<FixStats, String> {
     let mut stats = FixStats::default();
     for (path, base_dir, cfg, kind) in files {
-        if *kind == SourceKind::Markdown {
-            continue;
-        }
-        if apply_safe_fixes_in_place(path, cfg, base_dir)? {
+        let changed = match kind {
+            SourceKind::Markdown => {
+                apply_markdown_safe_fixes_in_place(path, cfg, base_dir)?
+            }
+            SourceKind::Yaml => apply_safe_fixes_in_place(path, cfg, base_dir)?,
+        };
+        if changed {
             stats.changed_files += 1;
         }
     }
     Ok(stats)
+}
+
+/// Apply safe fixes to every embedded YAML region of a markdown file in place.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or the rewritten contents cannot be
+/// written.
+pub fn apply_markdown_safe_fixes_in_place(
+    path: &Path,
+    cfg: &YamlLintConfig,
+    base_dir: &Path,
+) -> Result<bool, String> {
+    let decoded = decoder::read_file_lossless(path)?;
+    match fix_markdown_str(decoded.content(), path, cfg, base_dir) {
+        Some(fixed) => {
+            decoded.write(path, &fixed)?;
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Apply safe fixes to each embedded YAML region of `markdown` and splice the
+/// results back in, returning the rewritten document (or `None` if nothing
+/// changed).
+///
+/// File-shape rules are excluded per [`suppressed_rules`]. A region is only
+/// rewritten when its fixed YAML can be re-indented to reproduce the original raw
+/// bytes exactly (the reconstruct-and-verify guard); ragged-indent, tab-indented,
+/// or otherwise non-round-trippable regions are left untouched (still reported in
+/// check mode). Regions are spliced back-to-front so earlier edits do not shift
+/// later offsets.
+#[must_use]
+pub fn fix_markdown_str(
+    markdown: &str,
+    path: &Path,
+    cfg: &YamlLintConfig,
+    base_dir: &Path,
+) -> Option<String> {
+    let sources = MarkdownSources {
+        front_matter: cfg.markdown_front_matter(),
+        fenced_blocks: cfg.markdown_fenced_blocks(),
+    };
+    let mut regions = extract_regions(markdown, sources);
+    regions.sort_by_key(|region| std::cmp::Reverse(region.raw_span.start));
+
+    let mut out = markdown.to_string();
+    let mut changed = false;
+    for region in &regions {
+        if region.content.trim().is_empty() {
+            continue;
+        }
+        let fixed = apply_safe_fixes_filtered(
+            &region.content,
+            cfg,
+            path,
+            base_dir,
+            suppressed_rules(region.kind),
+        );
+        if fixed == region.content {
+            continue;
+        }
+        let raw = &markdown[region.raw_span.clone()];
+        let newline = detect_newline(raw);
+        if reindent(&region.content, region.col_offset, newline) != raw {
+            continue;
+        }
+        out.replace_range(
+            region.raw_span.clone(),
+            &reindent(&fixed, region.col_offset, newline),
+        );
+        changed = true;
+    }
+    changed.then_some(out)
+}
+
+/// The newline style of a raw region: CRLF if the first line ending is `\r\n`,
+/// otherwise LF.
+fn detect_newline(raw: &str) -> &'static str {
+    match raw.find('\n') {
+        Some(index) if raw.as_bytes().get(index.wrapping_sub(1)) == Some(&b'\r') => {
+            "\r\n"
+        }
+        _ => "\n",
+    }
+}
+
+/// Re-encode dedented region content into its host: each non-empty line regains
+/// `col_offset` leading spaces and lines are joined with `newline`. Empty lines
+/// stay empty (matching how the parser dedents blank lines), and the trailing
+/// newline is preserved.
+fn reindent(content: &str, col_offset: usize, newline: &str) -> String {
+    let indent = " ".repeat(col_offset);
+    let mut out = String::with_capacity(content.len());
+    for piece in content.replace("\r\n", "\n").split_inclusive('\n') {
+        let (line, terminated) = piece
+            .strip_suffix('\n')
+            .map_or((piece, false), |line| (line, true));
+        if !line.is_empty() {
+            out.push_str(&indent);
+            out.push_str(line);
+        }
+        if terminated {
+            out.push_str(newline);
+        }
+    }
+    out
 }
 
 #[must_use]
@@ -122,66 +263,61 @@ pub fn apply_safe_fixes(
     path: &Path,
     base_dir: &Path,
 ) -> String {
-    let mut content = input.to_string();
+    apply_safe_fixes_filtered(input, cfg, path, base_dir, &[])
+}
 
-    content = apply_rule_fix(content, NEW_LINES_FIX, cfg, path, base_dir, |buffer| {
+/// Apply safe fixes, skipping any rule whose id is in `skip`. Used by the markdown
+/// write-back path to exclude the file-shape rules (see [`suppressed_rules`]).
+#[must_use]
+pub fn apply_safe_fixes_filtered(
+    input: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+    skip: &[&str],
+) -> String {
+    let mut content = input.to_string();
+    let run = |content: String, rule: RuleFix, fix: &dyn Fn(&str) -> Option<String>| {
+        apply_rule_fix(content, rule, cfg, path, base_dir, skip, fix)
+    };
+
+    content = run(content, NEW_LINES_FIX, &|buffer: &str| {
         new_lines::fix(
             buffer,
             new_lines::Config::resolve(cfg),
             new_lines::platform_newline(),
         )
     });
-    content = apply_rule_fix(content, COMMENTS_FIX, cfg, path, base_dir, |buffer| {
+    content = run(content, COMMENTS_FIX, &|buffer: &str| {
         comments::fix(buffer, &comments::Config::resolve(cfg))
     });
-    content = apply_rule_fix(
-        content,
-        COMMENTS_INDENTATION_FIX,
-        cfg,
-        path,
-        base_dir,
-        |buffer| {
-            comments_indentation::fix(
-                buffer,
-                &comments_indentation::Config::resolve(cfg),
-            )
-        },
-    );
-    content = apply_rule_fix(content, COMMAS_FIX, cfg, path, base_dir, |buffer| {
+    content = run(content, COMMENTS_INDENTATION_FIX, &|buffer: &str| {
+        comments_indentation::fix(buffer, &comments_indentation::Config::resolve(cfg))
+    });
+    content = run(content, COMMAS_FIX, &|buffer: &str| {
         commas::fix(buffer, &commas::Config::resolve(cfg))
     });
-    content = apply_rule_fix(content, BRACES_FIX, cfg, path, base_dir, |buffer| {
+    content = run(content, BRACES_FIX, &|buffer: &str| {
         braces::fix(buffer, &braces::Config::resolve(cfg))
     });
-    content = apply_rule_fix(content, BRACKETS_FIX, cfg, path, base_dir, |buffer| {
+    content = run(content, BRACKETS_FIX, &|buffer: &str| {
         brackets::fix(buffer, &brackets::Config::resolve(cfg))
     });
-    content =
-        apply_rule_fix(content, FINAL_NEWLINE_FIX, cfg, path, base_dir, |buffer| {
-            let newline = target_newline(buffer, cfg, path, base_dir);
-            new_line_at_end_of_file::fix(buffer, newline.as_str())
-        });
-    content =
-        apply_rule_fix(content, QUOTED_STRINGS_FIX, cfg, path, base_dir, |buffer| {
-            quoted_strings::fix(buffer, &quoted_strings::Config::resolve(cfg))
-        });
-    content = apply_rule_fix(
-        content,
-        TRAILING_SPACES_FIX,
-        cfg,
-        path,
-        base_dir,
-        trailing_spaces::fix,
-    );
-    content =
-        apply_rule_fix(content, DOCUMENT_START_FIX, cfg, path, base_dir, |buffer| {
-            document_start::fix(buffer, &document_start::Config::resolve(cfg))
-        });
-    content =
-        apply_rule_fix(content, DOCUMENT_END_FIX, cfg, path, base_dir, |buffer| {
-            document_end::fix(buffer, &document_end::Config::resolve(cfg))
-        });
-    content = apply_rule_fix(content, EMPTY_LINES_FIX, cfg, path, base_dir, |buffer| {
+    content = run(content, FINAL_NEWLINE_FIX, &|buffer: &str| {
+        let newline = target_newline(buffer, cfg, path, base_dir);
+        new_line_at_end_of_file::fix(buffer, newline.as_str())
+    });
+    content = run(content, QUOTED_STRINGS_FIX, &|buffer: &str| {
+        quoted_strings::fix(buffer, &quoted_strings::Config::resolve(cfg))
+    });
+    content = run(content, TRAILING_SPACES_FIX, &trailing_spaces::fix);
+    content = run(content, DOCUMENT_START_FIX, &|buffer: &str| {
+        document_start::fix(buffer, &document_start::Config::resolve(cfg))
+    });
+    content = run(content, DOCUMENT_END_FIX, &|buffer: &str| {
+        document_end::fix(buffer, &document_end::Config::resolve(cfg))
+    });
+    content = run(content, EMPTY_LINES_FIX, &|buffer: &str| {
         empty_lines::fix(buffer, &empty_lines::Config::resolve(cfg))
     });
 
@@ -194,9 +330,10 @@ fn apply_rule_fix(
     cfg: &YamlLintConfig,
     path: &Path,
     base_dir: &Path,
-    fix: impl Fn(&str) -> Option<String>,
+    skip: &[&str],
+    fix: &dyn Fn(&str) -> Option<String>,
 ) -> String {
-    if !rule_enabled(rule, cfg, path, base_dir) {
+    if skip.contains(&rule.rule) || !rule_enabled(rule, cfg, path, base_dir) {
         return content;
     }
 

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 
 use crate::config::{SourceKind, YamlLintConfig};
 use crate::decoder;
-use crate::markdown_embed::{MarkdownSources, RegionKind, extract_regions};
+use crate::markdown_embed::{MarkdownSources, extract_regions};
+use crate::rules::support::line_syntax::buffer_newline;
 use crate::rules::{
     braces, brackets, commas, comments, comments_indentation, document_end,
     document_start, empty_lines, new_line_at_end_of_file, new_lines, quoted_strings,
@@ -11,33 +12,22 @@ use crate::rules::{
 
 const RULE_FIX_MAX_ITERATIONS: usize = 8;
 
-/// File-shape rules suppressed inside embedded markdown regions, per region kind:
-/// a region is not a standalone file, so "missing document start/end" and the
-/// file-newline checks do not apply, and `--fix` must never inject `---`/`...` or a
-/// trailing newline into a fragment. Front matter and fenced blocks suppress the
-/// same four rules today; the per-kind signature lets them diverge without a
-/// refactor. The single source is shared by the check path ([`lint_markdown_str`])
-/// and the fix path, so the two cannot drift.
-const FRONT_MATTER_SUPPRESSED: [&str; 4] = [
-    document_start::ID,
-    document_end::ID,
-    new_line_at_end_of_file::ID,
-    new_lines::ID,
-];
-const FENCED_BLOCK_SUPPRESSED: [&str; 4] = [
+/// File-shape rules suppressed inside embedded markdown regions: a region is not a
+/// standalone file, so "missing document start/end" and the file-newline checks do
+/// not apply, and `--fix` must never inject `---`/`...` or a trailing newline into a
+/// fragment. Shared by the check path ([`lint_markdown_str`]) and the fix path so
+/// the two cannot drift.
+const SUPPRESSED: [&str; 4] = [
     document_start::ID,
     document_end::ID,
     new_line_at_end_of_file::ID,
     new_lines::ID,
 ];
 
-/// Rules suppressed inside an embedded region of the given kind.
+/// Rules suppressed inside any embedded region.
 #[must_use]
-pub fn suppressed_rules(kind: RegionKind) -> &'static [&'static str] {
-    match kind {
-        RegionKind::FrontMatter => &FRONT_MATTER_SUPPRESSED,
-        RegionKind::FencedBlock => &FENCED_BLOCK_SUPPRESSED,
-    }
+pub fn suppressed_rules() -> &'static [&'static str] {
+    &SUPPRESSED
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -204,49 +194,35 @@ pub fn fix_markdown_str(
             cfg,
             path,
             base_dir,
-            suppressed_rules(region.kind),
+            suppressed_rules(),
         );
         if fixed == region.content {
             continue;
         }
         let raw = &markdown[region.raw_span.clone()];
-        let newline = detect_newline(raw);
-        if reindent(&region.content, region.col_offset, newline) != raw {
+        let newline = buffer_newline(raw);
+        let indent = " ".repeat(region.col_offset);
+        if reindent(&region.content, &indent, newline) != raw {
             continue;
         }
-        out.replace_range(
-            region.raw_span.clone(),
-            &reindent(&fixed, region.col_offset, newline),
-        );
+        out.replace_range(region.raw_span.clone(), &reindent(&fixed, &indent, newline));
         changed = true;
     }
     changed.then_some(out)
 }
 
-/// The newline style of a raw region: CRLF if the first line ending is `\r\n`,
-/// otherwise LF.
-fn detect_newline(raw: &str) -> &'static str {
-    match raw.find('\n') {
-        Some(index) if raw.as_bytes().get(index.wrapping_sub(1)) == Some(&b'\r') => {
-            "\r\n"
-        }
-        _ => "\n",
-    }
-}
-
-/// Re-encode dedented region content into its host: each non-empty line regains
-/// `col_offset` leading spaces and lines are joined with `newline`. Empty lines
-/// stay empty (matching how the parser dedents blank lines), and the trailing
-/// newline is preserved.
-fn reindent(content: &str, col_offset: usize, newline: &str) -> String {
-    let indent = " ".repeat(col_offset);
+/// Re-encode dedented region content into its host: each non-empty line regains the
+/// region's leading `indent` and lines are joined with `newline`. Empty lines stay
+/// empty (matching how the parser dedents blank lines), and the trailing newline is
+/// preserved.
+fn reindent(content: &str, indent: &str, newline: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for piece in content.replace("\r\n", "\n").split_inclusive('\n') {
         let (line, terminated) = piece
             .strip_suffix('\n')
             .map_or((piece, false), |line| (line, true));
         if !line.is_empty() {
-            out.push_str(&indent);
+            out.push_str(indent);
             out.push_str(line);
         }
         if terminated {

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -163,12 +163,13 @@ pub fn apply_markdown_safe_fixes_in_place(
 /// results back in, returning the rewritten document (or `None` if nothing
 /// changed).
 ///
-/// File-shape rules are excluded per [`suppressed_rules`]. A region is only
-/// rewritten when its fixed YAML can be re-indented to reproduce the original raw
-/// bytes exactly (the reconstruct-and-verify guard); ragged-indent, tab-indented,
-/// or otherwise non-round-trippable regions are left untouched (still reported in
-/// check mode). Regions are spliced back-to-front so earlier edits do not shift
-/// later offsets.
+/// File-shape rules are excluded per [`suppressed_rules`]. Each line regains the
+/// prefix the parser stripped (leading spaces, a blockquote `> `, or a tab), and a
+/// region is only rewritten when re-applying that prefix reproduces the original raw
+/// bytes exactly (the reconstruct-and-verify guard); a region whose lines do not
+/// share one prefix (ragged indentation) is left untouched (still reported in check
+/// mode). Regions are spliced back-to-front so earlier edits do not shift later
+/// offsets.
 #[must_use]
 pub fn fix_markdown_str(
     markdown: &str,
@@ -201,28 +202,34 @@ pub fn fix_markdown_str(
         }
         let raw = &markdown[region.raw_span.clone()];
         let newline = buffer_newline(raw);
-        let indent = " ".repeat(region.col_offset);
-        if reindent(&region.content, &indent, newline) != raw {
+        // The prefix the parser stripped from each content line — spaces for an
+        // indented fence, `> ` for a blockquoted one, a tab, etc. `raw` starts at the
+        // first content line and `col_offset` (its stripped char count) never spans a
+        // newline, so the first `col_offset` chars of `raw` are exactly that prefix.
+        // The guard below re-checks it reproduces every line, so a non-uniform
+        // (ragged) prefix still fails and is skipped.
+        let prefix: String = raw.chars().take(region.col_offset).collect();
+        if reindent(&region.content, &prefix, newline) != raw {
             continue;
         }
-        out.replace_range(region.raw_span.clone(), &reindent(&fixed, &indent, newline));
+        out.replace_range(region.raw_span.clone(), &reindent(&fixed, &prefix, newline));
         changed = true;
     }
     changed.then_some(out)
 }
 
 /// Re-encode dedented region content into its host: each non-empty line regains the
-/// region's leading `indent` and lines are joined with `newline`. Empty lines stay
+/// region's leading `prefix` and lines are joined with `newline`. Empty lines stay
 /// empty (matching how the parser dedents blank lines), and the trailing newline is
 /// preserved.
-fn reindent(content: &str, indent: &str, newline: &str) -> String {
+fn reindent(content: &str, prefix: &str, newline: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for piece in content.replace("\r\n", "\n").split_inclusive('\n') {
         let (line, terminated) = piece
             .strip_suffix('\n')
             .map_or((piece, false), |line| (line, true));
         if !line.is_empty() {
-            out.push_str(indent);
+            out.push_str(prefix);
             out.push_str(line);
         }
         if terminated {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,9 @@ use ryl::migrate::{
     MigrateOptions, OutputMode as MigrateOutputMode, SourceCleanup, WriteMode,
     migrate_configs,
 };
-use ryl::{LintProblem, Severity, lint_file, lint_markdown_file, lint_str};
+use ryl::{
+    LintProblem, Severity, lint_file, lint_markdown_file, lint_markdown_str, lint_str,
+};
 
 const STDIN_LABEL: &str = "<stdin>";
 
@@ -191,6 +193,11 @@ struct LintFlags {
 
     #[command(flatten)]
     compatibility: CompatibilityLintFlags,
+
+    /// Lint inputs as Markdown (embedded YAML front matter and fenced yaml/yml
+    /// blocks) using default globs, without configuring `[files].markdown`
+    #[arg(long = "markdown", default_value_t = false)]
+    markdown: bool,
 }
 
 #[derive(clap::Args, Debug, Default)]
@@ -384,6 +391,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         &candidates,
         &explicit_files,
         global_cfg.as_ref(),
+        cli.lint.markdown,
         &mut cache,
         &mut emitted_notices,
         &mut files,
@@ -402,11 +410,6 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
 
     let mut initial_problem_count = 0usize;
     if cli.lint.fix.fix {
-        if files.iter().any(|(.., kind)| *kind == SourceKind::Markdown) {
-            eprintln!(
-                "note: --fix does not modify markdown files; embedded YAML is checked only"
-            );
-        }
         let initial_results = lint_files(&files);
         initial_problem_count = count_reported_problems(
             &initial_results,
@@ -451,21 +454,19 @@ fn summary_to_exit(summary: &LintSummary, strict: bool) -> ExitCode {
 fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     let (path, base_dir, cfg, apply_yaml_files) = resolve_stdin_ctx(cli)?;
 
-    if apply_yaml_files
-        && (cfg.is_file_ignored(&path, &base_dir)
-            || !cfg.is_yaml_candidate(&path, &base_dir))
-    {
+    let Some(kind) = resolve_stdin_kind(cli, &cfg, &path, &base_dir, apply_yaml_files)?
+    else {
         return Ok(ExitCode::SUCCESS);
-    }
+    };
 
     if cli.lint.compatibility.list_files {
         println!("{}", path.display());
         return Ok(ExitCode::SUCCESS);
     }
 
-    let outcome = read_and_lint_stdin(&path, &base_dir, &cfg);
+    let outcome = read_and_lint_stdin(&path, &base_dir, &cfg, kind);
 
-    let files = vec![(path, base_dir, cfg, SourceKind::Yaml)];
+    let files = vec![(path, base_dir, cfg, kind)];
     let results = vec![(0usize, outcome)];
 
     let output_format = detect_output_format(cli.format);
@@ -478,10 +479,34 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     Ok(summary_to_exit(&summary, cli.lint.compatibility.strict))
 }
 
+/// Resolve the source kind for stdin, or `None` to skip (ignored / no glob match).
+/// With `--stdin-filename` the kind comes from `[files]` globs; without it, only
+/// `--markdown` selects markdown (there is no path to match), else YAML.
+fn resolve_stdin_kind(
+    cli: &Cli,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+    apply_yaml_files: bool,
+) -> Result<Option<SourceKind>, String> {
+    if !apply_yaml_files {
+        return Ok(Some(if cli.lint.markdown {
+            SourceKind::Markdown
+        } else {
+            SourceKind::Yaml
+        }));
+    }
+    if cfg.is_file_ignored(path, base_dir) {
+        return Ok(None);
+    }
+    cfg.source_kind(path, base_dir)
+}
+
 fn read_and_lint_stdin(
     path: &Path,
     base_dir: &Path,
     cfg: &YamlLintConfig,
+    kind: SourceKind,
 ) -> Result<Vec<LintProblem>, String> {
     let mut buf = Vec::new();
     std::io::stdin()
@@ -489,7 +514,10 @@ fn read_and_lint_stdin(
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
     let content = decoder::decode_bytes(&buf)
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-    Ok(lint_str(&content, path, cfg, base_dir))
+    Ok(match kind {
+        SourceKind::Markdown => lint_markdown_str(&content, path, cfg, base_dir),
+        SourceKind::Yaml => lint_str(&content, path, cfg, base_dir),
+    })
 }
 
 fn resolve_stdin_ctx(
@@ -509,6 +537,9 @@ fn resolve_stdin_ctx(
         eprintln!("{notice}");
     }
     let mut cfg = ctx.config;
+    if cli.lint.markdown {
+        cfg.enable_default_markdown(&ctx.base_dir);
+    }
     if !apply_yaml_files {
         cfg.disable_path_based_rule_ignores();
     }
@@ -538,16 +569,20 @@ fn gather_lint_files(
     candidates: &[PathBuf],
     explicit_files: &[PathBuf],
     global_cfg: Option<&ConfigContext>,
+    markdown: bool,
     cache: &mut HashMap<PathBuf, (PathBuf, YamlLintConfig)>,
     emitted_notices: &mut HashSet<String>,
     files: &mut Vec<(PathBuf, PathBuf, YamlLintConfig, SourceKind)>,
 ) -> Result<(), String> {
     for f in candidates {
-        let (base_dir, cfg, notices) = resolve_ctx(f, global_cfg, cache)?;
+        let (base_dir, mut cfg, notices) = resolve_ctx(f, global_cfg, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
                 eprintln!("{notice}");
             }
+        }
+        if markdown {
+            cfg.enable_default_markdown(&base_dir);
         }
         if cfg.is_file_ignored(f, &base_dir) {
             continue;
@@ -558,11 +593,14 @@ fn gather_lint_files(
     }
 
     for ef in explicit_files {
-        let (base_dir, cfg, notices) = resolve_ctx(ef, global_cfg, cache)?;
+        let (base_dir, mut cfg, notices) = resolve_ctx(ef, global_cfg, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
                 eprintln!("{notice}");
             }
+        }
+        if markdown {
+            cfg.enable_default_markdown(&base_dir);
         }
         if cfg.is_file_ignored(ef, &base_dir) {
             continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,10 +485,10 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     Ok(summary_to_exit(&summary, cli.lint.compatibility.strict))
 }
 
-/// Resolve the source kind for stdin, or `None` to skip (ignored / no glob match).
-/// `--markdown` forces Markdown (honouring an ignored `--stdin-filename` first);
-/// otherwise, with `--stdin-filename` the kind comes from `[files]` globs, and
-/// without one the input is linted as YAML.
+/// Resolve the source kind for stdin, or `None` to skip an ignored `--stdin-filename`.
+/// `--markdown` forces Markdown; otherwise, with `--stdin-filename` the kind comes
+/// from `[files]` globs (a named file matching no kind is an error, like an
+/// explicitly-passed file), and without one the input is linted as YAML.
 fn resolve_stdin_kind(
     cli: &Cli,
     cfg: &YamlLintConfig,
@@ -505,7 +505,16 @@ fn resolve_stdin_kind(
     if !apply_yaml_files {
         return Ok(Some(SourceKind::Yaml));
     }
-    cfg.source_kind(path, base_dir)
+    match cfg.source_kind(path, base_dir)? {
+        Some(kind) => Ok(Some(kind)),
+        // A named stdin file that matches no kind is an error, the same as an
+        // explicitly-passed file (see `gather_lint_files`).
+        None => Err(format!(
+            "{}: no source kind matches; add a matching glob under \
+             [files].yaml or [files].markdown",
+            path.display()
+        )),
+    }
 }
 
 fn read_and_lint_stdin(

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,7 +370,13 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
     }
 
     // Build a global config if -d/-c provided or env var set; else None for per-file discovery.
-    let global_cfg = build_global_cfg(&cli.inputs, &cli)?;
+    let mut global_cfg = build_global_cfg(&cli.inputs, &cli)?;
+    if cli.lint.markdown
+        && let Some(ctx) = global_cfg.as_mut()
+    {
+        // Enable markdown once here so per-file clones inherit the built matcher.
+        ctx.config.enable_default_markdown(&ctx.base_dir);
+    }
     if let Some(cfg) = &global_cfg {
         for notice in &cfg.notices {
             eprintln!("{notice}");
@@ -480,8 +486,9 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
 }
 
 /// Resolve the source kind for stdin, or `None` to skip (ignored / no glob match).
-/// With `--stdin-filename` the kind comes from `[files]` globs; without it, only
-/// `--markdown` selects markdown (there is no path to match), else YAML.
+/// `--markdown` forces Markdown (honouring an ignored `--stdin-filename` first);
+/// otherwise, with `--stdin-filename` the kind comes from `[files]` globs, and
+/// without one the input is linted as YAML.
 fn resolve_stdin_kind(
     cli: &Cli,
     cfg: &YamlLintConfig,
@@ -489,15 +496,14 @@ fn resolve_stdin_kind(
     base_dir: &Path,
     apply_yaml_files: bool,
 ) -> Result<Option<SourceKind>, String> {
-    if !apply_yaml_files {
-        return Ok(Some(if cli.lint.markdown {
-            SourceKind::Markdown
-        } else {
-            SourceKind::Yaml
-        }));
-    }
-    if cfg.is_file_ignored(path, base_dir) {
+    if apply_yaml_files && cfg.is_file_ignored(path, base_dir) {
         return Ok(None);
+    }
+    if cli.lint.markdown {
+        return Ok(Some(SourceKind::Markdown));
+    }
+    if !apply_yaml_files {
+        return Ok(Some(SourceKind::Yaml));
     }
     cfg.source_kind(path, base_dir)
 }
@@ -575,14 +581,11 @@ fn gather_lint_files(
     files: &mut Vec<(PathBuf, PathBuf, YamlLintConfig, SourceKind)>,
 ) -> Result<(), String> {
     for f in candidates {
-        let (base_dir, mut cfg, notices) = resolve_ctx(f, global_cfg, cache)?;
+        let (base_dir, cfg, notices) = resolve_ctx(f, global_cfg, markdown, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
                 eprintln!("{notice}");
             }
-        }
-        if markdown {
-            cfg.enable_default_markdown(&base_dir);
         }
         if cfg.is_file_ignored(f, &base_dir) {
             continue;
@@ -593,14 +596,11 @@ fn gather_lint_files(
     }
 
     for ef in explicit_files {
-        let (base_dir, mut cfg, notices) = resolve_ctx(ef, global_cfg, cache)?;
+        let (base_dir, cfg, notices) = resolve_ctx(ef, global_cfg, markdown, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
                 eprintln!("{notice}");
             }
-        }
-        if markdown {
-            cfg.enable_default_markdown(&base_dir);
         }
         if cfg.is_file_ignored(ef, &base_dir) {
             continue;

--- a/src/markdown_embed/lint.rs
+++ b/src/markdown_embed/lint.rs
@@ -3,26 +3,17 @@
 
 use std::path::Path;
 
-use super::{MarkdownSources, extract_regions};
+use super::{EmbeddedRegion, MarkdownSources, extract_regions};
 use crate::config::YamlLintConfig;
+use crate::fix::suppressed_rules;
 use crate::lint::{LintProblem, lint_str};
-use crate::rules::{document_end, document_start, new_line_at_end_of_file, new_lines};
-
-/// File-shape rules suppressed inside embedded regions: a region is not a
-/// standalone file, so "missing document start/end" and file-newline checks do
-/// not apply (the analog of markdown linters skipping their first-line/EOF rules).
-const SUPPRESSED: [&str; 4] = [
-    new_line_at_end_of_file::ID,
-    new_lines::ID,
-    document_start::ID,
-    document_end::ID,
-];
 
 /// Lint every embedded YAML region in `markdown` and return diagnostics whose
 /// line/column point into the original markdown document.
 ///
 /// Each region is linted as an independent YAML document. File-shape rules that
-/// only make sense for a standalone file are suppressed (see [`is_suppressed`]).
+/// only make sense for a standalone file are suppressed per region kind (see
+/// [`suppressed_rules`]).
 #[must_use]
 pub fn lint_markdown_str(
     markdown: &str,
@@ -40,18 +31,39 @@ pub fn lint_markdown_str(
         if region.content.trim().is_empty() {
             continue;
         }
+        let suppressed = suppressed_rules(region.kind);
+        let stripped = stripped_indents(markdown, &region);
         for mut problem in lint_str(&region.content, path, cfg, base_dir) {
-            if is_suppressed(problem.rule) {
+            if problem.rule.is_some_and(|id| suppressed.contains(&id)) {
                 continue;
             }
+            problem.column += stripped
+                .get(problem.line - 1)
+                .copied()
+                .unwrap_or(region.col_offset);
             problem.line += region.line_offset;
-            problem.column += region.col_offset;
             problems.push(problem);
         }
     }
     problems
 }
 
-fn is_suppressed(rule: Option<&str>) -> bool {
-    rule.is_some_and(|id| SUPPRESSED.contains(&id))
+/// Per content line, the indent pulldown actually stripped (`min(leading spaces on
+/// the raw line, col_offset)`). A uniformly-indented block yields `col_offset` for
+/// every line; a line indented less than the fence yields its own smaller value, so
+/// its column is not over-shifted. Empty for regions with no indent (front matter),
+/// where the `col_offset` fallback (0) applies.
+fn stripped_indents(markdown: &str, region: &EmbeddedRegion) -> Vec<usize> {
+    if region.col_offset == 0 {
+        return Vec::new();
+    }
+    markdown[region.raw_span.clone()]
+        .split('\n')
+        .map(|line| {
+            line.bytes()
+                .take_while(|byte| *byte == b' ')
+                .count()
+                .min(region.col_offset)
+        })
+        .collect()
 }

--- a/src/markdown_embed/lint.rs
+++ b/src/markdown_embed/lint.rs
@@ -26,17 +26,20 @@ pub fn lint_markdown_str(
         fenced_blocks: cfg.markdown_fenced_blocks(),
     };
 
+    let suppressed = suppressed_rules();
     let mut problems = Vec::new();
     for region in extract_regions(markdown, sources) {
         if region.content.trim().is_empty() {
             continue;
         }
-        let suppressed = suppressed_rules(region.kind);
+        let mut region_problems = lint_str(&region.content, path, cfg, base_dir);
+        region_problems
+            .retain(|problem| !problem.rule.is_some_and(|id| suppressed.contains(&id)));
+        if region_problems.is_empty() {
+            continue;
+        }
         let stripped = stripped_indents(markdown, &region);
-        for mut problem in lint_str(&region.content, path, cfg, base_dir) {
-            if problem.rule.is_some_and(|id| suppressed.contains(&id)) {
-                continue;
-            }
+        for mut problem in region_problems {
             problem.column += stripped
                 .get(problem.line - 1)
                 .copied()
@@ -48,22 +51,21 @@ pub fn lint_markdown_str(
     problems
 }
 
-/// Per content line, the indent pulldown actually stripped (`min(leading spaces on
-/// the raw line, col_offset)`). A uniformly-indented block yields `col_offset` for
-/// every line; a line indented less than the fence yields its own smaller value, so
-/// its column is not over-shifted. Empty for regions with no indent (front matter),
-/// where the `col_offset` fallback (0) applies.
+/// Per content line, the number of characters the `CommonMark` parser stripped from
+/// its start — `chars(raw line) - chars(content line)` — which covers leading
+/// space/tab indentation, blockquote markers, and CRLF normalisation alike. Added
+/// back to each diagnostic column so positions point into the host document, and
+/// correct for ragged blocks (a line dedented less than the fence yields a smaller
+/// value). Front matter content equals its raw span, so every entry is 0.
 fn stripped_indents(markdown: &str, region: &EmbeddedRegion) -> Vec<usize> {
-    if region.col_offset == 0 {
-        return Vec::new();
-    }
     markdown[region.raw_span.clone()]
         .split('\n')
-        .map(|line| {
-            line.bytes()
-                .take_while(|byte| *byte == b' ')
+        .zip(region.content.split('\n'))
+        .map(|(raw, content)| {
+            raw.trim_end_matches('\r')
+                .chars()
                 .count()
-                .min(region.col_offset)
+                .saturating_sub(content.trim_end_matches('\r').chars().count())
         })
         .collect()
 }

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -61,20 +61,20 @@ pub fn extract_regions(
     if sources.fenced_blocks {
         collect_fenced_blocks(markdown, &mut regions);
     }
-    // A ```yaml fence inside the front-matter scalar is part of that scalar's
-    // string value, not a standalone document, yet CommonMark still parses it.
-    // Drop fenced regions nested inside the front matter (always the first region
-    // when present) so they are neither double-linted nor, under --fix, rewritten
-    // as spans overlapping the front matter.
-    let front = regions
+    // A ```yaml fence that overlaps the front matter (always the leading region when
+    // present) is malformed: it opens inside the front-matter scalar — possibly
+    // closing after the `---`/`...` terminator — so its content is partly that
+    // scalar's string value, not a standalone document, yet CommonMark still parses
+    // it. Front matter starts at the top, so any fence that begins before it ends
+    // intersects it; drop those so their content is neither double-linted nor, under
+    // --fix, spliced over the front matter's span.
+    let front_end = regions
         .first()
         .filter(|region| region.kind == RegionKind::FrontMatter)
-        .map(|region| region.raw_span.clone());
-    if let Some(front) = front {
+        .map(|region| region.raw_span.end);
+    if let Some(front_end) = front_end {
         regions.retain(|region| {
-            region.kind == RegionKind::FrontMatter
-                || region.raw_span.start < front.start
-                || region.raw_span.end > front.end
+            region.kind == RegionKind::FrontMatter || region.raw_span.start >= front_end
         });
     }
     regions

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -61,6 +61,22 @@ pub fn extract_regions(
     if sources.fenced_blocks {
         collect_fenced_blocks(markdown, &mut regions);
     }
+    // A ```yaml fence inside the front-matter scalar is part of that scalar's
+    // string value, not a standalone document, yet CommonMark still parses it.
+    // Drop fenced regions nested inside the front matter (always the first region
+    // when present) so they are neither double-linted nor, under --fix, rewritten
+    // as spans overlapping the front matter.
+    let front = regions
+        .first()
+        .filter(|region| region.kind == RegionKind::FrontMatter)
+        .map(|region| region.raw_span.clone());
+    if let Some(front) = front {
+        regions.retain(|region| {
+            region.kind == RegionKind::FrontMatter
+                || region.raw_span.start < front.start
+                || region.raw_span.end > front.end
+        });
+    }
     regions
 }
 

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -61,20 +61,23 @@ pub fn extract_regions(
     if sources.fenced_blocks {
         collect_fenced_blocks(markdown, &mut regions);
     }
-    // A ```yaml fence that overlaps the front matter (always the leading region when
-    // present) is malformed: it opens inside the front-matter scalar — possibly
-    // closing after the `---`/`...` terminator — so its content is partly that
-    // scalar's string value, not a standalone document, yet CommonMark still parses
-    // it. Front matter starts at the top, so any fence that begins before it ends
-    // intersects it; drop those so their content is neither double-linted nor, under
-    // --fix, spliced over the front matter's span.
+    // A ```yaml fence that opens inside the front-matter scalar is malformed: its
+    // content is partly that scalar's string value, not a standalone document, yet
+    // CommonMark still parses it (possibly extending past the `---`/`...` terminator).
+    // Front matter is the leading region, and a real body fence's content always
+    // begins *strictly after* the terminator line, so keep a fence only when its
+    // content starts past the front matter end. Content starting before the end is a
+    // fence inside the scalar; content starting exactly at the end means the opening
+    // fence was the last front-matter line (the terminator is its first content line)
+    // — both are dropped so their content is neither double-linted nor, under --fix,
+    // spliced over the front matter's span.
     let front_end = regions
         .first()
         .filter(|region| region.kind == RegionKind::FrontMatter)
         .map(|region| region.raw_span.end);
     if let Some(front_end) = front_end {
         regions.retain(|region| {
-            region.kind == RegionKind::FrontMatter || region.raw_span.start >= front_end
+            region.kind == RegionKind::FrontMatter || region.raw_span.start > front_end
         });
     }
     regions

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -12,6 +12,8 @@ mod lint;
 
 pub use lint::lint_markdown_str;
 
+use std::ops::Range;
+
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 
 /// Which embedded YAML sources to extract from a markdown document.
@@ -39,6 +41,10 @@ pub struct EmbeddedRegion {
     /// to every diagnostic column. Always 0 for front matter.
     pub col_offset: usize,
     pub content: String,
+    /// Byte span of the region's raw content in the source markdown. Used by
+    /// `--fix` write-back to splice fixed YAML back, and by the per-line column
+    /// remap to recover each line's actually-stripped indent.
+    pub raw_span: Range<usize>,
 }
 
 #[must_use]
@@ -75,6 +81,7 @@ fn front_matter_region(markdown: &str) -> Option<EmbeddedRegion> {
                 line_offset: markdown[..content_start].matches('\n').count(),
                 col_offset: 0,
                 content: markdown[content_start..cursor].to_string(),
+                raw_span: content_start..cursor,
             });
         }
         cursor = line_end + 1;
@@ -108,10 +115,17 @@ fn collect_fenced_blocks(markdown: &str, regions: &mut Vec<EmbeddedRegion>) {
                 if let Some(accumulator) = active.take()
                     && let Some(first_byte) = accumulator.first_byte
                 {
+                    let line_start = line_start_of(markdown, first_byte);
                     regions.push(EmbeddedRegion {
                         kind: RegionKind::FencedBlock,
-                        line_offset: markdown[..first_byte].matches('\n').count(),
-                        col_offset: fence_indent(markdown, first_byte),
+                        line_offset: markdown[..line_start].matches('\n').count(),
+                        col_offset: markdown[line_start..first_byte].chars().count(),
+                        raw_span: line_start
+                            ..fenced_content_end(
+                                markdown,
+                                line_start,
+                                &accumulator.content,
+                            ),
                         content: accumulator.content,
                     });
                 }
@@ -127,15 +141,33 @@ struct FenceAccumulator {
     first_byte: Option<usize>,
 }
 
-/// Characters of leading indentation pulldown stripped from the fenced block,
-/// i.e. the column of its first content byte. The block's content always sits on
-/// a line after its opening fence, so a preceding newline is guaranteed.
-fn fence_indent(markdown: &str, content_start: usize) -> usize {
-    let line_start = markdown[..content_start]
+/// Byte offset of the start of the line containing `content_start`. The block's
+/// content always sits on a line after its opening fence, so a preceding newline
+/// is guaranteed.
+fn line_start_of(markdown: &str, content_start: usize) -> usize {
+    markdown[..content_start]
         .rfind('\n')
         .expect("fenced block content follows its opening fence line")
-        + 1;
-    markdown[line_start..content_start].chars().count()
+        + 1
+}
+
+/// Byte offset where the fenced block's raw content ends (the start of the closing
+/// fence line, or end of input for a block left open at EOF). Found by walking the
+/// same number of source lines the dedented content spans.
+fn fenced_content_end(markdown: &str, start: usize, content: &str) -> usize {
+    // Content without a trailing newline only happens for a block left open at EOF,
+    // whose content runs to the end of input.
+    if !content.ends_with('\n') {
+        return markdown.len();
+    }
+    let mut pos = start;
+    for _ in 0..content.matches('\n').count() {
+        let offset = markdown[pos..]
+            .find('\n')
+            .expect("each content line precedes the closing fence");
+        pos += offset + 1;
+    }
+    pos
 }
 
 fn is_yaml_info(info: &str) -> bool {

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -52,9 +52,15 @@ pub fn extract_regions(
     markdown: &str,
     sources: MarkdownSources,
 ) -> Vec<EmbeddedRegion> {
+    // Locate the front matter regardless of whether it is linted, so a fence nested
+    // in its scalar is filtered out even when `front-matter = false` (otherwise that
+    // disabled source would still be linted/fixed via the nested fence).
+    let front_matter = front_matter_region(markdown);
+    let front_end = front_matter.as_ref().map(|region| region.raw_span.end);
+
     let mut regions = Vec::new();
     if sources.front_matter
-        && let Some(region) = front_matter_region(markdown)
+        && let Some(region) = front_matter
     {
         regions.push(region);
     }
@@ -64,17 +70,13 @@ pub fn extract_regions(
     // A ```yaml fence that opens inside the front-matter scalar is malformed: its
     // content is partly that scalar's string value, not a standalone document, yet
     // CommonMark still parses it (possibly extending past the `---`/`...` terminator).
-    // Front matter is the leading region, and a real body fence's content always
-    // begins *strictly after* the terminator line, so keep a fence only when its
-    // content starts past the front matter end. Content starting before the end is a
-    // fence inside the scalar; content starting exactly at the end means the opening
-    // fence was the last front-matter line (the terminator is its first content line)
-    // — both are dropped so their content is neither double-linted nor, under --fix,
-    // spliced over the front matter's span.
-    let front_end = regions
-        .first()
-        .filter(|region| region.kind == RegionKind::FrontMatter)
-        .map(|region| region.raw_span.end);
+    // Front matter is at the top, and a real body fence's content always begins
+    // *strictly after* the terminator line, so keep a fence only when its content
+    // starts past the front matter end. Content before the end is a fence inside the
+    // scalar; content exactly at the end means the opening fence was the last
+    // front-matter line (the terminator is its first content line) — both are dropped
+    // so their content is neither double-linted nor, under --fix, spliced over the
+    // front matter's span.
     if let Some(front_end) = front_end {
         regions.retain(|region| {
             region.kind == RegionKind::FrontMatter || region.raw_span.start > front_end

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -141,6 +141,23 @@ fn fence_nested_in_front_matter_is_not_double_linted() {
 }
 
 #[test]
+fn fence_crossing_front_matter_terminator_is_dropped() {
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
+    let body = "---\ntags: [x,y]\ndesc: |\n  ```yaml\n  inner: [1,2]\n---\nafter: [3,4]\n```\n\ntext\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("2:10"), "front matter is linted: {err}");
+    assert!(
+        !err.contains("5:13") && !err.contains("7:11"),
+        "a fence opened inside front matter and closed after the terminator must \
+         not be linted as a separate region: {err}"
+    );
+}
+
+#[test]
 fn multibyte_front_matter_columns_pass_through() {
     let body = "---\ncaf\u{e9}:  x\n---\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -158,6 +158,37 @@ fn fence_crossing_front_matter_terminator_is_dropped() {
 }
 
 #[test]
+fn fence_opening_on_last_front_matter_line_is_dropped() {
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
+    let body = "---\ndesc: |\n  ```yaml\n---\nafter: [1,2]\n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert!(
+        out.is_empty() && err.is_empty(),
+        "a fence whose opener is the last front-matter line (content starting on the \
+         terminator) must not be linted as a body fence: out={out} err={err}"
+    );
+}
+
+#[test]
+fn body_fence_immediately_after_front_matter_is_linted() {
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
+    let body = "---\na: 1\n---\n```yaml\nnums: [1,2]\n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(
+        err.contains("5:10") && err.contains("commas"),
+        "a real body fence directly after the terminator must still be linted: {err}"
+    );
+}
+
+#[test]
 fn multibyte_front_matter_columns_pass_through() {
     let body = "---\ncaf\u{e9}:  x\n---\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -170,21 +170,22 @@ fn explicit_markdown_without_files_pattern_is_rejected() {
 }
 
 #[test]
-fn fix_skips_markdown_with_notice() {
-    let body = "---\na:  1\n---\n";
-    let (_dir, file) = project(COLONS_ONLY, "doc.md", body);
+fn fix_rewrites_markdown_front_matter() {
+    let config =
+        "files = { markdown = [\"*.md\"] }\n[rules]\ntrailing-spaces = \"enable\"\n";
+    let body = "---\nfoo: bar  \n---\n";
+    let (_dir, file) = project(config, "doc.md", body);
 
     let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
         .arg("--fix")
         .arg(&file));
 
-    assert_eq!(code, 1, "stderr={err}");
-    assert!(err.contains("does not modify markdown files"), "{err}");
-    assert!(err.contains("(0 fixed, 1 remaining)"), "{err}");
+    assert_eq!(code, 0, "stderr={err}");
+    assert!(!err.contains("does not modify markdown files"), "{err}");
     assert_eq!(
         fs::read_to_string(&file).unwrap(),
-        body,
-        "file must be unchanged"
+        "---\nfoo: bar\n---\n",
+        "trailing spaces in front matter must be fixed in place"
     );
 }
 

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -111,6 +111,36 @@ fn crlf_markdown_maps_positions() {
 }
 
 #[test]
+fn blockquoted_fence_column_accounts_for_quote_marker() {
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ntruthy = \"enable\"\n";
+    let body = "> ```yaml\n> foo: True\n> ```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(
+        err.contains("2:8"),
+        "blockquote `> ` prefix must shift the column to 8: {err}"
+    );
+}
+
+#[test]
+fn fence_nested_in_front_matter_is_not_double_linted() {
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ntruthy = \"enable\"\n";
+    let body = "---\ndesc: |\n  ```yaml\n  inner: True\n  ```\n---\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert!(
+        out.is_empty() && err.is_empty(),
+        "a fence inside a front-matter scalar is string content, not a document: out={out} err={err}"
+    );
+}
+
+#[test]
 fn multibyte_front_matter_columns_pass_through() {
     let body = "---\ncaf\u{e9}:  x\n---\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -158,6 +158,22 @@ fn fence_crossing_front_matter_terminator_is_dropped() {
 }
 
 #[test]
+fn fence_inside_disabled_front_matter_is_not_linted() {
+    let config = "files = { markdown = [\"*.md\"] }\nmarkdown = { front-matter = false }\n[rules]\ncommas = \"enable\"\n";
+    let body = "---\ndesc: |\n  ```yaml\n  inner: [1,2]\n  ```\n---\n\ntext\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert!(
+        out.is_empty() && err.is_empty(),
+        "a fence inside the front-matter scalar must stay unlinted when front-matter \
+         is disabled: out={out} err={err}"
+    );
+}
+
+#[test]
 fn fence_opening_on_last_front_matter_line_is_dropped() {
     let config = "files = { markdown = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
     let body = "---\ndesc: |\n  ```yaml\n---\nafter: [1,2]\n```\n";

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -112,18 +112,32 @@ fn fix_skips_ragged_indent_block_but_reports() {
 }
 
 #[test]
-fn fix_skips_tab_indented_block_but_reports() {
+fn fix_rewrites_tab_indented_block_preserving_tab() {
     let body = "- item\n\n\t```yaml\n\tnums: [1,2]\n\t```\n";
     let (_dir, file) = project(COMMAS, "doc.md", body);
 
     let (code, _out, err) = fix(&file);
 
-    assert_eq!(code, 1, "stderr={err}");
-    assert!(err.contains("commas"), "tab block must still report: {err}");
+    assert_eq!(code, 0, "stderr={err}");
     assert_eq!(
         fs::read_to_string(&file).unwrap(),
-        body,
-        "tab-indented block must be left byte-identical"
+        "- item\n\n\t```yaml\n\tnums: [1, 2]\n\t```\n",
+        "a uniformly tab-indented fence is fixed with its tab prefix preserved"
+    );
+}
+
+#[test]
+fn fix_rewrites_blockquoted_fence_preserving_markers() {
+    let body = "> ```yaml\n> nums: [1,2]\n> more: [3,4]\n> ```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "> ```yaml\n> nums: [1, 2]\n> more: [3, 4]\n> ```\n",
+        "a blockquoted fence is fixed with its `> ` prefix preserved on every line"
     );
 }
 

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -1,0 +1,315 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+fn project(
+    config: &str,
+    name: &str,
+    body: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".ryl.toml"), config).unwrap();
+    let file = dir.path().join(name);
+    fs::write(&file, body.as_bytes()).unwrap();
+    (dir, file)
+}
+
+fn fix(file: &std::path::Path) -> (i32, String, String) {
+    run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--fix")
+        .arg(file))
+}
+
+const TRAILING: &str =
+    "files = { markdown = [\"*.md\"] }\n[rules]\ntrailing-spaces = \"enable\"\n";
+const COMMAS: &str =
+    "files = { markdown = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
+
+#[test]
+fn fix_rewrites_indented_fenced_block_preserving_indent() {
+    let body = "- item\n\n  ```yaml\n  nums: [1,2,3]\n  ```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "- item\n\n  ```yaml\n  nums: [1, 2, 3]\n  ```\n",
+        "fenced block fixed and re-indented to the fence column"
+    );
+}
+
+#[test]
+fn fix_preserves_crlf_in_fenced_block() {
+    let body = "# t\r\n\r\n```yaml\r\nnums: [1,2,3]\r\n```\r\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "# t\r\n\r\n```yaml\r\nnums: [1, 2, 3]\r\n```\r\n",
+        "CRLF newlines must be preserved through the fix"
+    );
+}
+
+#[test]
+fn fix_handles_front_matter_and_multiple_fenced_blocks() {
+    let body = "---\nfoo: [1,2]\n---\n\n```yaml\nbar: [3,4]\n```\n\nText\n\n```yaml\nbaz: [5,6]\n```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "---\nfoo: [1, 2]\n---\n\n```yaml\nbar: [3, 4]\n```\n\nText\n\n```yaml\nbaz: [5, 6]\n```\n",
+        "front matter and every fenced block must be fixed back-to-front"
+    );
+}
+
+#[test]
+fn fix_does_not_inject_document_start_or_final_newline() {
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ndocument-start = \"enable\"\ntrailing-spaces = \"enable\"\n";
+    let body = "---\nfoo: bar  \n---\n\n```yaml\nbaz: qux  \n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "---\nfoo: bar\n---\n\n```yaml\nbaz: qux\n```\n",
+        "file-shape rules must not inject --- or trailing newlines into fragments"
+    );
+}
+
+#[test]
+fn fix_skips_ragged_indent_block_but_reports() {
+    let body = "Intro\n\n   ```yaml\n   a: [1,2 ]\n  b: 3\n   ```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("4:10") && err.contains("commas"), "{err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        body,
+        "ragged-indent block must be left byte-identical"
+    );
+}
+
+#[test]
+fn fix_skips_tab_indented_block_but_reports() {
+    let body = "- item\n\n\t```yaml\n\tnums: [1,2]\n\t```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("commas"), "tab block must still report: {err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        body,
+        "tab-indented block must be left byte-identical"
+    );
+}
+
+#[test]
+fn fix_handles_unclosed_fence_at_eof() {
+    let body = "# t\n\n```yaml\nnums: [1,2]";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "# t\n\n```yaml\nnums: [1, 2]",
+        "unclosed fence is fixed without inventing a closing fence or newline"
+    );
+}
+
+#[test]
+fn fix_preserves_utf8_bom() {
+    let body = "\u{feff}---\nfoo: bar  \n---\n";
+    let (_dir, file) = project(TRAILING, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    let fixed = fs::read(&file).unwrap();
+    assert_eq!(&fixed[..3], &[0xEF, 0xBB, 0xBF], "BOM must be preserved");
+    assert_eq!(
+        String::from_utf8(fixed).unwrap(),
+        "\u{feff}---\nfoo: bar\n---\n",
+        "content after the BOM must be fixed"
+    );
+}
+
+#[test]
+fn fix_is_idempotent() {
+    let body = "---\nfoo: [1,2]\n---\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (_c, _o, _e) = fix(&file);
+    let once = fs::read_to_string(&file).unwrap();
+    let (code, _out, err) = fix(&file);
+    let twice = fs::read_to_string(&file).unwrap();
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(once, twice, "a second --fix must be a no-op");
+    assert!(
+        !err.contains("fixed"),
+        "no fixes reported on the second run: {err}"
+    );
+}
+
+#[test]
+fn fix_reports_fixed_and_remaining_summary() {
+    let config = "files = { markdown = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\ncolons = \"enable\"\n";
+    let body = "```yaml\nnums: [1,2]\nfoo:  bar\n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("(1 fixed, 1 remaining)"), "{err}");
+}
+
+#[test]
+fn fix_leaves_clean_markdown_untouched() {
+    let body = "---\nfoo: bar\n---\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        body,
+        "no fixes, no rewrite"
+    );
+    assert!(!err.contains("fixed"), "{err}");
+}
+
+#[test]
+fn fix_skips_empty_region() {
+    let body = "---\n   \n---\n\n```yaml\nnums: [1,2]\n```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "---\n   \n---\n\n```yaml\nnums: [1, 2]\n```\n",
+        "whitespace-only region is skipped while the fixable block is fixed"
+    );
+}
+
+#[test]
+fn markdown_flag_is_noop_when_globs_already_configured() {
+    let body = "```yaml\nnums: [1,2]\n```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--fix")
+        .arg("--markdown")
+        .arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "```yaml\nnums: [1, 2]\n```\n",
+        "--markdown leaves an already-configured markdown glob set untouched"
+    );
+}
+
+#[test]
+fn markdown_flag_scans_directory() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ncommas = \"enable\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("doc.md"), "```yaml\nnums: [1,2]\n```\n").unwrap();
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--markdown")
+        .arg(dir.path()));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(
+        err.contains("commas"),
+        "directory scan with --markdown: {err}"
+    );
+}
+
+#[test]
+fn fix_missing_markdown_file_reports_read_error() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".ryl.toml"), COMMAS).unwrap();
+    let file = dir.path().join("missing.md");
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 2, "missing markdown file must fail: {err}");
+    assert!(err.contains("failed to read"), "{err}");
+}
+
+#[test]
+#[allow(clippy::permissions_set_readonly_false)]
+fn fix_markdown_write_error_is_reported() {
+    let (_dir, file) = project(COMMAS, "doc.md", "```yaml\nnums: [1,2]\n```\n");
+
+    let mut perms = fs::metadata(&file).unwrap().permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&file, perms).unwrap();
+
+    let (code, _out, err) = fix(&file);
+
+    let mut perms = fs::metadata(&file).unwrap().permissions();
+    perms.set_readonly(false);
+    let _ = fs::set_permissions(&file, perms);
+
+    assert_eq!(code, 2, "read-only markdown fix must fail: {err}");
+    assert!(err.contains("failed to write fixed file"), "{err}");
+}
+
+#[test]
+fn markdown_flag_enables_fix_without_files_glob() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ncommas = \"enable\"\n",
+    )
+    .unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(&file, "```yaml\nnums: [1,2]\n```\n").unwrap();
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--fix")
+        .arg("--markdown")
+        .arg(&file));
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "```yaml\nnums: [1, 2]\n```\n",
+        "--markdown enables embedded-YAML fixing without a [files].markdown glob"
+    );
+}

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -326,6 +326,22 @@ fn markdown_flag_applies_to_global_config() {
 }
 
 #[test]
+fn fix_drops_fence_crossing_front_matter_terminator() {
+    let body = "---\ntags: [x,y]\ndesc: |\n  ```yaml\n  inner: [1,2]\n---\nafter: [3,4]\n```\n\ntext\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "---\ntags: [x, y]\ndesc: |\n  ```yaml\n  inner: [1,2]\n---\nafter: [3,4]\n```\n\ntext\n",
+        "only the front matter is fixed; a fence crossing the terminator is left \
+         untouched (no overlapping splice)"
+    );
+}
+
+#[test]
 fn markdown_flag_wins_over_overlapping_yaml_glob() {
     let config = "files = { yaml = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
     let (_dir, file) = project(config, "doc.md", "```yaml\nnums: [1,2]\n```\n");

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -291,6 +291,58 @@ fn fix_markdown_write_error_is_reported() {
 }
 
 #[test]
+fn fix_does_not_corrupt_fence_inside_front_matter() {
+    let body = "---\nzzz: [9,9]\nfoo: |\n  ```yaml\n  bar: [1,2]\n  ```\n---\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "---\nzzz: [9, 9]\nfoo: |\n  ```yaml\n  bar: [1,2]\n  ```\n---\n",
+        "a fence nested in a front-matter scalar must not be fixed as standalone \
+         YAML or cause overlapping-splice corruption"
+    );
+}
+
+#[test]
+fn markdown_flag_applies_to_global_config() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(&file, "```yaml\nnums: [1,2]\n```\n").unwrap();
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--markdown")
+        .arg("-d")
+        .arg("rules: {commas: enable}")
+        .arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(
+        err.contains("commas"),
+        "--markdown must enable markdown on a -d/-c global config: {err}"
+    );
+}
+
+#[test]
+fn markdown_flag_wins_over_overlapping_yaml_glob() {
+    let config = "files = { yaml = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
+    let (_dir, file) = project(config, "doc.md", "```yaml\nnums: [1,2]\n```\n");
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--markdown")
+        .arg(&file));
+
+    assert_eq!(code, 1, "stderr={err}");
+    assert!(err.contains("commas"), "linted as markdown: {err}");
+    assert!(
+        !err.contains("matches both"),
+        "--markdown-injected globs must win over yaml on overlap: {err}"
+    );
+}
+
+#[test]
 fn markdown_flag_enables_fix_without_files_glob() {
     let dir = tempdir().unwrap();
     fs::write(

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -356,6 +356,23 @@ fn fix_drops_fence_crossing_front_matter_terminator() {
 }
 
 #[test]
+fn fix_leaves_fence_inside_disabled_front_matter_untouched() {
+    let config = "files = { markdown = [\"*.md\"] }\nmarkdown = { front-matter = false }\n[rules]\ncommas = \"enable\"\n";
+    let body = "---\ndesc: |\n  ```yaml\n  inner: [1,2]\n  ```\n---\n\ntext\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        body,
+        "front-matter content (including a nested fence) must be untouched when \
+         front-matter is disabled"
+    );
+}
+
+#[test]
 fn fix_drops_fence_opening_on_last_front_matter_line() {
     let body = "---\ndesc: |\n  ```yaml\n---\nafter: [1,2]\n```\n";
     let (_dir, file) = project(COMMAS, "doc.md", body);

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -342,6 +342,22 @@ fn fix_drops_fence_crossing_front_matter_terminator() {
 }
 
 #[test]
+fn fix_drops_fence_opening_on_last_front_matter_line() {
+    let body = "---\ndesc: |\n  ```yaml\n---\nafter: [1,2]\n```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (code, _out, err) = fix(&file);
+
+    assert_eq!(code, 0, "stderr={err}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        body,
+        "a fence opening on the last front-matter line is not a body fence; --fix \
+         must leave the document untouched"
+    );
+}
+
+#[test]
 fn markdown_flag_wins_over_overlapping_yaml_glob() {
     let config = "files = { yaml = [\"*.md\"] }\n[rules]\ncommas = \"enable\"\n";
     let (_dir, file) = project(config, "doc.md", "```yaml\nnums: [1,2]\n```\n");

--- a/tests/cli_stdin.rs
+++ b/tests/cli_stdin.rs
@@ -422,3 +422,93 @@ fn stdin_no_warnings_suppresses_warning_output() {
     assert!(stdout.trim().is_empty(), "expected empty stdout: {stdout}");
     assert!(stderr.trim().is_empty(), "expected empty stderr: {stderr}");
 }
+
+#[test]
+fn stdin_markdown_filename_lints_embedded_yaml() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "files = { markdown = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .current_dir(dir.path())
+            .arg("-")
+            .arg("--stdin-filename")
+            .arg(dir.path().join("doc.md")),
+        b"---\nfoo:  bar\n---\n",
+    );
+    assert_eq!(code, 1, "embedded YAML must be linted: {stderr}");
+    assert!(
+        stderr.contains("2:6") && stderr.contains("colons"),
+        "front-matter diagnostic maps to host position: {stderr}"
+    );
+}
+
+#[test]
+fn stdin_markdown_flag_lints_embedded_yaml() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--markdown")
+            .arg("-")
+            .arg("-d")
+            .arg("rules: {colons: enable}"),
+        b"# t\n\n```yaml\nfoo:  bar\n```\n",
+    );
+    assert_eq!(code, 1, "fenced block must be linted: {stderr}");
+    assert!(
+        stderr.contains("<stdin>") && stderr.contains("4:6"),
+        "fenced diagnostic uses stdin label and host position: {stderr}"
+    );
+}
+
+#[test]
+fn stdin_markdown_filename_ignored_is_skipped() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "files = { markdown = [\"*.md\"] }\nignore = [\"doc.md\"]\n[rules]\ncolons = \"enable\"\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .current_dir(dir.path())
+            .arg("-")
+            .arg("--stdin-filename")
+            .arg(dir.path().join("doc.md")),
+        b"---\nfoo:  bar\n---\n",
+    );
+    assert_eq!(code, 0, "ignored stdin path must be skipped: {stderr}");
+    assert!(
+        stdout.is_empty() && stderr.is_empty(),
+        "out={stdout} err={stderr}"
+    );
+}
+
+#[test]
+fn stdin_markdown_overlap_is_a_hard_error() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "files = { yaml = [\"*.md\"], markdown = [\"*.md\"] }\n[rules]\ncolons = \"enable\"\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .current_dir(dir.path())
+            .arg("-")
+            .arg("--stdin-filename")
+            .arg(dir.path().join("doc.md")),
+        b"foo: bar\n",
+    );
+    assert_eq!(code, 2, "overlap must be a usage error: {stderr}");
+    assert!(stderr.contains("matches both"), "{stderr}");
+}

--- a/tests/cli_stdin.rs
+++ b/tests/cli_stdin.rs
@@ -103,7 +103,7 @@ fn stdin_filename_appears_in_diagnostics() {
 }
 
 #[test]
-fn stdin_filename_filters_non_yaml_extension() {
+fn stdin_filename_no_source_kind_errors() {
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, stdout, stderr) = run_with_stdin(
         Command::new(exe)
@@ -112,9 +112,15 @@ fn stdin_filename_filters_non_yaml_extension() {
             .arg("script.sh"),
         b"key:  value\n",
     );
-    assert_eq!(code, 0, "non-yaml ext should be skipped: {stderr}");
+    assert_eq!(
+        code, 2,
+        "unmatched stdin filename errors like an explicit file: {stderr}"
+    );
     assert!(stdout.is_empty(), "stdout should be empty: {stdout}");
-    assert!(stderr.is_empty(), "stderr should be empty: {stderr}");
+    assert!(
+        stderr.contains("no source kind matches"),
+        "expected no-source-kind error: {stderr}"
+    );
 }
 
 #[test]

--- a/tests/cli_stdin.rs
+++ b/tests/cli_stdin.rs
@@ -492,6 +492,31 @@ fn stdin_markdown_filename_ignored_is_skipped() {
 }
 
 #[test]
+fn stdin_markdown_flag_overrides_non_markdown_filename() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--markdown")
+            .arg("-")
+            .arg("--stdin-filename")
+            .arg("notes.txt")
+            .arg("-d")
+            .arg("rules: {colons: enable}"),
+        b"---\nfoo:  bar\n---\n",
+    );
+    assert_eq!(
+        code, 1,
+        "--markdown must force markdown regardless of filename: {stderr}"
+    );
+    assert!(
+        stderr.contains("notes.txt")
+            && stderr.contains("2:6")
+            && stderr.contains("colons"),
+        "embedded front matter linted under the provided label: {stderr}"
+    );
+}
+
+#[test]
 fn stdin_markdown_overlap_is_a_hard_error() {
     let dir = tempdir().unwrap();
     fs::write(

--- a/tests/property_markdown_fix.rs
+++ b/tests/property_markdown_fix.rs
@@ -1,0 +1,189 @@
+//! Property-based tests for `fix_markdown_str` — the `--fix` write-back into YAML
+//! embedded in markdown.
+//!
+//! Reuses the safe-fix YAML generator (`ast`/`strategy`/`config`) so the embedded
+//! YAML matches the flat `--fix` suite, and wraps it into a markdown host
+//! (`wrap`). The invariants are self-consistent (no external oracle): the host
+//! bytes outside embedded regions are preserved, region count/kinds are stable,
+//! each region's parsed value is preserved, every region is either left untouched
+//! or rewritten to exactly its safe-fixed form, and the whole operation is
+//! idempotent. Deterministic siblings pin known-dirty documents (front matter,
+//! indented + CRLF fenced blocks) and the guard-skip path (ragged indent) so the
+//! random invariants cannot pass vacuously.
+
+// These modules are shared with the safe-fix suite, which exercises every item;
+// this binary reuses only the YAML generator and a few helpers, so allow the rest
+// to be unused here.
+#[path = "property_safe_fix/ast.rs"]
+#[allow(dead_code)]
+mod ast;
+#[path = "property_safe_fix/config.rs"]
+#[allow(dead_code)]
+mod config;
+#[path = "property_safe_fix/strategy.rs"]
+mod strategy;
+#[path = "property_markdown_fix/wrap.rs"]
+mod wrap;
+
+use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+use ryl::config::YamlLintConfig;
+use ryl::fix::{apply_safe_fixes_filtered, fix_markdown_str, suppressed_rules};
+use ryl::{EmbeddedRegion, MarkdownSources, extract_regions};
+
+use config::{parse_for_compare, safe_fix_configs, synthetic_base_dir, synthetic_path};
+use wrap::arb_markdown_doc;
+
+fn regions_of(markdown: &str, cfg: &YamlLintConfig) -> Vec<EmbeddedRegion> {
+    extract_regions(
+        markdown,
+        MarkdownSources {
+            front_matter: cfg.markdown_front_matter(),
+            fenced_blocks: cfg.markdown_fenced_blocks(),
+        },
+    )
+}
+
+/// Every byte outside the embedded regions is byte-identical, and the regions
+/// line up one-to-one by kind.
+fn verify_host_preserved(
+    original: &str,
+    fixed: &str,
+    cfg: &YamlLintConfig,
+) -> Result<(), TestCaseError> {
+    let before = regions_of(original, cfg);
+    let after = regions_of(fixed, cfg);
+    prop_assert_eq!(
+        before.len(),
+        after.len(),
+        "region count changed: {:?} -> {:?}",
+        original,
+        fixed
+    );
+    let mut original_cursor = 0;
+    let mut fixed_cursor = 0;
+    for (orig, fixd) in before.iter().zip(after.iter()) {
+        prop_assert_eq!(orig.kind, fixd.kind, "region kind changed");
+        prop_assert_eq!(
+            &original[original_cursor..orig.raw_span.start],
+            &fixed[fixed_cursor..fixd.raw_span.start],
+            "host bytes around a region changed"
+        );
+        original_cursor = orig.raw_span.end;
+        fixed_cursor = fixd.raw_span.end;
+    }
+    prop_assert_eq!(
+        &original[original_cursor..],
+        &fixed[fixed_cursor..],
+        "trailing host bytes changed"
+    );
+    Ok(())
+}
+
+/// Each region preserves its parsed YAML value and is either left untouched or
+/// rewritten to exactly the safe-fixed form of its original content.
+fn verify_regions(
+    original: &str,
+    fixed: &str,
+    cfg: &YamlLintConfig,
+) -> Result<(), TestCaseError> {
+    for (orig, fixd) in regions_of(original, cfg).iter().zip(regions_of(fixed, cfg)) {
+        if let Some(before) = parse_for_compare(&orig.content) {
+            prop_assert!(
+                parse_for_compare(&fixd.content).as_ref() == Some(&before),
+                "region parsed value changed: {:?} -> {:?}",
+                orig.content,
+                fixd.content
+            );
+        }
+        let safe_fixed = apply_safe_fixes_filtered(
+            &orig.content,
+            cfg,
+            synthetic_path(),
+            synthetic_base_dir(),
+            suppressed_rules(orig.kind),
+        );
+        prop_assert!(
+            fixd.content == orig.content || fixd.content == safe_fixed,
+            "region must be unchanged or exactly safe-fixed: orig={:?} fixed={:?} safe_fixed={:?}",
+            orig.content,
+            fixd.content,
+            safe_fixed
+        );
+    }
+    Ok(())
+}
+
+fn run_invariants(markdown: &str) -> Result<(), TestCaseError> {
+    for prepared in safe_fix_configs() {
+        let cfg = &prepared.cfg;
+        let fixed =
+            fix_markdown_str(markdown, synthetic_path(), cfg, synthetic_base_dir());
+        let result = fixed.clone().unwrap_or_else(|| markdown.to_string());
+        verify_host_preserved(markdown, &result, cfg)?;
+        verify_regions(markdown, &result, cfg)?;
+        if let Some(once) = fixed {
+            let twice =
+                fix_markdown_str(&once, synthetic_path(), cfg, synthetic_base_dir());
+            prop_assert!(
+                twice.is_none() || twice.as_deref() == Some(once.as_str()),
+                "fix not idempotent under '{}': once={:?} twice={:?}",
+                prepared.name,
+                once,
+                twice
+            );
+        }
+    }
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "tests/proptest-regressions/property_markdown_fix.txt",
+        ))),
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn markdown_fix_invariants(document in arb_markdown_doc()) {
+        run_invariants(&document.render())?;
+    }
+}
+
+fn fixed_with_default(markdown: &str) -> Option<String> {
+    let cfg = &safe_fix_configs()[0].cfg;
+    fix_markdown_str(markdown, synthetic_path(), cfg, synthetic_base_dir())
+}
+
+#[test]
+fn known_dirty_front_matter_and_indented_block_is_fixed() {
+    let markdown = "---\nfoo: [1,2]\n---\n\ntext\n\n  ```yaml\n  bar: [3,4]\n  ```\n";
+    run_invariants(markdown).expect("invariants hold for known-dirty markdown");
+    assert_eq!(
+        fixed_with_default(markdown).as_deref(),
+        Some("---\nfoo: [1, 2]\n---\n\ntext\n\n  ```yaml\n  bar: [3, 4]\n  ```\n"),
+        "front matter and indented fenced block must both be fixed"
+    );
+}
+
+#[test]
+fn known_dirty_crlf_block_round_trips() {
+    let markdown = "# t\r\n\r\n```yaml\r\nbar: [3,4]\r\n```\r\n";
+    run_invariants(markdown).expect("invariants hold for CRLF markdown");
+    assert_eq!(
+        fixed_with_default(markdown).as_deref(),
+        Some("# t\r\n\r\n```yaml\r\nbar: [3, 4]\r\n```\r\n"),
+        "CRLF must be preserved through the fix"
+    );
+}
+
+#[test]
+fn ragged_indent_block_is_skipped() {
+    let markdown = "text\n\n   ```yaml\n   a: [1,2 ]\n  b: 3\n   ```\n";
+    run_invariants(markdown).expect("invariants hold for ragged markdown");
+    assert!(
+        fixed_with_default(markdown).is_none(),
+        "ragged-indent block cannot be reproduced exactly, so it is left untouched"
+    );
+}

--- a/tests/property_markdown_fix.rs
+++ b/tests/property_markdown_fix.rs
@@ -191,6 +191,28 @@ fn fence_opening_on_last_front_matter_line_does_not_corrupt() {
 }
 
 #[test]
+fn blockquoted_fence_round_trips() {
+    let markdown = "> ```yaml\n> nums: [1,2]\n> more: [3,4]\n> ```\n";
+    run_invariants(markdown).expect("invariants hold for a blockquoted fence");
+    assert_eq!(
+        fixed_with_default(markdown).as_deref(),
+        Some("> ```yaml\n> nums: [1, 2]\n> more: [3, 4]\n> ```\n"),
+        "a uniform `> ` prefix is preserved on every fixed line"
+    );
+}
+
+#[test]
+fn tab_indented_fence_round_trips() {
+    let markdown = "- item\n\n\t```yaml\n\tnums: [1,2]\n\t```\n";
+    run_invariants(markdown).expect("invariants hold for a tab-indented fence");
+    assert_eq!(
+        fixed_with_default(markdown).as_deref(),
+        Some("- item\n\n\t```yaml\n\tnums: [1, 2]\n\t```\n"),
+        "a uniform tab prefix is preserved when fixing"
+    );
+}
+
+#[test]
 fn ragged_indent_block_is_skipped() {
     let markdown = "text\n\n   ```yaml\n   a: [1,2 ]\n  b: 3\n   ```\n";
     run_invariants(markdown).expect("invariants hold for ragged markdown");

--- a/tests/property_markdown_fix.rs
+++ b/tests/property_markdown_fix.rs
@@ -101,7 +101,7 @@ fn verify_regions(
             cfg,
             synthetic_path(),
             synthetic_base_dir(),
-            suppressed_rules(orig.kind),
+            suppressed_rules(),
         );
         prop_assert!(
             fixd.content == orig.content || fixd.content == safe_fixed,
@@ -176,6 +176,14 @@ fn known_dirty_crlf_block_round_trips() {
         Some("# t\r\n\r\n```yaml\r\nbar: [3, 4]\r\n```\r\n"),
         "CRLF must be preserved through the fix"
     );
+}
+
+#[test]
+fn fence_nested_in_front_matter_does_not_corrupt() {
+    let markdown =
+        "---\nzzz: [9,9]\nfoo: |\n  ```yaml\n  bar: [1,2]\n  ```\n---\n\nbody\n";
+    run_invariants(markdown)
+        .expect("invariants hold when a fence is nested in a front-matter scalar");
 }
 
 #[test]

--- a/tests/property_markdown_fix.rs
+++ b/tests/property_markdown_fix.rs
@@ -1,19 +1,13 @@
-//! Property-based tests for `fix_markdown_str` — the `--fix` write-back into YAML
-//! embedded in markdown.
-//!
-//! Reuses the safe-fix YAML generator (`ast`/`strategy`/`config`) so the embedded
-//! YAML matches the flat `--fix` suite, and wraps it into a markdown host
-//! (`wrap`). The invariants are self-consistent (no external oracle): the host
-//! bytes outside embedded regions are preserved, region count/kinds are stable,
-//! each region's parsed value is preserved, every region is either left untouched
-//! or rewritten to exactly its safe-fixed form, and the whole operation is
-//! idempotent. Deterministic siblings pin known-dirty documents (front matter,
-//! indented + CRLF fenced blocks) and the guard-skip path (ragged indent) so the
-//! random invariants cannot pass vacuously.
+//! Property tests for `fix_markdown_str` — the `--fix` write-back into YAML embedded
+//! in markdown. The YAML generator is reused from the safe-fix suite via `#[path]`
+//! (`ast`/`strategy`/`config`) and wrapped into a markdown host (`wrap`); the
+//! invariants (`verify_host_preserved`/`verify_regions`/`run_invariants`) are
+//! self-consistent, with no external oracle. Deterministic siblings pin
+//! known-dirty/CRLF/ragged/boundary-crossing cases so the random property cannot
+//! pass vacuously.
 
-// These modules are shared with the safe-fix suite, which exercises every item;
-// this binary reuses only the YAML generator and a few helpers, so allow the rest
-// to be unused here.
+// Shared with the safe-fix suite (which uses every item); this binary reuses only
+// the generator and a few helpers, so allow the rest to be unused.
 #[path = "property_safe_fix/ast.rs"]
 #[allow(dead_code)]
 mod ast;
@@ -44,8 +38,6 @@ fn regions_of(markdown: &str, cfg: &YamlLintConfig) -> Vec<EmbeddedRegion> {
     )
 }
 
-/// Every byte outside the embedded regions is byte-identical, and the regions
-/// line up one-to-one by kind.
 fn verify_host_preserved(
     original: &str,
     fixed: &str,
@@ -80,8 +72,6 @@ fn verify_host_preserved(
     Ok(())
 }
 
-/// Each region preserves its parsed YAML value and is either left untouched or
-/// rewritten to exactly the safe-fixed form of its original content.
 fn verify_regions(
     original: &str,
     fixed: &str,

--- a/tests/property_markdown_fix.rs
+++ b/tests/property_markdown_fix.rs
@@ -184,6 +184,13 @@ fn fence_crossing_front_matter_terminator_does_not_corrupt() {
 }
 
 #[test]
+fn fence_opening_on_last_front_matter_line_does_not_corrupt() {
+    let markdown = "---\ndesc: |\n  ```yaml\n---\nafter: [1,2]\n```\n\ntext\n";
+    run_invariants(markdown)
+        .expect("invariants hold when a fence opens on the last front-matter line");
+}
+
+#[test]
 fn ragged_indent_block_is_skipped() {
     let markdown = "text\n\n   ```yaml\n   a: [1,2 ]\n  b: 3\n   ```\n";
     run_invariants(markdown).expect("invariants hold for ragged markdown");

--- a/tests/property_markdown_fix.rs
+++ b/tests/property_markdown_fix.rs
@@ -187,6 +187,13 @@ fn fence_nested_in_front_matter_does_not_corrupt() {
 }
 
 #[test]
+fn fence_crossing_front_matter_terminator_does_not_corrupt() {
+    let markdown = "---\ntags: [x,y]\ndesc: |\n  ```yaml\n  inner: [1,2]\n---\nafter: [3,4]\n```\n\ntext\n";
+    run_invariants(markdown)
+        .expect("invariants hold when a fence crosses the front-matter terminator");
+}
+
+#[test]
 fn ragged_indent_block_is_skipped() {
     let markdown = "text\n\n   ```yaml\n   a: [1,2 ]\n  b: 3\n   ```\n";
     run_invariants(markdown).expect("invariants hold for ragged markdown");

--- a/tests/property_markdown_fix/wrap.rs
+++ b/tests/property_markdown_fix/wrap.rs
@@ -1,0 +1,118 @@
+//! Wraps generated YAML `Document`s into a markdown host: optional front matter
+//! plus prose-separated fenced `yaml`/`yml` blocks at varied indent. Reuses the
+//! safe-fix YAML AST/strategy so the embedded YAML matches the flat `--fix` suite.
+
+use proptest::prelude::*;
+
+use super::ast::{Document, NewlineStyle};
+use super::strategy::arb_document;
+
+#[derive(Debug)]
+pub struct FencedSection {
+    pub prose: String,
+    pub doc: Document,
+    pub indent: usize,
+    pub fence: char,
+    pub info: String,
+}
+
+#[derive(Debug)]
+pub struct MarkdownDoc {
+    pub front: Option<Document>,
+    pub sections: Vec<FencedSection>,
+    pub newline: NewlineStyle,
+}
+
+fn newline_str(newline: NewlineStyle) -> &'static str {
+    match newline {
+        NewlineStyle::Lf => "\n",
+        NewlineStyle::Crlf => "\r\n",
+    }
+}
+
+/// The YAML body as logical lines (LF-split, no trailing terminator), so the host
+/// renderer can re-terminate with its own newline and indent each non-empty line.
+fn yaml_lines(doc: &Document) -> Vec<String> {
+    let mut normalized = doc.clone();
+    normalized.newline = NewlineStyle::Lf;
+    normalized.has_final_newline = false;
+    normalized.render().split('\n').map(String::from).collect()
+}
+
+impl MarkdownDoc {
+    pub fn render(&self) -> String {
+        let nl = newline_str(self.newline);
+        let mut out = String::new();
+        if let Some(front) = &self.front {
+            out.push_str("---");
+            out.push_str(nl);
+            push_body(&mut out, &yaml_lines(front), "", nl);
+            out.push_str("---");
+            out.push_str(nl);
+            out.push_str(nl);
+        }
+        for section in &self.sections {
+            out.push_str(&section.prose);
+            out.push_str(nl);
+            out.push_str(nl);
+            let indent = " ".repeat(section.indent);
+            let fence: String = std::iter::repeat_n(section.fence, 3).collect();
+            out.push_str(&indent);
+            out.push_str(&fence);
+            out.push_str(&section.info);
+            out.push_str(nl);
+            push_body(&mut out, &yaml_lines(&section.doc), &indent, nl);
+            out.push_str(&indent);
+            out.push_str(&fence);
+            out.push_str(nl);
+            out.push_str(nl);
+        }
+        out
+    }
+}
+
+/// Append YAML body lines, indenting non-empty lines (blank lines stay empty, the
+/// way the CommonMark parser dedents them) and terminating with `nl`.
+fn push_body(out: &mut String, lines: &[String], indent: &str, nl: &str) {
+    for line in lines {
+        if !line.is_empty() {
+            out.push_str(indent);
+            out.push_str(line);
+        }
+        out.push_str(nl);
+    }
+}
+
+fn arb_prose() -> impl Strategy<Value = String> {
+    prop::collection::vec("[a-z]{1,6}", 1..=4).prop_map(|words| words.join(" "))
+}
+
+fn arb_section() -> impl Strategy<Value = FencedSection> {
+    (
+        arb_prose(),
+        arb_document(),
+        0usize..=3,
+        prop_oneof![Just('`'), Just('~')],
+        prop_oneof![Just("yaml".to_string()), Just("yml".to_string())],
+    )
+        .prop_map(|(prose, doc, indent, fence, info)| FencedSection {
+            prose,
+            doc,
+            indent,
+            fence,
+            info,
+        })
+}
+
+pub fn arb_markdown_doc() -> impl Strategy<Value = MarkdownDoc> {
+    (
+        prop::option::of(arb_document()),
+        prop::collection::vec(arb_section(), 0..=3),
+        prop_oneof![Just(NewlineStyle::Lf), Just(NewlineStyle::Crlf)],
+    )
+        .prop_map(|(front, sections, newline)| MarkdownDoc {
+            front,
+            sections,
+            newline,
+        })
+}

--- a/tests/property_markdown_fix/wrap.rs
+++ b/tests/property_markdown_fix/wrap.rs
@@ -71,8 +71,8 @@ impl MarkdownDoc {
     }
 }
 
-/// Append YAML body lines, indenting non-empty lines (blank lines stay empty, the
-/// way the CommonMark parser dedents them) and terminating with `nl`.
+/// Indent each non-blank line; blank lines stay empty (matching how the CommonMark
+/// parser dedents them) so an indented block round-trips.
 fn push_body(out: &mut String, lines: &[String], indent: &str, nl: &str) {
     for line in lines {
         if !line.is_empty() {

--- a/tests/resolve_ctx_empty_parent.rs
+++ b/tests/resolve_ctx_empty_parent.rs
@@ -7,7 +7,7 @@ use ryl::config::YamlLintConfig;
 #[test]
 fn resolve_ctx_handles_path_without_parent() {
     let mut cache: HashMap<PathBuf, (PathBuf, YamlLintConfig)> = HashMap::new();
-    let (base_dir, cfg, notices) = resolve_ctx(Path::new(""), None, &mut cache)
+    let (base_dir, cfg, notices) = resolve_ctx(Path::new(""), None, false, &mut cache)
         .expect("resolve_ctx should fall back to current directory");
     assert_eq!(base_dir, PathBuf::from("."));
     assert!(notices.is_empty());

--- a/uv.lock
+++ b/uv.lock
@@ -4,14 +4,14 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.10.2"
+version = "0.11.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Implements the full scope of #236 (the deferred follow-ups to the check-only v1 from #222/#237).

## What

- **`--fix` write-back for embedded YAML** — applies safe fixes to each region and splices them back into the Markdown, re-indenting to the fence column and preserving CRLF. File-shape rules (`document-start`/`-end`, `new-line-at-end-of-file`, `new-lines`) are excluded so a fragment never gains a `---`/`...` or trailing newline.
- **Lint embedded YAML from stdin** — `ryl - --stdin-filename doc.md` routes through `source_kind` to the Markdown linter.
- **Ragged-indent column accuracy** — diagnostics are remapped by each line's actually-stripped indent (`chars(raw) - chars(content)`), correct for spaces, tabs, blockquote markers, CRLF, and ragged blocks.
- **`--markdown` flag** — enables Markdown linting with default globs (`*.md`,`*.markdown`,`*.mdx`,`*.qmd`,`*.Rmd`) without editing config; its globs win over `yaml` on overlap.
- **Per-`RegionKind` suppression** — collapsed to a single shared `suppressed_rules()` used by both the check and fix paths (kept the no-drift benefit; dropped speculative per-kind duplication).

## Safety

`--fix` write-back is **on by default**, made safe by a **reconstruct-and-verify guard**: a region is only rewritten if re-indenting its fixed YAML reproduces the original bytes exactly. Ragged/tab/blockquoted/non-round-trippable regions (and fences nested inside front-matter scalars) are reported but left byte-untouched — so write-back cannot corrupt a document.

## Review

Addresses a Codex review and a `/code-review` pass: the front-matter/fence **overlap corruption**, the **column regression** for non-space indents, stdin `--markdown` routing, the `--markdown`/`yaml` overlap footgun, and assorted reuse/efficiency cleanups (shared `buffer_newline`, build the markdown matcher once per dir, `FixContext`). Confirmed the rumdl `code-block-tools` integration (#209) is unaffected — it uses plain `ryl -`, which is unchanged.

## Testing

- 1139 tests; **100% line + region coverage**; prek clean.
- New property suite `tests/property_markdown_fix.rs` (host-byte preservation, parse preservation, region unchanged-or-exactly-safe-fixed, idempotence) + `tests/cli_markdown_fix.rs`; property sweep clean at `PROPTEST_CASES=10000`.
- **Manual `--fix` on real corpora** (idempotent, zero structural changes inside Markdown): home-assistant.io, kubernetes/website, github/docs, helm/helm, prometheus/docs, plus Quarto (`quarto-web`), RMarkdown (`rstudio/rmarkdown`, `r4ds`), and anthropics/skills.

## Docs

`docs/markdown.md`: write-back + reconstruct guarantee, `--markdown`/stdin, Markdown-family extensions (Quarto/RMarkdown/MDX/skills) with worked examples, and non-obvious YAML extensions (`CITATION.cff`, `.clang-format`, `*.cwl`).

---

## ⚠️ Breaking changes / upgrade notes (0.10.2 → 0.11.0)

This release also carries the `[files]` config redesign (#237) and the byte→char offset fix (#240), so the upgrade isn't purely additive. **Markdown linting itself is strictly opt-in** — it requires `[files].markdown` globs or the `--markdown` flag and never activates on an existing config (the `[files]` table is new in 0.11.0; YAML configs can't enable it; there's no default `.md` glob). The breaking changes are:

1. **TOML configs: top-level `yaml-files` is rejected.** Use `[files].yaml` instead. A `ryl.toml`/`.ryl.toml`/`[tool.ryl]` that set `yaml-files = [...]` now fails with `invalid config: \`yaml-files\` is not valid in TOML; use \`[files]\` with \`yaml = [...]\` instead` (exit 2). **YAML (`.yamllint`) configs are unaffected** — `yaml-files` still works there.

2. **Explicitly passing a file that matches no source kind now errors (was a silent skip).** `ryl README.md`, `ryl notes.txt`, `ryl $(git diff --name-only)` etc. previously skipped non-YAML files silently (exit 0); they now exit 2 with `no source kind matches; add a matching glob under [files].yaml or [files].markdown`. Mitigation: pass only YAML, add the extension to `[files].yaml`, or use `--markdown` for Markdown. **pre-commit users are unaffected** (the `ryl-pre-commit` hook is `types: [yaml]`, so only YAML files are passed).

3. **`ryl - --stdin-filename <non-YAML-path>` now errors (was a silent skip).** Editor/LSP integrations that pipe arbitrary buffers via `--stdin-filename` will get exit 2 for paths matching no source kind. **Plain `ryl -` (no `--stdin-filename`) is unchanged**, so the rumdl `code-block-tools` integration (#209) is unaffected.

4. **Diagnostic columns are corrected on lines with multibyte characters** (#240). The `commas`/`colons`/`braces`/`brackets` rules now report char-based columns; no diagnostics are added or removed, but reported `col` values can shift on multibyte lines.

Not affected: no new default-enabled rules (clean files stay clean apart from #4's column shifts), no removed/renamed CLI flags (only `--markdown` added), and arbitrary unknown top-level TOML keys are not newly rejected.
