### PR TITLE
Sync markdown pre-commit docs with ryl-pre-commit's ryl-markdown hook

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -179,23 +179,45 @@ also be turned on for a single run from the command line:
 
 ## Use with pre-commit
 
-When `ryl` runs as a pre-commit hook, the hook only sees the file paths
-pre-commit passes to it. The `ryl` hook targets YAML files by default, so to lint
-Markdown you must both (a) add a `markdown` glob under `[files]` in your ryl config
-and (b) widen the hook to pass Markdown files, for example:
+`ryl` is published as a pre-commit hook at
+[ryl-pre-commit](https://github.com/owenlamont/ryl-pre-commit). The default `ryl`
+hook only sees YAML files. To also lint YAML embedded in Markdown, add the
+dedicated `ryl-markdown` hook — it runs `ryl --markdown`, so it needs **no**
+`[files]` config:
 
 ```yaml
 - repo: https://github.com/owenlamont/ryl-pre-commit
-  rev: <version>
+  rev: v0.11.0
+  hooks:
+    - id: ryl
+    - id: ryl-markdown
+```
+
+The `ryl-markdown` hook targets `.md`, `.markdown`, `.mdx`, `.qmd`, and `.Rmd`
+files and requires `ryl >= 0.11.0`. To autofix the embedded YAML in place, add
+`args: [--fix]`:
+
+```yaml
+    - id: ryl-markdown
+      args: [--fix]
+```
+
+Prefer a single hook? You can instead widen the plain `ryl` hook to also pass
+Markdown files and opt them in via `[files]`:
+
+```yaml
+- repo: https://github.com/owenlamont/ryl-pre-commit
+  rev: v0.11.0
   hooks:
     - id: ryl
       types_or: [yaml, markdown]
 ```
 
-pre-commit decides *which* files to pass; `[files]` decides *how* ryl treats each.
-So if the hook passes a `.md` that no `[files]` glob matches, ryl reports an error
-(it was named explicitly) — add a `markdown` glob to `[files]` to lint it, or narrow
-the hook's file filter.
+This route needs a `markdown` glob under `[files]` in your ryl config: pre-commit
+decides *which* files to pass; `[files]` decides *how* ryl treats each. So if the
+hook passes a `.md` that no `[files]` glob matches, ryl reports an error (it was
+named explicitly) — add a `markdown` glob to `[files]` to lint it, or narrow the
+hook's file filter.
 
 `ryl` also applies its `ignore` patterns to **explicitly passed** files, not just
 to files found by scanning a directory. So a file pre-commit hands to `ryl` that


### PR DESCRIPTION
## Summary

`docs/markdown.md`'s "Use with pre-commit" section had drifted out of sync with
what [ryl-pre-commit](https://github.com/owenlamont/ryl-pre-commit) actually
documents.

The docs recommended the *old* approach — widening the plain `ryl` hook with
`types_or: [yaml, markdown]` **and** adding a `[files].markdown` glob. But
ryl-pre-commit (since v0.11.0) now ships a dedicated **`ryl-markdown`** hook that
runs `ryl --markdown`, targets `.md/.markdown/.mdx/.qmd/.Rmd`, and needs no
`[files]` config.

## Changes

- Lead with the recommended `ryl-markdown` hook (mirrors ryl-pre-commit's
  README), including the `args: [--fix]` autofix variant and the
  `ryl >= 0.11.0` requirement.
- Pin the example `rev` to `v0.11.0` (was a `<version>` placeholder; matches the
  current ryl release).
- Keep the `types_or` single-hook approach as a clearly-labelled alternative,
  since it ties into this doc's `[files]` discussion and is still valid.
- Preserve the `ignore`/force-exclude paragraph, which applies regardless of
  hook.

Docs-only change; `prek` (rumdl, typos, whitespace, …) scoped to the file passes.