### PR TITLE
Harden against malicious YAML payloads (closes #246)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,6 +413,25 @@ sticking to the quick-status step above.
   reproduces the original bytes exactly (the reconstruct-and-verify guard) — a
   region whose lines lack a single shared prefix (ragged) is reported but left
   untouched, so write-back cannot corrupt a document. See `docs/markdown.md`.
+- Malicious-payload hardening (issue #246): `--fix` never writes through a
+  symlink — `fix::refuse_symlink` skips a symlinked input (still linted) with a
+  warning, so an untrusted tree cannot redirect an in-place write outside itself.
+  The write target is always the input path, never derived from YAML content. The
+  YAML config loader (`yaml_dom::loader`, used only for YAML config — `lint_str`
+  builds no DOM) bounds alias expansion at `MAX_EXPANDED_NODES`, rejecting
+  billion-laughs configs (`-c`/`-d`/discovered `.yamllint`) instead of exhausting
+  memory; an empty/whitespace/comment-only config reports "invalid config: not a
+  mapping" rather than panicking. The markdown extractor derives each fenced
+  block's line offset by binary search over precomputed newline positions
+  (`markdown_embed::collect_fenced_blocks`), not by rescanning from the document
+  start, so a file with many embedded blocks stays linear rather than quadratic.
+  Regression guards: `tests/cli_alias_bomb.rs`, `tests/cli_fix_symlink.rs`,
+  `tests/cli_config_data_error.rs`, `cli_markdown_embed.rs`
+  (`many_fenced_blocks_map_to_correct_host_lines`). granit-parser itself caps
+  nesting recursion (~256), so deep-nesting payloads are rejected before a deep DOM
+  is built. Config-supplied regexes (`key-ordering`, `quoted-strings`) are validated
+  at config-parse time and the `regex` crate is linear-time, so ReDoS is not
+  reachable.
 - Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding
   detection as files. `-` cannot be combined with other inputs and is not
   compatible with `--fix`. `--stdin-filename <PATH>` (ruff convention) sets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,24 @@ add a `wrap.rs` variant and a deterministic sibling. Failing inputs persist to t
 committed `tests/proptest-regressions/property_markdown_fix.txt`; run with
 `cargo test --test property_markdown_fix`.
 
+### Property Tests For Config Parsing
+
+`tests/property_config.rs` property-tests **configuration robustness** (issue #246
+hardening): `property_config/strategy.rs` generates randomized configs — random
+subsets of rules with random levels and options, mixing valid values with hostile
+ones (invalid regexes, ill-typed/out-of-range scalars, bogus locales) — and renders
+each model to both YAML and TOML. The oracle-free invariant is that the whole
+pipeline errors or succeeds but **never panics**: YAML goes through
+`YamlLintConfig::from_yaml_str` and, when it parses, lints sample documents (driving
+the `.expect()` calls in `key-ordering`/`quoted-strings` `resolve()`); TOML goes
+through `parse_toml_config_str -> validate_toml_config -> normalize_toml_config`.
+Deterministic siblings pin the empty-config (YAML and TOML), invalid-regex,
+billion-laughs, and rich-valid-config cases so the random invariant cannot pass
+vacuously. When a rule gains a config-compiled regex or a new typed option, add its
+real option key(s) to `CATALOG` in `strategy.rs`. Failing inputs persist to the
+committed `tests/proptest-regressions/property_config.txt`; run with
+`cargo test --test property_config`.
+
 ### Rules Without A Safe `--fix`
 
 These rules are intentionally not part of `SAFE_FIX_RULES`. Each entry is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,18 +438,25 @@ sticking to the quick-status step above.
   YAML config loader (`yaml_dom::loader`, used only for YAML config — `lint_str`
   builds no DOM) bounds alias expansion at `MAX_EXPANDED_NODES`, rejecting
   billion-laughs configs (`-c`/`-d`/discovered `.yamllint`) instead of exhausting
-  memory; an empty/whitespace/comment-only config reports "invalid config: not a
-  mapping" rather than panicking. The markdown extractor derives each fenced
-  block's line offset by binary search over precomputed newline positions
-  (`markdown_embed::collect_fenced_blocks`), not by rescanning from the document
-  start, so a file with many embedded blocks stays linear rather than quadratic.
-  Regression guards: `tests/cli_alias_bomb.rs`, `tests/cli_fix_symlink.rs`,
-  `tests/cli_config_data_error.rs`, `cli_markdown_embed.rs`
-  (`many_fenced_blocks_map_to_correct_host_lines`). granit-parser itself caps
-  nesting recursion (~256), so deep-nesting payloads are rejected before a deep DOM
-  is built. Config-supplied regexes (`key-ordering`, `quoted-strings`) are validated
-  at config-parse time and the `regex` crate is linear-time, so ReDoS is not
-  reachable.
+  memory; cyclic `extends` is bounded by `MAX_EXTENDS_DEPTH` (was a stack overflow).
+  An empty/whitespace/comment-only YAML config reports "not a mapping"; an empty
+  TOML config (incl. an empty `[tool.ryl]`) reports "configuration is empty" instead
+  of silently linting zero rules — neither panics. The markdown extractor derives
+  each fenced block's line offset by binary search over precomputed newline
+  positions (`markdown_embed::collect_fenced_blocks`), not by rescanning from the
+  document start, so many embedded blocks stay linear rather than quadratic. Output
+  is injection-safe: the GitHub format escapes user text (`github_escape_data`/
+  `_property`, covering `::group::` and `file=`) so a crafted key/anchor/filename
+  cannot inject a `::command::` in CI, and the standard/colored/parsable formats run
+  user text through `sanitize_control` so control chars can't inject terminal escapes
+  or split a diagnostic line. Regression guards: `tests/cli_alias_bomb.rs`,
+  `tests/cli_fix_symlink.rs`, `tests/cli_config_data_error.rs`,
+  `tests/cli_toml_config.rs`, `tests/config_extends_inline.rs`,
+  `tests/cli_format_options.rs`, `cli_markdown_embed.rs`, and the randomized
+  `tests/property_config.rs`. granit-parser itself caps nesting recursion (~256), so
+  deep-nesting payloads are rejected before a deep DOM is built. Config-supplied
+  regexes (`key-ordering`, `quoted-strings`) are validated at config-parse time and
+  the `regex` crate is linear-time, so ReDoS is not reachable.
 - Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding
   detection as files. `-` cannot be combined with other inputs and is not
   compatible with `--fix`. `--stdin-filename <PATH>` (ruff convention) sets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,4 +480,11 @@ sticking to the quick-status step above.
   Markdown. Match yamllint's semantics exactly (validate with
   `tests/yamllint_compat_directives.rs`); the bare rule ids live in
   `rules::ALL_RULE_IDS`. User docs: `docs/directives.md`.
+- A resolved config that enables no rules would lint nothing while exiting 0, so the
+  lint commands reject it loudly (`main::NO_RULES_ENABLED_ERROR`, exit 2) via
+  `YamlLintConfig::enables_any_rule`. This is intentionally stricter than yamllint
+  (which silently accepts a rule-less config) and fires only on an explicit/discovered
+  config that turns everything off — the no-config path uses the default preset, which
+  enables rules. `--migrate-configs` (converts configs, does not lint) and
+  `--list-files` (a file query) are exempt; only the actual lint paths enforce it.
 - Exit codes: `0` (ok/none), `1` (invalid YAML), `2` (usage error).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security Policy
 
-`ryl` is an **unpaid, personal open-source project**. Security reports are genuinely
+`ryl` is a **personal open-source project**. Security reports are genuinely
 welcome and taken seriously, but there is **no service-level agreement and no
-guaranteed response time** — fixes are made on a best-effort basis, in spare time.
+guaranteed response time** — fixes are made on a best-effort basis.
 
 ## Reporting a vulnerability
 
@@ -40,9 +40,9 @@ security backports to older versions — please upgrade to the latest release.
 ## Response expectations
 
 Best-effort only. As a rough guide the maintainer aims to acknowledge a report
-within about 30 days, but **cannot commit to that or to any fix timeline** — this is
-an unpaid project maintained in spare time. Reports are triaged and addressed as
-capacity allows; thank you for your patience.
+within 28 days, but **cannot commit to that or to any fix timeline** — this is
+a project maintained in spare time. Reports are triaged and addressed as capacity
+allows; thank you for your patience.
 
 ## Coordinated disclosure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,84 @@
+# Security Policy
+
+`ryl` is an **unpaid, personal open-source project**. Security reports are genuinely
+welcome and taken seriously, but there is **no service-level agreement and no
+guaranteed response time** — fixes are made on a best-effort basis, in spare time.
+
+## Reporting a vulnerability
+
+**Please report vulnerabilities privately — do not open a public issue, pull
+request, or discussion.**
+
+Use GitHub's private vulnerability reporting:
+
+1. Open the [Security tab](https://github.com/owenlamont/ryl/security) of the
+   repository.
+2. Click **"Report a vulnerability"**.
+3. Fill in the advisory form.
+
+This creates a private channel visible only to the maintainer and you. If you cannot
+use it, contact the maintainer privately via the email on their GitHub profile — but
+the GitHub channel is strongly preferred.
+
+### What to include
+
+- The `ryl` version (`ryl --version`) and how it was installed (cargo / pip / npm).
+- A minimal reproducer: the YAML and/or config file(s) and the exact command.
+- The impact (crash, hang, memory/CPU exhaustion, unexpected file write, CI or
+  terminal output injection, …).
+
+## Supported versions
+
+Only the **latest released version** is supported. `ryl` is pre-1.0 and there are no
+security backports to older versions — please upgrade to the latest release.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| older   | ❌        |
+
+## Response expectations
+
+Best-effort only. As a rough guide the maintainer aims to acknowledge a report
+within about 30 days, but **cannot commit to that or to any fix timeline** — this is
+an unpaid project maintained in spare time. Reports are triaged and addressed as
+capacity allows; thank you for your patience.
+
+## Coordinated disclosure
+
+Please give the maintainer a reasonable opportunity to release a fix before
+disclosing a vulnerability publicly. When a fix ships, a
+[GitHub Security Advisory](https://github.com/owenlamont/ryl/security/advisories)
+is published (and, where relevant, a CVE requested and a
+[RustSec](https://rustsec.org/) advisory filed so `cargo audit` users are alerted).
+Reporters are credited unless they ask otherwise.
+
+## Threat model and scope
+
+`ryl` routinely processes **untrusted input**: YAML files and auto-discovered
+configuration (`.yamllint`, `.ryl.toml`, `pyproject.toml`) from a repository, often
+in CI on contributor branches.
+
+**In scope** (please report):
+
+- Denial of service — excessive memory or CPU, hangs, or crashes/panics — triggered
+  by a crafted YAML file or configuration.
+- `--fix` writing to a file other than the one being linted.
+- Injection into CI or terminal output (e.g. GitHub Actions workflow-command
+  injection, terminal escape sequences) via crafted file contents or filenames.
+
+**Out of scope** (generally not treated as vulnerabilities):
+
+- Resource use merely proportional to input size — a multi-gigabyte input being slow
+  is expected, not a vulnerability.
+- Issues that require the attacker to already control the environment `ryl` runs in,
+  such as a symlink you created yourself, a symlinked parent directory of an
+  explicitly-named path, or hostile environment variables (e.g.
+  `YAMLLINT_FILE_ENCODING`).
+
+## Vulnerabilities `ryl` finds in others
+
+When auditing `ryl` surfaces a vulnerability in a dependency or another project, the
+same coordinated, private disclosure asked for here is practised outward: the
+upstream maintainer is contacted privately and given time to fix before any public
+mention.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -49,6 +49,12 @@ ryl --fix .
 
 See the [Rules reference](../rules.md) for which rules are fixable.
 
+`--fix` rewrites files in place but never writes through a symlink: a
+symlinked input is linted but skipped for fixing (with a warning on
+stderr), so a symlink in an untrusted tree cannot redirect a write to a
+file outside it. This mirrors directory scanning, which does not follow
+symlinks.
+
 ## Configure for your project
 
 Drop a `.ryl.toml` (or `ryl.toml`) at the root of your repo. TOML

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -36,8 +36,13 @@ Exit codes:
 - `0` &mdash; no problems found.
 - `1` &mdash; lint errors, invalid YAML, or a path that could not be read
   (including nonexistent files).
-- `2` &mdash; CLI usage error (no inputs provided, bad flags) or
+- `2` &mdash; CLI usage error (no inputs provided, bad flags), or
   `--strict` was set and only warnings were produced.
+
+A configuration that enables no rules would lint nothing, so ryl rejects it with
+exit `2` rather than silently passing. Enable at least one rule, or remove the
+configuration to fall back to the default rule set. (This is stricter than yamllint,
+which silently accepts a rule-less config.)
 
 ## Apply auto-fixes
 

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.11.0"
+  "version": "0.12.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.11.0"
+version = "0.12.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/cli_support.rs
+++ b/src/cli_support.rs
@@ -1,8 +1,35 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::hash::BuildHasher;
 use std::path::{Path, PathBuf};
 
 use crate::config::{ConfigContext, YamlLintConfig, discover_per_file};
+
+/// Replace control characters — which a crafted key, value, anchor name, or
+/// filename can carry into a diagnostic, warning, or path — with a visible `\u{..}`
+/// escape, so they cannot inject terminal escape sequences or (via a newline) a
+/// GitHub Actions workflow command, and cannot split a single-line message.
+/// Printable text (including multibyte Unicode) is untouched, and the common
+/// control-free case borrows without allocating. Shared by the CLI output layer and
+/// the `--fix` symlink warning so every user-controlled string is sanitized the same
+/// way.
+#[must_use]
+pub fn sanitize_control(text: &str) -> Cow<'_, str> {
+    if !text.contains(char::is_control) {
+        return Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch.is_control() {
+            write!(out, "\\u{{{:x}}}", ch as u32)
+                .expect("writing to a String is infallible");
+        } else {
+            out.push(ch);
+        }
+    }
+    Cow::Owned(out)
+}
 
 /// Resolve the configuration context for a given file path, optionally using a cached
 /// global configuration.

--- a/src/config.rs
+++ b/src/config.rs
@@ -786,6 +786,19 @@ impl YamlLintConfig {
     }
 
     fn finalize(&mut self, envx: &dyn Env, base_dir: &Path) -> Result<(), String> {
+        // Reject unknown/misspelled rule names (matching yamllint's "no such rule").
+        // ryl does not support custom/unrecognised rules: an unknown rule is never
+        // dispatched by `lint_str`, so without this a typo lints nothing and a config
+        // whose only entries are unknown would also slip past the "no rules enabled"
+        // guard.
+        if let Some(unknown) = self
+            .rule_names
+            .iter()
+            .find(|name| !crate::rules::ALL_RULE_IDS.contains(&name.as_str()))
+        {
+            return Err(format!("invalid config: no such rule: \"{unknown}\""));
+        }
+
         let (matcher, extra_patterns) = build_ignore_matcher(
             &self.ignore_patterns,
             &self.ignore_from_files,

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,6 +466,14 @@ impl YamlLintConfig {
         &self.rule_names
     }
 
+    /// Whether the configuration enables at least one rule (one with a severity
+    /// level). A configuration that enables none would lint nothing; the lint CLI
+    /// rejects that, though config resolution itself (e.g. for migration) does not.
+    #[must_use]
+    pub fn enables_any_rule(&self) -> bool {
+        self.rules.values().any(|rule| rule.level().is_some())
+    }
+
     #[must_use]
     pub fn rule_level(&self, rule: &str) -> Option<RuleLevel> {
         self.rules.get(rule)?.level()

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,12 @@ use crate::{conf, decoder};
 
 pub use crate::config_schema::RuleLevel;
 
+/// Maximum depth of `extends` resolution. A cyclic `extends` (a config that
+/// extends itself, directly or via a chain) would otherwise recurse until the
+/// stack overflows; real chains are only a level or two deep, so this bounds the
+/// recursion far above any legitimate use and turns a cycle into a clean error.
+const MAX_EXTENDS_DEPTH: usize = 32;
+
 /// How a file should be linted, as resolved from the `[files]` globs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceKind {
@@ -408,6 +414,7 @@ impl YamlLintConfig {
         entry: &str,
         envx: Option<&dyn Env>,
         base_dir: &Path,
+        depth: usize,
     ) -> Result<(), String> {
         if let Some(builtin) = conf::builtin(entry) {
             let base = Self::from_yaml_str(builtin).expect("builtin preset must parse");
@@ -440,7 +447,12 @@ impl YamlLintConfig {
         let parent_dir = resolved
             .parent()
             .map_or_else(|| base_dir.to_path_buf(), Path::to_path_buf);
-        let base = Self::from_yaml_str_with_env(&data, Some(envx), Some(&parent_dir))?;
+        let base = Self::from_yaml_str_with_env_depth(
+            &data,
+            Some(envx),
+            Some(&parent_dir),
+            depth + 1,
+        )?;
         self.merge_from(base);
         Ok(())
     }
@@ -624,6 +636,23 @@ impl YamlLintConfig {
         envx: Option<&dyn Env>,
         base_dir: Option<&Path>,
     ) -> Result<Self, String> {
+        Self::from_yaml_str_with_env_depth(s, envx, base_dir, 0)
+    }
+
+    /// `depth` tracks `extends` recursion so a cycle is rejected (see
+    /// [`MAX_EXTENDS_DEPTH`]) rather than overflowing the stack.
+    fn from_yaml_str_with_env_depth(
+        s: &str,
+        envx: Option<&dyn Env>,
+        base_dir: Option<&Path>,
+        depth: usize,
+    ) -> Result<Self, String> {
+        if depth > MAX_EXTENDS_DEPTH {
+            return Err(
+                "invalid config: extends nested too deeply (possible cyclic extends)"
+                    .to_string(),
+            );
+        }
         let docs = YamlOwned::load_from_str(s)
             .map_err(|e| format!("failed to parse config data: {e}"))?;
         // An empty document stream (empty/whitespace/comment-only config) yields no
@@ -633,6 +662,7 @@ impl YamlLintConfig {
             docs.first().unwrap_or(&YamlOwned::BadValue),
             envx,
             base_dir,
+            depth,
         )
     }
 
@@ -661,12 +691,13 @@ impl YamlLintConfig {
         doc: &YamlOwned,
         envx: Option<&dyn Env>,
         base_dir: Option<&Path>,
+        depth: usize,
     ) -> Result<Self, String> {
         let parsed = parse_yaml_config(doc)?;
         let mut cfg = Self::default();
         let base_path = base_dir.unwrap_or_else(|| Path::new(""));
         for entry in &parsed.extends {
-            cfg.extend_from_entry(entry, envx, base_path)?;
+            cfg.extend_from_entry(entry, envx, base_path, depth)?;
         }
         cfg.apply_normalized_config(parsed.normalized);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -626,7 +626,14 @@ impl YamlLintConfig {
     ) -> Result<Self, String> {
         let docs = YamlOwned::load_from_str(s)
             .map_err(|e| format!("failed to parse config data: {e}"))?;
-        Self::from_doc_with_env(&docs[0], envx, base_dir)
+        // An empty document stream (empty/whitespace/comment-only config) yields no
+        // docs; treat it as a non-mapping so it reports "invalid config: not a
+        // mapping" (matching yamllint) instead of panicking on `docs[0]`.
+        Self::from_doc_with_env(
+            docs.first().unwrap_or(&YamlOwned::BadValue),
+            envx,
+            base_dir,
+        )
     }
 
     fn from_toml_str_with_env(

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -696,19 +696,15 @@ pub fn parse_toml_config_str(
     input: &str,
     pyproject: bool,
 ) -> Result<Option<TomlConfig>, String> {
-    // An empty standalone config configures no rules, so linting it would silently
-    // pass everything; reject it (like an empty YAML config) rather than surprise the
-    // user. An empty `[tool.ryl]` in `pyproject.toml`, however, is treated like an
-    // absent one — "ryl is not configured in this file" (`Ok(None)`) — so config
-    // discovery falls back to defaults instead of aborting the whole run on a stub
-    // section. Checking the raw document keeps this correct as `TomlConfig` gains
-    // fields.
+    // A config that defines nothing enables no rules; since rules must be explicitly
+    // enabled, an empty config configures the linter to do nothing, so reject it. This
+    // covers an empty standalone `.ryl.toml` and an empty `[tool.ryl]` table — the
+    // latter is a present-but-empty config (an error), distinct from an *absent*
+    // `[tool.ryl]` ("ryl is not configured in this file"), which `toml_document_is_empty`
+    // reports as non-empty so discovery keeps looking. Checking the raw document keeps
+    // this correct as `TomlConfig` gains fields.
     if toml_document_is_empty(input, pyproject) {
-        return if pyproject {
-            Ok(None)
-        } else {
-            Err("invalid config: configuration is empty".to_string())
-        };
+        return Err("invalid config: configuration is empty".to_string());
     }
 
     if pyproject {

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -696,6 +696,15 @@ pub fn parse_toml_config_str(
     input: &str,
     pyproject: bool,
 ) -> Result<Option<TomlConfig>, String> {
+    // An empty config configures no rules, so linting it would silently pass
+    // everything; reject it (like an empty YAML config) rather than surprise the
+    // user. Checking the raw document keeps this correct as `TomlConfig` gains
+    // fields. A `pyproject.toml` with no `[tool.ryl]` is not empty here — that means
+    // "ryl is not configured in this file", which the caller resolves separately.
+    if toml_document_is_empty(input, pyproject) {
+        return Err("invalid config: configuration is empty".to_string());
+    }
+
     if pyproject {
         return toml::from_str::<PyProjectToml>(input)
             .map(|doc| doc.tool.ryl)
@@ -705,6 +714,26 @@ pub fn parse_toml_config_str(
     toml::from_str::<TomlConfig>(input)
         .map(Some)
         .map_err(|err| format!("failed to parse config data: {err}"))
+}
+
+/// Whether the relevant TOML configuration table has no entries: the whole
+/// document for a standalone config, or the `[tool.ryl]` subtable for
+/// `pyproject.toml`. A document that fails to parse is not treated as empty so the
+/// real parse error surfaces below; an absent `[tool.ryl]` is likewise not empty.
+fn toml_document_is_empty(input: &str, pyproject: bool) -> bool {
+    let Ok(table) = input.parse::<toml::Table>() else {
+        return false;
+    };
+    let config = if pyproject {
+        table
+            .get("tool")
+            .and_then(toml::Value::as_table)
+            .and_then(|tool| tool.get("ryl"))
+            .and_then(toml::Value::as_table)
+    } else {
+        Some(&table)
+    };
+    config.is_some_and(toml::map::Map::is_empty)
 }
 
 /// Validate semantic constraints for a typed TOML config model.

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -696,13 +696,19 @@ pub fn parse_toml_config_str(
     input: &str,
     pyproject: bool,
 ) -> Result<Option<TomlConfig>, String> {
-    // An empty config configures no rules, so linting it would silently pass
-    // everything; reject it (like an empty YAML config) rather than surprise the
-    // user. Checking the raw document keeps this correct as `TomlConfig` gains
-    // fields. A `pyproject.toml` with no `[tool.ryl]` is not empty here — that means
-    // "ryl is not configured in this file", which the caller resolves separately.
+    // An empty standalone config configures no rules, so linting it would silently
+    // pass everything; reject it (like an empty YAML config) rather than surprise the
+    // user. An empty `[tool.ryl]` in `pyproject.toml`, however, is treated like an
+    // absent one — "ryl is not configured in this file" (`Ok(None)`) — so config
+    // discovery falls back to defaults instead of aborting the whole run on a stub
+    // section. Checking the raw document keeps this correct as `TomlConfig` gains
+    // fields.
     if toml_document_is_empty(input, pyproject) {
-        return Err("invalid config: configuration is empty".to_string());
+        return if pyproject {
+            Ok(None)
+        } else {
+            Err("invalid config: configuration is empty".to_string())
+        };
     }
 
     if pyproject {

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -93,9 +93,6 @@ pub(crate) fn yaml_owned_to_toml_value(
     if let Some(num) = value.as_integer() {
         return Ok(toml::Value::Integer(num));
     }
-    if let Some(num) = value.as_floating_point() {
-        return Ok(toml::Value::Float(num));
-    }
     if value.is_null() {
         return Err(
             "cannot convert null values to TOML (TOML has no null type)".to_string()

--- a/src/config_schema/validation.rs
+++ b/src/config_schema/validation.rs
@@ -1,5 +1,4 @@
 use regex::Regex;
-use toml::Value;
 
 use super::{
     KeyOrderingOptions, QuotedStringsOptions, QuotedStringsRequired,
@@ -45,39 +44,8 @@ impl<Q: QuotedStringsOptionSet> RulesTable<Q> {
     pub(super) fn validate(&self) -> Result<(), String> {
         validate_key_ordering_rule(self.key_ordering.as_ref())?;
         validate_quoted_strings_rule(self.quoted_strings.as_ref())?;
-        validate_extra_rule_filters(&self.extra)?;
         Ok(())
     }
-}
-
-fn validate_extra_rule_filters(
-    rules: &std::collections::BTreeMap<String, Value>,
-) -> Result<(), String> {
-    for (rule_name, value) in rules {
-        let Value::Table(table) = value else {
-            continue;
-        };
-
-        if let Some(ignore) = table.get("ignore") {
-            validate_string_or_array_of_strings(
-                ignore,
-                &format!(
-                    "invalid config: option \"ignore\" of \"{rule_name}\" should contain file patterns"
-                ),
-            )?;
-        }
-
-        if let Some(ignore_from_file) = table.get("ignore-from-file") {
-            validate_string_or_array_of_strings(
-                ignore_from_file,
-                &format!(
-                    "invalid config: option \"ignore-from-file\" of \"{rule_name}\" should contain filename(s), either as a list or string"
-                ),
-            )?;
-        }
-    }
-
-    Ok(())
 }
 
 fn validate_key_ordering_rule(
@@ -206,19 +174,4 @@ fn validate_regex_list(
     }
 
     Ok(())
-}
-
-fn validate_string_or_array_of_strings(
-    value: &Value,
-    error: &str,
-) -> Result<(), String> {
-    match value {
-        Value::String(_) => Ok(()),
-        Value::Array(items)
-            if items.iter().all(|item| matches!(item, Value::String(_))) =>
-        {
-            Ok(())
-        }
-        _ => Err(error.to_string()),
-    }
 }

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -96,6 +96,22 @@ pub struct FixStats {
     pub changed_files: usize,
 }
 
+/// `--fix` rewrites a path in place, and `std::fs::write` follows symlinks, so a
+/// symlinked input would let an untrusted tree redirect the write to a file
+/// outside it (e.g. `innocent.yaml -> ~/.bashrc`). Skip symlinks with a warning,
+/// keeping writes confined to real files — consistent with the directory walker's
+/// `follow_links(false)`. Linting (read-only) through symlinks is unaffected.
+fn refuse_symlink(path: &Path) -> bool {
+    if std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        eprintln!(
+            "skipping {}: refusing to apply --fix through a symlink",
+            path.display()
+        );
+        return true;
+    }
+    false
+}
+
 /// Apply all currently supported safe fixes to `path` in place.
 ///
 /// # Errors
@@ -106,6 +122,9 @@ pub fn apply_safe_fixes_in_place(
     cfg: &YamlLintConfig,
     base_dir: &Path,
 ) -> Result<bool, String> {
+    if refuse_symlink(path) {
+        return Ok(false);
+    }
     let decoded = decoder::read_file_lossless(path)?;
     let fixed = apply_safe_fixes(decoded.content(), cfg, path, base_dir);
     if fixed == decoded.content() {
@@ -150,6 +169,9 @@ pub fn apply_markdown_safe_fixes_in_place(
     cfg: &YamlLintConfig,
     base_dir: &Path,
 ) -> Result<bool, String> {
+    if refuse_symlink(path) {
+        return Ok(false);
+    }
     let decoded = decoder::read_file_lossless(path)?;
     match fix_markdown_str(decoded.content(), path, cfg, base_dir) {
         Some(fixed) => {

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -97,10 +97,18 @@ pub struct FixStats {
 }
 
 /// `--fix` rewrites a path in place, and `std::fs::write` follows symlinks, so a
-/// symlinked input would let an untrusted tree redirect the write to a file
-/// outside it (e.g. `innocent.yaml -> ~/.bashrc`). Skip symlinks with a warning,
-/// keeping writes confined to real files — consistent with the directory walker's
-/// `follow_links(false)`. Linting (read-only) through symlinks is unaffected.
+/// symlinked input would let an untrusted tree redirect the write to a file outside
+/// it (e.g. `innocent.yaml -> ~/.bashrc`). Skip a symlinked input with a warning —
+/// consistent with the directory walker's `follow_links(false)`, which is the path
+/// by which untrusted trees are scanned. Linting (read-only) through symlinks is
+/// unaffected.
+///
+/// This checks only the final path component (`symlink_metadata` resolves parent
+/// components), and the check is not atomic with the later write. It is therefore
+/// best-effort, not a hard sandbox: an explicitly-named path through a symlinked
+/// parent directory, or an attacker who swaps the file for a symlink between this
+/// check and the write (TOCTOU), is not covered. A complete defense would need
+/// `openat`/`O_NOFOLLOW`, which is not portable here.
 fn refuse_symlink(path: &Path) -> bool {
     if std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
         eprintln!(

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -113,7 +113,7 @@ fn refuse_symlink(path: &Path) -> bool {
     if std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
         eprintln!(
             "skipping {}: refusing to apply --fix through a symlink",
-            path.display()
+            crate::cli_support::sanitize_control(&path.display().to_string())
         );
         return true;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@
     clippy::cognitive_complexity
 )]
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Write as _;
@@ -17,7 +16,7 @@ use std::process::ExitCode;
 use clap::{Parser, ValueEnum};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
-use ryl::cli_support::resolve_ctx;
+use ryl::cli_support::{resolve_ctx, sanitize_control};
 use ryl::config::{
     ConfigContext, Overrides, SourceKind, YamlLintConfig, discover_config,
 };
@@ -777,27 +776,6 @@ fn count_reported_problems(
 
 fn pluralize(singular: &str, count: usize) -> &str {
     if count == 1 { singular } else { "problems" }
-}
-
-/// Replace control characters — which a crafted key, value, anchor name, or
-/// filename can carry into a diagnostic — with a visible `\u{..}` escape, so they
-/// cannot inject terminal escape sequences or split a single-line diagnostic.
-/// Printable text (including multibyte Unicode) is untouched, and the common
-/// control-free case borrows without allocating.
-fn sanitize_control(text: &str) -> Cow<'_, str> {
-    if !text.contains(char::is_control) {
-        return Cow::Borrowed(text);
-    }
-    let mut out = String::with_capacity(text.len());
-    for ch in text.chars() {
-        if ch.is_control() {
-            write!(out, "\\u{{{:x}}}", ch as u32)
-                .expect("writing to a String is infallible");
-        } else {
-            out.push(ch);
-        }
-    }
-    Cow::Owned(out)
 }
 
 fn format_standard(problem: &LintProblem) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,10 @@
     clippy::cognitive_complexity
 )]
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -659,7 +661,7 @@ fn process_results(
 
                 match output_format {
                     OutputFormat::Standard => {
-                        eprintln!("{}", path.display());
+                        eprintln!("{}", sanitize_control(&path.display().to_string()));
                         for problem in problems {
                             eprintln!("{}", format_standard(problem));
                             match problem.level {
@@ -671,7 +673,10 @@ fn process_results(
                         eprintln!();
                     }
                     OutputFormat::Colored => {
-                        eprintln!("\u{001b}[4m{}\u{001b}[0m", path.display());
+                        eprintln!(
+                            "\u{001b}[4m{}\u{001b}[0m",
+                            sanitize_control(&path.display().to_string())
+                        );
                         for problem in problems {
                             eprintln!("{}", format_colored(problem));
                             match problem.level {
@@ -683,7 +688,10 @@ fn process_results(
                         eprintln!();
                     }
                     OutputFormat::Github => {
-                        eprintln!("::group::{}", path.display());
+                        eprintln!(
+                            "::group::{}",
+                            github_escape_data(&path.display().to_string())
+                        );
                         for problem in problems {
                             eprintln!("{}", format_github(problem, path));
                             match problem.level {
@@ -740,12 +748,33 @@ fn pluralize(singular: &str, count: usize) -> &str {
     if count == 1 { singular } else { "problems" }
 }
 
+/// Replace control characters — which a crafted key, value, anchor name, or
+/// filename can carry into a diagnostic — with a visible `\u{..}` escape, so they
+/// cannot inject terminal escape sequences or split a single-line diagnostic.
+/// Printable text (including multibyte Unicode) is untouched, and the common
+/// control-free case borrows without allocating.
+fn sanitize_control(text: &str) -> Cow<'_, str> {
+    if !text.contains(char::is_control) {
+        return Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch.is_control() {
+            write!(out, "\\u{{{:x}}}", ch as u32)
+                .expect("writing to a String is infallible");
+        } else {
+            out.push(ch);
+        }
+    }
+    Cow::Owned(out)
+}
+
 fn format_standard(problem: &LintProblem) -> String {
     let mut line = format!("  {}:{}", problem.line, problem.column);
     line.push_str(&" ".repeat(12usize.saturating_sub(line.len())));
     line.push_str(problem.level.as_str());
     line.push_str(&" ".repeat(21usize.saturating_sub(line.len())));
-    line.push_str(&problem.message);
+    line.push_str(&sanitize_control(&problem.message));
     if let Some(rule) = problem.rule {
         line.push_str("  (");
         line.push_str(rule);
@@ -766,7 +795,7 @@ fn format_colored(problem: &LintProblem) -> String {
     };
     line.push_str(level_str);
     line.push_str(&" ".repeat(38usize.saturating_sub(line.len())));
-    line.push_str(&problem.message);
+    line.push_str(&sanitize_control(&problem.message));
     if let Some(rule) = problem.rule {
         line.push_str("  \u{001b}[2m(");
         line.push_str(rule);
@@ -816,11 +845,11 @@ fn format_github(problem: &LintProblem, path: &Path) -> String {
 fn format_parsable(problem: &LintProblem, path: &Path) -> String {
     let mut line = format!(
         "{}:{}:{}: [{}] {}",
-        path.display(),
+        sanitize_control(&path.display().to_string()),
         problem.line,
         problem.column,
         problem.level.as_str(),
-        problem.message
+        sanitize_control(&problem.message)
     );
     if let Some(rule) = problem.rule {
         line.push_str(" (");

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,22 +115,29 @@ fn run_migration(cli: &Cli) -> Result<ExitCode, String> {
     };
     let result = migrate_configs(&options)?;
     for warning in result.warnings {
-        eprintln!("{warning}");
+        eprintln!("{}", sanitize_control(&warning));
     }
     if result.entries.is_empty() {
         println!(
             "No legacy YAML config files found under {}",
-            options.root.display()
+            sanitize_control(&options.root.display().to_string())
         );
         return Ok(ExitCode::SUCCESS);
     }
 
     for entry in &result.entries {
-        println!("{} -> {}", entry.source.display(), entry.target.display());
+        println!(
+            "{} -> {}",
+            sanitize_control(&entry.source.display().to_string()),
+            sanitize_control(&entry.target.display().to_string())
+        );
     }
     if options.output_mode == MigrateOutputMode::IncludeToml {
         for entry in &result.entries {
-            println!("# {}", entry.target.display());
+            println!(
+                "# {}",
+                sanitize_control(&entry.target.display().to_string())
+            );
             println!("{}", entry.toml);
         }
     }
@@ -316,7 +323,10 @@ fn main() -> ExitCode {
     match run_cli(cli) {
         Ok(code) => code,
         Err(err) => {
-            eprintln!("{err}");
+            // Usage/config errors embed user-controlled paths and config values;
+            // sanitize so a crafted filename or value cannot inject control
+            // sequences or a CI workflow command.
+            eprintln!("{}", sanitize_control(&err));
             ExitCode::from(2)
         }
     }
@@ -381,7 +391,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
     }
     if let Some(cfg) = &global_cfg {
         for notice in &cfg.notices {
-            eprintln!("{notice}");
+            eprintln!("{}", sanitize_control(notice));
         }
     }
     let inputs = cli.inputs;
@@ -407,7 +417,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
 
     if cli.lint.compatibility.list_files {
         for (path, ..) in &files {
-            println!("{}", path.display());
+            println!("{}", sanitize_control(&path.display().to_string()));
         }
         return Ok(ExitCode::SUCCESS);
     }
@@ -468,7 +478,7 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     };
 
     if cli.lint.compatibility.list_files {
-        println!("{}", path.display());
+        println!("{}", sanitize_control(&path.display().to_string()));
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -551,7 +561,7 @@ fn resolve_stdin_ctx(
     };
     let ctx = discover_config(std::slice::from_ref(&anchor), &cli_overrides(cli))?;
     for notice in &ctx.notices {
-        eprintln!("{notice}");
+        eprintln!("{}", sanitize_control(notice.as_str()));
     }
     let mut cfg = ctx.config;
     if cli.lint.markdown {
@@ -595,7 +605,7 @@ fn gather_lint_files(
         let (base_dir, cfg, notices) = resolve_ctx(f, global_cfg, markdown, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
-                eprintln!("{notice}");
+                eprintln!("{}", sanitize_control(notice.as_str()));
             }
         }
         if cfg.is_file_ignored(f, &base_dir) {
@@ -610,7 +620,7 @@ fn gather_lint_files(
         let (base_dir, cfg, notices) = resolve_ctx(ef, global_cfg, markdown, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
-                eprintln!("{notice}");
+                eprintln!("{}", sanitize_control(notice.as_str()));
             }
         }
         if cfg.is_file_ignored(ef, &base_dir) {
@@ -643,7 +653,11 @@ fn process_results(
         let (path, ..) = &files[idx];
         match outcome {
             Err(message) => {
-                eprintln!("{message}");
+                // Error messages embed user-controlled paths/values; sanitize so a
+                // crafted filename cannot inject terminal escapes or (via a newline)
+                // a GitHub workflow command. `sanitize_control` is safe for every
+                // format because it neutralises the newline that injection needs.
+                eprintln!("{}", sanitize_control(&message));
                 summary.has_error = true;
                 summary.problem_count += 1;
             }
@@ -688,12 +702,11 @@ fn process_results(
                         eprintln!();
                     }
                     OutputFormat::Github => {
-                        eprintln!(
-                            "::group::{}",
-                            github_escape_data(&path.display().to_string())
-                        );
+                        let path_str = path.display().to_string();
+                        eprintln!("::group::{}", github_escape(&path_str, false));
+                        let escaped_file = github_escape(&path_str, true);
                         for problem in problems {
-                            eprintln!("{}", format_github(problem, path));
+                            eprintln!("{}", format_github(problem, &escaped_file));
                             match problem.level {
                                 Severity::Error => summary.has_error = true,
                                 Severity::Warning => summary.has_warning = true,
@@ -704,8 +717,10 @@ fn process_results(
                         eprintln!();
                     }
                     OutputFormat::Parsable => {
+                        let sanitized_path =
+                            sanitize_control(&path.display().to_string()).into_owned();
                         for problem in problems {
-                            eprintln!("{}", format_parsable(problem, path));
+                            eprintln!("{}", format_parsable(problem, &sanitized_path));
                             match problem.level {
                                 Severity::Error => summary.has_error = true,
                                 Severity::Warning => summary.has_warning = true,
@@ -807,27 +822,35 @@ fn format_colored(problem: &LintProblem) -> String {
 // User-controlled text (a quoted key, an anchor name, a filename) reaches GitHub
 // Actions workflow-command output, where a raw newline would start a new
 // `::command::` — a command-injection vector in CI. Encode it the way GitHub's
-// `@actions/core` does: data (the message) escapes `%`/CR/LF; properties (the
-// `file=` path) additionally escape `:` and `,`. `%` must be escaped first so the
-// `%XX` sequences are not themselves re-encoded.
-fn github_escape_data(value: &str) -> String {
-    value
-        .replace('%', "%25")
-        .replace('\r', "%0D")
-        .replace('\n', "%0A")
+// `@actions/core` does (data escapes `%`/CR/LF; a `property` such as `file=` also
+// escapes `:`/`,`), and additionally render any other control character as a
+// literal `\u{..}` — never a `%XX`, which the runner would decode back into the raw
+// control char and let it drive ANSI sequences in the log viewer.
+fn github_escape(value: &str, property: bool) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '%' => out.push_str("%25"),
+            '\r' => out.push_str("%0D"),
+            '\n' => out.push_str("%0A"),
+            ':' if property => out.push_str("%3A"),
+            ',' if property => out.push_str("%2C"),
+            c if c.is_control() => {
+                write!(out, "\\u{{{:x}}}", c as u32)
+                    .expect("writing to a String is infallible");
+            }
+            c => out.push(c),
+        }
+    }
+    out
 }
 
-fn github_escape_property(value: &str) -> String {
-    github_escape_data(value)
-        .replace(':', "%3A")
-        .replace(',', "%2C")
-}
-
-fn format_github(problem: &LintProblem, path: &Path) -> String {
+/// `escaped_file` is the `file=` property value, escaped once per file by the
+/// caller (it is identical for every diagnostic in the same file).
+fn format_github(problem: &LintProblem, escaped_file: &str) -> String {
     let mut line = format!(
-        "::{} file={},line={},col={}::{}:{} ",
+        "::{} file={escaped_file},line={},col={}::{}:{} ",
         problem.level.as_str(),
-        github_escape_property(&path.display().to_string()),
         problem.line,
         problem.column,
         problem.line,
@@ -838,14 +861,15 @@ fn format_github(problem: &LintProblem, path: &Path) -> String {
         line.push_str(rule);
         line.push_str("] ");
     }
-    line.push_str(&github_escape_data(&problem.message));
+    line.push_str(&github_escape(&problem.message, false));
     line
 }
 
-fn format_parsable(problem: &LintProblem, path: &Path) -> String {
+/// `sanitized_path` is sanitized once per file by the caller (identical for every
+/// diagnostic in the file).
+fn format_parsable(problem: &LintProblem, sanitized_path: &str) -> String {
     let mut line = format!(
-        "{}:{}:{}: [{}] {}",
-        sanitize_control(&path.display().to_string()),
+        "{sanitized_path}:{}:{}: [{}] {}",
         problem.line,
         problem.column,
         problem.level.as_str(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -775,11 +775,30 @@ fn format_colored(problem: &LintProblem) -> String {
     line
 }
 
+// User-controlled text (a quoted key, an anchor name, a filename) reaches GitHub
+// Actions workflow-command output, where a raw newline would start a new
+// `::command::` — a command-injection vector in CI. Encode it the way GitHub's
+// `@actions/core` does: data (the message) escapes `%`/CR/LF; properties (the
+// `file=` path) additionally escape `:` and `,`. `%` must be escaped first so the
+// `%XX` sequences are not themselves re-encoded.
+fn github_escape_data(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+
+fn github_escape_property(value: &str) -> String {
+    github_escape_data(value)
+        .replace(':', "%3A")
+        .replace(',', "%2C")
+}
+
 fn format_github(problem: &LintProblem, path: &Path) -> String {
     let mut line = format!(
         "::{} file={},line={},col={}::{}:{} ",
         problem.level.as_str(),
-        path.display(),
+        github_escape_property(&path.display().to_string()),
         problem.line,
         problem.column,
         problem.line,
@@ -790,7 +809,7 @@ fn format_github(problem: &LintProblem, path: &Path) -> String {
         line.push_str(rule);
         line.push_str("] ");
     }
-    line.push_str(&problem.message);
+    line.push_str(&github_escape_data(&problem.message));
     line
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,14 @@ use ryl::{
 
 const STDIN_LABEL: &str = "<stdin>";
 
+// A resolved config that enables no rules would lint nothing while exiting 0 — a
+// silent no-op that almost always means a misconfiguration. The lint commands fail
+// loudly on it (config resolution itself does not, so `--migrate-configs` can still
+// convert a rule-less config, and `--list-files` still answers its file query). ryl
+// is deliberately stricter than yamllint here, which accepts a rule-less config.
+const NO_RULES_ENABLED_ERROR: &str = "error: configuration enables no rules, so nothing would be linted; enable at \
+     least one rule, or remove the configuration to use the default rule set";
+
 fn gather_inputs(inputs: &[PathBuf]) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let mut explicit_files = Vec::new();
     let mut candidates = Vec::new();
@@ -426,6 +434,10 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         return Ok(ExitCode::SUCCESS);
     }
 
+    if files.iter().any(|(_, _, cfg, _)| !cfg.enables_any_rule()) {
+        return Err(NO_RULES_ENABLED_ERROR.to_string());
+    }
+
     let mut initial_problem_count = 0usize;
     if cli.lint.fix.fix {
         let initial_results = lint_files(&files);
@@ -480,6 +492,10 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     if cli.lint.compatibility.list_files {
         println!("{}", sanitize_control(&path.display().to_string()));
         return Ok(ExitCode::SUCCESS);
+    }
+
+    if !cfg.enables_any_rule() {
+        return Err(NO_RULES_ENABLED_ERROR.to_string());
     }
 
     let outcome = read_and_lint_stdin(&path, &base_dir, &cfg, kind);

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -119,6 +119,11 @@ fn is_front_matter_close(line: &str) -> bool {
 }
 
 fn collect_fenced_blocks(markdown: &str, regions: &mut Vec<EmbeddedRegion>) {
+    // Byte offsets of every newline, ascending. A block's line offset is then a
+    // binary search rather than an O(offset) rescan from the document start, which
+    // would be quadratic over a document with many fenced blocks.
+    let newlines: Vec<usize> =
+        markdown.match_indices('\n').map(|(idx, _)| idx).collect();
     let mut active: Option<FenceAccumulator> = None;
     for (event, range) in Parser::new_ext(markdown, Options::empty()).into_offset_iter()
     {
@@ -139,7 +144,7 @@ fn collect_fenced_blocks(markdown: &str, regions: &mut Vec<EmbeddedRegion>) {
                     let line_start = line_start_of(markdown, first_byte);
                     regions.push(EmbeddedRegion {
                         kind: RegionKind::FencedBlock,
-                        line_offset: markdown[..line_start].matches('\n').count(),
+                        line_offset: newlines.partition_point(|&pos| pos < line_start),
                         col_offset: markdown[line_start..first_byte].chars().count(),
                         raw_span: line_start
                             ..fenced_content_end(

--- a/src/yaml_dom/loader.rs
+++ b/src/yaml_dom/loader.rs
@@ -6,17 +6,39 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
-use granit_parser::{Event, Parser, ScanError, Span, SpannedEventReceiver, Tag};
+use granit_parser::{
+    Event, Marker, Parser, ScanError, Span, SpannedEventReceiver, Tag,
+};
 
 use crate::yaml_dom::scalar::Scalar;
 use crate::yaml_dom::yaml_owned::{MappingOwned, YamlOwned};
 
+/// Upper bound on the number of nodes an alias may materialise across a whole
+/// document. granit emits one O(1) `Event::Alias` per alias and never expands;
+/// this loader is what resolves an alias by cloning the referenced subtree, so
+/// nested anchors (`a: &a [..]`, `b: &b [*a, *a, ..]`, …) would otherwise blow up
+/// exponentially — the classic "billion laughs" denial of service. Real configs
+/// (the only input that reaches this loader) expand to at most a few hundred
+/// nodes, so this ceiling is enormous headroom while still bounding a malicious
+/// payload to a fixed, fast-to-reject cost.
+const MAX_EXPANDED_NODES: usize = 1_000_000;
+
 /// # Errors
-/// Propagates [`ScanError`] when the granit parser rejects the input.
+/// Propagates [`ScanError`] when the granit parser rejects the input, or when
+/// alias expansion exceeds [`MAX_EXPANDED_NODES`] (a billion-laughs payload).
 pub fn load_owned_documents(source: &str) -> Result<Vec<YamlOwned>, ScanError> {
     let mut parser = Parser::new_from_str(source);
     let mut loader = Loader::default();
     parser.load(&mut loader, true)?;
+    if let Some(mark) = loader.overflow {
+        return Err(ScanError::new(
+            mark,
+            format!(
+                "too many alias expansions (limit {MAX_EXPANDED_NODES}); \
+                 refusing to expand further to avoid a denial-of-service"
+            ),
+        ));
+    }
     Ok(loader.docs)
 }
 
@@ -29,6 +51,9 @@ struct Frame {
     container: Container,
     anchor_id: usize,
     tag: Option<Tag>,
+    /// Node count of the children attached so far; the container's own size is
+    /// this plus one (computed in [`Loader::close_frame`]).
+    size: usize,
 }
 
 #[derive(Default)]
@@ -37,10 +62,18 @@ struct Loader {
     stack: Vec<Frame>,
     root: Option<YamlOwned>,
     anchor_map: BTreeMap<usize, YamlOwned>,
+    /// Materialised node count of each anchor's value, so an alias can be costed
+    /// in O(1) without walking the (possibly huge) cloned subtree.
+    anchor_sizes: BTreeMap<usize, usize>,
+    /// Running total of nodes produced by alias expansion. Source-built nodes are
+    /// bounded by the input length and are not counted; only clones can multiply.
+    expanded: usize,
+    /// Set to the first location where [`MAX_EXPANDED_NODES`] was exceeded.
+    overflow: Option<Marker>,
 }
 
 impl<'input> SpannedEventReceiver<'input> for Loader {
-    fn on_event(&mut self, ev: Event<'input>, _span: Span) {
+    fn on_event(&mut self, ev: Event<'input>, span: Span) {
         match ev {
             Event::DocumentStart(_)
             | Event::Nothing
@@ -56,6 +89,7 @@ impl<'input> SpannedEventReceiver<'input> for Loader {
                     container: Container::Sequence(Vec::new()),
                     anchor_id: aid,
                     tag: tag.map(Cow::into_owned),
+                    size: 0,
                 });
             }
             Event::MappingStart(_, aid, tag) => {
@@ -66,6 +100,7 @@ impl<'input> SpannedEventReceiver<'input> for Loader {
                     ),
                     anchor_id: aid,
                     tag: tag.map(Cow::into_owned),
+                    size: 0,
                 });
             }
             Event::MappingEnd | Event::SequenceEnd => {
@@ -73,8 +108,8 @@ impl<'input> SpannedEventReceiver<'input> for Loader {
                     .stack
                     .pop()
                     .expect("structure end without matching start");
-                let node = self.close_frame(frame);
-                self.attach(node);
+                let (node, size) = self.close_frame(frame);
+                self.attach(node, size);
             }
             Event::Scalar(value, style, aid, tag) => {
                 let node = match tag.as_ref() {
@@ -95,33 +130,41 @@ impl<'input> SpannedEventReceiver<'input> for Loader {
                 };
                 if aid > 0 {
                     self.anchor_map.insert(aid, node.clone());
+                    self.anchor_sizes.insert(aid, 1);
                 }
-                self.attach(node);
+                self.attach(node, 1);
             }
             Event::Alias(id) => {
                 // granit normally rejects unresolved aliases during the scan,
                 // but a linter must never panic on malformed input, so fall
                 // back to `BadValue` rather than relying on that ordering.
-                // `unwrap_or` constructs the unit variant eagerly, keeping the
-                // branch covered without a lazy closure.
-                let node = self
-                    .anchor_map
-                    .get(&id)
-                    .cloned()
-                    .unwrap_or(YamlOwned::BadValue);
-                self.attach(node);
+                let size = self.anchor_sizes.get(&id).copied().unwrap_or(1);
+                if self.expanded.saturating_add(size) > MAX_EXPANDED_NODES {
+                    self.overflow.get_or_insert(span.start);
+                    self.attach(YamlOwned::BadValue, 1);
+                } else {
+                    self.expanded += size;
+                    let node = self
+                        .anchor_map
+                        .get(&id)
+                        .cloned()
+                        .unwrap_or(YamlOwned::BadValue);
+                    self.attach(node, size);
+                }
             }
         }
     }
 }
 
 impl Loader {
-    fn close_frame(&mut self, frame: Frame) -> YamlOwned {
+    fn close_frame(&mut self, frame: Frame) -> (YamlOwned, usize) {
         let Frame {
             container,
             anchor_id,
             tag,
+            size,
         } = frame;
+        let self_size = size + 1;
         let node = match container {
             Container::Sequence(seq) => YamlOwned::Sequence(seq),
             Container::Mapping(map, _) => YamlOwned::Mapping(map),
@@ -134,23 +177,28 @@ impl Loader {
         };
         if anchor_id > 0 {
             self.anchor_map.insert(anchor_id, node.clone());
+            self.anchor_sizes.insert(anchor_id, self_size);
         }
-        node
+        (node, self_size)
     }
 
-    fn attach(&mut self, node: YamlOwned) {
+    fn attach(&mut self, node: YamlOwned, size: usize) {
         match self.stack.last_mut() {
-            Some(frame) => match &mut frame.container {
-                Container::Sequence(seq) => seq.push(node),
-                Container::Mapping(map, pending_key) => {
-                    if matches!(pending_key, YamlOwned::BadValue) {
-                        *pending_key = node;
-                    } else {
-                        let key = std::mem::replace(pending_key, YamlOwned::BadValue);
-                        map.insert(key, node);
+            Some(frame) => {
+                frame.size += size;
+                match &mut frame.container {
+                    Container::Sequence(seq) => seq.push(node),
+                    Container::Mapping(map, pending_key) => {
+                        if matches!(pending_key, YamlOwned::BadValue) {
+                            *pending_key = node;
+                        } else {
+                            let key =
+                                std::mem::replace(pending_key, YamlOwned::BadValue);
+                            map.insert(key, node);
+                        }
                     }
                 }
-            },
+            }
             None => self.root = Some(node),
         }
     }

--- a/tests/cli_alias_bomb.rs
+++ b/tests/cli_alias_bomb.rs
@@ -1,0 +1,75 @@
+//! Billion-laughs (YAML alias-expansion) regression guards.
+//!
+//! `alias_bomb` is the classic ~470-byte payload whose nested anchors expand to
+//! 9^10 (~3.5 billion) nodes if a loader resolves aliases by cloning. Two
+//! invariants are pinned, one per code path:
+//! - config parsing (which *does* build the alias-expanded DOM) must bound the
+//!   expansion and reject the payload instead of exhausting memory;
+//! - the lint path (which streams events to a no-op sink and never materialises
+//!   the DOM) must stay immune, so a future change that starts building a DOM for
+//!   linted content cannot silently reintroduce the vulnerability.
+//!
+//! A regression in either direction makes the offending test hang/OOM rather than
+//! pass, so these stay meaningful even though they assert on a fast, bounded run.
+
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+fn alias_bomb() -> String {
+    let mut payload = String::from("a0: &a0 \"lol\"\n");
+    for level in 1..=9 {
+        let refs = vec![format!("*a{}", level - 1); 9].join(",");
+        payload.push_str(&format!("a{level}: &a{level} [{refs}]\n"));
+    }
+    let top = vec!["*a9".to_string(); 9].join(",");
+    payload.push_str(&format!("boom: [{top}]\n"));
+    payload
+}
+
+#[test]
+fn config_alias_bomb_is_rejected_instead_of_expanded() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("file.yaml");
+    fs::write(&target, "key: value\n").unwrap();
+    let config = dir.path().join("bomb.yaml");
+    fs::write(&config, alias_bomb()).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _out, err) = run(Command::new(exe).arg("-c").arg(&config).arg(&target));
+    assert_eq!(
+        code, 2,
+        "billion-laughs config must be rejected with a usage exit: {err}"
+    );
+    assert!(
+        err.contains("too many alias expansions"),
+        "expected the billion-laughs guard message: {err}"
+    );
+}
+
+#[test]
+fn linting_alias_bomb_file_does_not_expand_aliases() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("bomb.yaml");
+    fs::write(&target, alias_bomb()).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _out, err) = run(Command::new(exe).arg(&target));
+    assert!(
+        code == 0 || code == 1,
+        "linting a billion-laughs file should finish cleanly (no DOM built), got {code}: {err}"
+    );
+    assert!(
+        !err.contains("too many alias expansions"),
+        "the lint path must never reach the config alias-expansion guard: {err}"
+    );
+}

--- a/tests/cli_config_data_error.rs
+++ b/tests/cli_config_data_error.rs
@@ -28,3 +28,18 @@ fn invalid_inline_config_causes_exit_2() {
         "expected config read error: {err}"
     );
 }
+
+#[test]
+fn empty_inline_config_is_rejected_without_panicking() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("file.yaml");
+    fs::write(&file, "key: value\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _out, err) = run(Command::new(exe).arg("-d").arg("").arg(&file));
+    assert_eq!(code, 2, "empty config should exit 2, not panic: {err}");
+    assert!(
+        err.contains("invalid config: not a mapping"),
+        "empty config should match yamllint's message: {err}"
+    );
+}

--- a/tests/cli_config_flags.rs
+++ b/tests/cli_config_flags.rs
@@ -19,6 +19,8 @@ fn config_file_ignores_docs_globally() {
     fs::write(root.join("a.yaml"), "a: 1\n").unwrap();
     fs::write(root.join("docs/ignored.yaml"), "x: 0\n").unwrap();
 
+    // `--list-files` answers a file-selection query and is exempt from the
+    // "no rules enabled" lint check, so a rule-less config is fine here.
     let cfg = root.join("cfg.yml");
     fs::write(&cfg, "ignore: ['docs/**']\n").unwrap();
 
@@ -49,6 +51,36 @@ fn config_data_yaml_files_only_lists_dot_yamllint_yml() {
     assert_eq!(code, 0, "expected success: {err}");
     assert!(out.contains(".yamllint.yml"));
     assert!(!out.contains("a.yaml"));
+}
+
+#[test]
+fn config_enabling_no_rules_is_rejected_loudly() {
+    let td = tempdir().unwrap();
+    let file = td.path().join("a.yaml");
+    fs::write(&file, "a: 1\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    // A config that turns every rule off lints nothing; ryl rejects it (stricter than
+    // yamllint, which silently accepts a rule-less config) rather than exit 0 silently.
+    for data in ["rules: {}\n", "rules:\n  document-start: disable\n"] {
+        let (code, _out, err) = run(Command::new(exe).arg("-d").arg(data).arg(&file));
+        assert_eq!(code, 2, "a rule-less config must error: {err}");
+        assert!(
+            err.contains("enables no rules"),
+            "expected the no-rules error: {err}"
+        );
+    }
+
+    // `--list-files` is exempt — it answers a file query, it does not lint.
+    let (code, _out, err) = run(Command::new(exe)
+        .arg("--list-files")
+        .arg("-d")
+        .arg("rules: {}\n")
+        .arg(&file));
+    assert_eq!(
+        code, 0,
+        "--list-files must not require enabled rules: {err}"
+    );
 }
 
 #[test]

--- a/tests/cli_env_config.rs
+++ b/tests/cli_env_config.rs
@@ -17,7 +17,7 @@ fn env_config_file_is_honored() {
     let cfg = dir.path().join("env-config.yml");
     fs::write(
         &cfg,
-        "rules:\n  new-line-at-end-of-file: disable\n  document-start: disable\n",
+        "rules:\n  new-line-at-end-of-file: disable\n  document-start: disable\n  key-duplicates: enable\n",
     )
     .unwrap();
     let file = dir.path().join("no_newline.yaml");

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -132,7 +132,7 @@ fn fix_reports_summary_for_invalid_yaml() {
     fs::write(&file, "key: [\n").unwrap();
     fs::write(
         dir.path().join(".ryl.toml"),
-        "[rules]\ndocument-start = 'disable'\n",
+        "[rules]\ndocument-start = 'disable'\nkey-duplicates = 'enable'\n",
     )
     .unwrap();
 

--- a/tests/cli_fix_symlink.rs
+++ b/tests/cli_fix_symlink.rs
@@ -1,0 +1,91 @@
+//! `--fix` must never write through a symlink.
+//!
+//! `std::fs::write` follows symlinks, so without a guard an untrusted tree could
+//! ship `innocent.yaml -> ~/.bashrc` and have `ryl --fix` rewrite a file outside
+//! the tree. These pin that `--fix` skips symlinks (with a warning) and leaves the
+//! target byte-for-byte unchanged, for the explicit-arg, directory-walk, and
+//! embedded-markdown paths. Unix-only: symlink creation needs privileges on
+//! Windows, and CI's coverage gate runs on Linux.
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+const FIXABLE_YAML: &str = "secret: topsecret   \n";
+
+#[test]
+fn fix_skips_explicit_symlink_arg_and_leaves_target_untouched() {
+    let dir = tempdir().unwrap();
+    let secret = dir.path().join("secret.yaml");
+    fs::write(&secret, FIXABLE_YAML).unwrap();
+    let link = dir.path().join("innocent.yaml");
+    symlink(&secret, &link).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _out, err) = run(Command::new(exe).arg("--fix").arg(&link));
+    assert!(
+        err.contains("refusing to apply --fix through a symlink"),
+        "expected the symlink skip warning: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        FIXABLE_YAML,
+        "the symlink target must be left byte-for-byte unchanged"
+    );
+}
+
+#[test]
+fn fix_skips_symlink_pointing_outside_the_scanned_directory() {
+    let dir = tempdir().unwrap();
+    let secret = dir.path().join("secret.yaml");
+    fs::write(&secret, FIXABLE_YAML).unwrap();
+    let repo = dir.path().join("repo");
+    fs::create_dir(&repo).unwrap();
+    symlink(&secret, repo.join("innocent.yaml")).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _out, err) = run(Command::new(exe).arg("--fix").arg(&repo));
+    assert!(
+        err.contains("refusing to apply --fix through a symlink"),
+        "directory-walk --fix must skip symlinks: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        FIXABLE_YAML,
+        "dir-walk --fix must not reach a file outside the tree via a symlink"
+    );
+}
+
+#[test]
+fn fix_skips_symlinked_markdown_target() {
+    let dir = tempdir().unwrap();
+    let secret = dir.path().join("secret.md");
+    let original = "```yaml\nk: v   \n```\n";
+    fs::write(&secret, original).unwrap();
+    let link = dir.path().join("innocent.md");
+    symlink(&secret, &link).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _out, err) =
+        run(Command::new(exe).arg("--fix").arg("--markdown").arg(&link));
+    assert!(
+        err.contains("refusing to apply --fix through a symlink"),
+        "embedded-markdown --fix must skip symlinks: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        original,
+        "the symlinked markdown target must be left byte-for-byte unchanged"
+    );
+}

--- a/tests/cli_fix_symlink.rs
+++ b/tests/cli_fix_symlink.rs
@@ -25,6 +25,33 @@ fn run(cmd: &mut Command) -> (i32, String, String) {
 const FIXABLE_YAML: &str = "secret: topsecret   \n";
 
 #[test]
+fn fix_symlink_warning_sanitizes_the_path() {
+    // The skip warning embeds the (user-controlled) path; a newline in a symlink's
+    // name must not break out of the warning line into a forged workflow command.
+    let dir = tempdir().unwrap();
+    let secret = dir.path().join("secret.yaml");
+    fs::write(&secret, FIXABLE_YAML).unwrap();
+    let link = dir.path().join("evil\n::error::INJECT.yaml");
+    symlink(&secret, &link).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _out, err) = run(Command::new(exe).arg("--fix").arg(&link));
+    assert!(
+        err.contains("refusing to apply --fix through a symlink"),
+        "expected the symlink skip warning: {err:?}"
+    );
+    assert!(
+        !err.contains("\n::error::INJECT"),
+        "the warning's path must be sanitized, not injected: {err:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        FIXABLE_YAML,
+        "the symlink target must be left unchanged"
+    );
+}
+
+#[test]
 fn fix_skips_explicit_symlink_arg_and_leaves_target_untouched() {
     let dir = tempdir().unwrap();
     let secret = dir.path().join("secret.yaml");

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -169,6 +169,33 @@ fn github_format_escapes_newlines_to_prevent_command_injection() {
 }
 
 #[test]
+fn human_formats_escape_control_characters_in_messages() {
+    let dir = tempdir().unwrap();
+    let cfg = dir.path().join("config.yml");
+    fs::write(&cfg, "rules:\n  key-duplicates: enable\n").unwrap();
+    let file = dir.path().join("esc.yaml");
+    // A duplicate key carrying a raw ESC (YAML \x1b) — echoed into the message; the
+    // parsable format has no ANSI of its own, so any ESC in the output is the payload.
+    fs::write(&file, "\"\\x1b[2Jx\": 1\n\"\\x1b[2Jx\": 2\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("parsable")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert!(
+        !stderr.contains('\u{1b}'),
+        "a raw ESC control char must not reach the terminal: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("\\u{1b}"),
+        "the control char must be rendered as a visible escape: {stderr}"
+    );
+}
+
+#[test]
 fn colored_format_uses_ansi_sequences() {
     let dir = tempdir().unwrap();
     let cfg = disable_doc_start_config(dir.path());

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -196,6 +196,83 @@ fn human_formats_escape_control_characters_in_messages() {
 }
 
 #[test]
+fn github_format_escapes_control_chars_not_just_newlines() {
+    let dir = tempdir().unwrap();
+    let cfg = dir.path().join("config.yml");
+    fs::write(&cfg, "rules:\n  key-duplicates: enable\n").unwrap();
+    let file = dir.path().join("esc.yaml");
+    fs::write(&file, "\"\\x1b[31mEVIL\": 1\n\"\\x1b[31mEVIL\": 2\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("github")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    // The GitHub format has no ANSI of its own, so a raw ESC would be the payload
+    // reaching the CI log viewer; it must be rendered as a literal escape, not a
+    // %XX (which the runner would decode back into a control char).
+    assert!(
+        !stderr.contains('\u{1b}'),
+        "raw ESC must not reach the GitHub log: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("\\u{1b}"),
+        "ESC must be rendered as a literal escape in the GitHub format: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn github_format_escapes_percent_cr_and_property_delimiters() {
+    let dir = tempdir().unwrap();
+    let cfg = dir.path().join("config.yml");
+    fs::write(&cfg, "rules:\n  key-duplicates: enable\n").unwrap();
+    // The filename's `:`/`,` exercise the `file=` property escaping; the duplicate
+    // key carries a literal `%` and a CR into the message.
+    let file = dir.path().join("we:ird,name.yaml");
+    fs::write(&file, "\"a%b\\rc\": 1\n\"a%b\\rc\": 2\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("github")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert!(
+        stderr.contains("%3A") && stderr.contains("%2C"),
+        "`:` and `,` in the file= path must be percent-escaped: {stderr}"
+    );
+    assert!(
+        stderr.contains("%25"),
+        "a literal `%` must become %25: {stderr}"
+    );
+    assert!(stderr.contains("%0D"), "a CR must become %0D: {stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn error_message_paths_are_escaped_in_github_format() {
+    // A filename with an embedded newline + a fake workflow command, whose content
+    // is invalid UTF-8 so linting fails and the error message (which embeds the
+    // path) is emitted. The path must be sanitized so the newline cannot start a
+    // new ::command:: in CI.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("evil\n::error::ARM_INJECT.yaml");
+    fs::write(&file, [0x80u8]).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _stdout, stderr) =
+        run(Command::new(exe).arg("--format").arg("github").arg(&file));
+    assert!(
+        !stderr.contains("\n::error::ARM_INJECT"),
+        "an error-message path must not inject a workflow command: {stderr:?}"
+    );
+}
+
+#[test]
 fn colored_format_uses_ansi_sequences() {
     let dir = tempdir().unwrap();
     let cfg = disable_doc_start_config(dir.path());

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -138,6 +138,37 @@ fn github_format_emits_workflow_commands() {
 }
 
 #[test]
+fn github_format_escapes_newlines_to_prevent_command_injection() {
+    let dir = tempdir().unwrap();
+    let cfg = dir.path().join("config.yml");
+    fs::write(&cfg, "rules:\n  key-duplicates: enable\n").unwrap();
+    let file = dir.path().join("inject.yaml");
+    // A duplicate key whose name embeds a newline and a fake workflow command;
+    // the key text is echoed verbatim into the key-duplicates message.
+    fs::write(
+        &file,
+        "\"x\\n::error::INJECTED\": 1\n\"x\\n::error::INJECTED\": 2\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("github")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert!(
+        stderr.contains("%0A"),
+        "the newline in the key must be encoded as %0A: {stderr}"
+    );
+    assert!(
+        !stderr.contains("\n::error::INJECTED"),
+        "an embedded newline must not start a new ::error:: command: {stderr}"
+    );
+}
+
+#[test]
 fn colored_format_uses_ansi_sequences() {
     let dir = tempdir().unwrap();
     let cfg = disable_doc_start_config(dir.path());

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -44,6 +44,33 @@ fn front_matter_and_fenced_blocks_map_to_host_positions() {
 }
 
 #[test]
+fn many_fenced_blocks_map_to_correct_host_lines() {
+    // The extractor derives each block's line offset by binary search over
+    // precomputed newline positions; a regression to rescanning from the document
+    // start is quadratic over many blocks. Each 4-line block puts its content (with
+    // a trailing space) on host line `4*i + 2`, so this pins that a block far down
+    // the document still maps to the right host line.
+    let dir = tempdir().unwrap();
+    let body = "```yaml\nk: v  \n```\n\n".repeat(2000);
+    let file = dir.path().join("many.md");
+    fs::write(&file, &body).unwrap();
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
+        .arg("--markdown")
+        .arg(&file));
+
+    assert_eq!(code, 1, "trailing spaces should be reported: {err}");
+    assert!(
+        err.contains("2:5"),
+        "first block trailing-space position: {err}"
+    );
+    assert!(
+        err.contains("7998:5"),
+        "last block (i=1999) must map to host line 4*1999+2 = 7998: {err}"
+    );
+}
+
+#[test]
 fn indented_fenced_block_adds_indent_to_column() {
     let body = "-  item\n\n   ```yaml\n   key:  value\n   ```\n";
     let (_dir, file) = project(COLONS_ONLY, "doc.md", body);

--- a/tests/cli_new_line_rule.rs
+++ b/tests/cli_new_line_rule.rs
@@ -74,7 +74,11 @@ fn disabled_new_line_rule_allows_success() {
     let file = dir.path().join("no_newline.yaml");
     fs::write(&file, "key: value").unwrap();
     let config = dir.path().join("config.yml");
-    fs::write(&config, "rules:\n  new-line-at-end-of-file: disable\n").unwrap();
+    fs::write(
+        &config,
+        "rules:\n  new-line-at-end-of-file: disable\n  key-duplicates: enable\n",
+    )
+    .unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, stdout, stderr) =

--- a/tests/cli_stdin.rs
+++ b/tests/cli_stdin.rs
@@ -34,6 +34,20 @@ fn run(cmd: &mut Command) -> (i32, String, String) {
 }
 
 #[test]
+fn stdin_with_no_enabled_rules_errors() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run_with_stdin(
+        Command::new(exe).arg("-").arg("-d").arg("rules: {}\n"),
+        b"key: value\n",
+    );
+    assert_eq!(
+        code, 2,
+        "stdin lint with no enabled rules must error: {stderr}"
+    );
+    assert!(stderr.contains("enables no rules"), "{stderr}");
+}
+
+#[test]
 fn stdin_clean_yaml_succeeds_and_uses_label() {
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, stdout, stderr) =
@@ -142,7 +156,7 @@ fn stdin_filename_anchors_project_config_discovery() {
     fs::create_dir(&pkg).unwrap();
     fs::write(
         dir.path().join(".ryl.toml"),
-        "[rules]\nkey-duplicates = \"disable\"\n",
+        "[rules]\nkey-duplicates = \"disable\"\ntrailing-spaces = \"enable\"\n",
     )
     .unwrap();
 
@@ -299,10 +313,9 @@ fn stdin_list_files_uses_stdin_filename() {
 fn stdin_honors_config_data_override() {
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, _stdout, stderr) = run_with_stdin(
-        Command::new(exe)
-            .arg("-")
-            .arg("-d")
-            .arg("rules:\n  new-line-at-end-of-file: disable\n"),
+        Command::new(exe).arg("-").arg("-d").arg(
+            "rules:\n  new-line-at-end-of-file: disable\n  key-duplicates: enable\n",
+        ),
         b"key: value",
     );
     assert_eq!(code, 0, "disabled rule should pass: {stderr}");
@@ -398,7 +411,11 @@ fn stdin_with_missing_config_file_errors() {
 #[test]
 fn stdin_emits_legacy_yaml_notice_when_toml_present() {
     let dir = tempdir().unwrap();
-    fs::write(dir.path().join(".ryl.toml"), "[rules]\n").unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ntrailing-spaces = \"enable\"\n",
+    )
+    .unwrap();
     fs::write(
         dir.path().join(".yamllint"),
         "rules:\n  trailing-spaces: enable\n",

--- a/tests/cli_toml_config.rs
+++ b/tests/cli_toml_config.rs
@@ -75,27 +75,19 @@ fn discovered_empty_toml_config_is_rejected() {
 }
 
 #[test]
-fn discovered_pyproject_with_empty_tool_ryl_falls_back_to_defaults() {
-    // A stub `[tool.ryl]` (header, no keys) found during discovery must behave like
-    // a missing section — fall back to default rules — not abort the whole run the
-    // way a standalone empty config does. Regression guard for the empty-TOML fix.
+fn discovered_pyproject_with_empty_tool_ryl_is_rejected() {
+    // A present-but-empty `[tool.ryl]` enables no rules; ryl rejects it rather than
+    // silently handing back the default rule set (rules must be explicitly enabled).
+    // An *absent* `[tool.ryl]` is different — discovery keeps looking.
     let td = tempdir().unwrap();
     let root = td.path();
     fs::write(root.join("pyproject.toml"), "[tool.ryl]\n").unwrap();
-    fs::write(root.join("a.yaml"), "a: 1  \n").unwrap();
+    fs::write(root.join("a.yaml"), "a: 1\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, _stdout, stderr) = run(Command::new(exe).arg(root.join("a.yaml")));
-    assert_eq!(
-        code, 1,
-        "stub [tool.ryl] in a discovered pyproject must lint with defaults, not \
-         abort: {stderr}"
-    );
-    assert!(
-        stderr.contains("trailing-spaces")
-            && !stderr.contains("configuration is empty"),
-        "expected default rules to run, not an empty-config abort: {stderr}"
-    );
+    assert_eq!(code, 2, "an empty [tool.ryl] must be rejected: {stderr}");
+    assert!(stderr.contains("configuration is empty"), "{stderr}");
 }
 
 #[test]

--- a/tests/cli_toml_config.rs
+++ b/tests/cli_toml_config.rs
@@ -75,6 +75,30 @@ fn discovered_empty_toml_config_is_rejected() {
 }
 
 #[test]
+fn discovered_pyproject_with_empty_tool_ryl_falls_back_to_defaults() {
+    // A stub `[tool.ryl]` (header, no keys) found during discovery must behave like
+    // a missing section — fall back to default rules — not abort the whole run the
+    // way a standalone empty config does. Regression guard for the empty-TOML fix.
+    let td = tempdir().unwrap();
+    let root = td.path();
+    fs::write(root.join("pyproject.toml"), "[tool.ryl]\n").unwrap();
+    fs::write(root.join("a.yaml"), "a: 1  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe).arg(root.join("a.yaml")));
+    assert_eq!(
+        code, 1,
+        "stub [tool.ryl] in a discovered pyproject must lint with defaults, not \
+         abort: {stderr}"
+    );
+    assert!(
+        stderr.contains("trailing-spaces")
+            && !stderr.contains("configuration is empty"),
+        "expected default rules to run, not an empty-config abort: {stderr}"
+    );
+}
+
+#[test]
 fn global_config_notice_is_emitted_when_env_var_triggers_global_discovery() {
     let td = tempdir().unwrap();
     let root = td.path();

--- a/tests/cli_toml_config.rs
+++ b/tests/cli_toml_config.rs
@@ -59,6 +59,22 @@ fn explicit_pyproject_without_tool_ryl_errors() {
 }
 
 #[test]
+fn discovered_empty_toml_config_is_rejected() {
+    let td = tempdir().unwrap();
+    let root = td.path();
+    fs::write(root.join(".ryl.toml"), "").unwrap();
+    fs::write(root.join("a.yaml"), "a: 1\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe).arg(root.join("a.yaml")));
+    assert_eq!(
+        code, 2,
+        "an empty config must error, not silently lint nothing: {stderr}"
+    );
+    assert!(stderr.contains("configuration is empty"), "{stderr}");
+}
+
+#[test]
 fn global_config_notice_is_emitted_when_env_var_triggers_global_discovery() {
     let td = tempdir().unwrap();
     let root = td.path();

--- a/tests/config_extends_inline.rs
+++ b/tests/config_extends_inline.rs
@@ -101,6 +101,30 @@ fn extends_invalid_yaml_propagates_error() {
 }
 
 #[test]
+fn cyclic_extends_is_rejected_without_overflowing_the_stack() {
+    let root = PathBuf::from("/workspace");
+    let a = root.join("a.yml");
+    let b = root.join("b.yml");
+    let env = FakeEnv::new()
+        .with_cwd(root.clone())
+        .with_file(a.clone(), "extends: b.yml\nrules: {}\n")
+        .with_file(b.clone(), "extends: a.yml\nrules: {}\n")
+        .with_exists(a)
+        .with_exists(b);
+
+    let err = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(root.join("a.yml")),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect_err("a cyclic extends chain must error, not overflow the stack");
+    assert!(err.contains("nested too deeply"), "{err}");
+}
+
+#[test]
 fn extend_prefers_absolute_paths() {
     let root = PathBuf::from("/workspace");
     let abs = PathBuf::from("/configs/base.yml");

--- a/tests/config_extends_inline.rs
+++ b/tests/config_extends_inline.rs
@@ -130,7 +130,7 @@ fn extend_prefers_absolute_paths() {
     let abs = PathBuf::from("/configs/base.yml");
     let env = FakeEnv::new()
         .with_cwd(root.clone())
-        .with_file(abs.clone(), "rules:\n  abs_rule: enable\n")
+        .with_file(abs.clone(), "rules:\n  colons: enable\n")
         .with_exists(abs.clone());
 
     let ctx = discover_config_with(
@@ -142,7 +142,7 @@ fn extend_prefers_absolute_paths() {
         &env,
     )
     .expect("absolute extends should resolve");
-    assert!(ctx.config.rule_names().iter().any(|r| r == "abs_rule"));
+    assert!(ctx.config.rule_names().iter().any(|r| r == "colons"));
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn extend_falls_back_to_env_cwd_when_base_dir_missing_entry() {
         .with_cwd(cwd.clone())
         .with_file(cli_cfg.clone(), "extends: config.yml\n")
         .with_exists(cli_cfg.clone())
-        .with_file(cwd.join("config.yml"), "rules:\n  cwd_rule: enable\n")
+        .with_file(cwd.join("config.yml"), "rules:\n  commas: enable\n")
         .with_exists(cwd.join("config.yml"));
 
     let ctx = discover_config_with(
@@ -166,7 +166,7 @@ fn extend_falls_back_to_env_cwd_when_base_dir_missing_entry() {
         &env,
     )
     .expect("extend should fall back to cwd");
-    assert!(ctx.config.rule_names().iter().any(|r| r == "cwd_rule"));
+    assert!(ctx.config.rule_names().iter().any(|r| r == "commas"));
 }
 
 #[test]
@@ -197,7 +197,7 @@ fn extend_relative_entry_uses_base_directory() {
         .with_cwd(project.clone())
         .with_file(child.clone(), "extends: base.yml\n")
         .with_exists(child.clone())
-        .with_file(base.clone(), "rules: { base_rule: enable }\n")
+        .with_file(base.clone(), "rules: { hyphens: enable }\n")
         .with_exists(base.clone());
 
     let ctx = discover_config_with(
@@ -209,5 +209,5 @@ fn extend_relative_entry_uses_base_directory() {
         &env,
     )
     .expect("relative extends should resolve using config directory");
-    assert!(ctx.config.rule_names().iter().any(|r| r == "base_rule"));
+    assert!(ctx.config.rule_names().iter().any(|r| r == "hyphens"));
 }

--- a/tests/config_find_project_home_boundary.rs
+++ b/tests/config_find_project_home_boundary.rs
@@ -35,7 +35,7 @@ fn project_search_supports_relative_home() {
         .with_var("HOME", "userhome".to_string())
         .with_file(
             PathBuf::from("/workspace/userhome/.yamllint"),
-            "rules: { rel: enable }\n",
+            "rules: { colons: enable }\n",
         )
         .with_exists(PathBuf::from("/workspace/userhome/.yamllint"))
         .with_exists(PathBuf::from("/workspace/userhome/project/file.yaml"));
@@ -50,5 +50,5 @@ fn project_search_supports_relative_home() {
         ctx.source.as_deref(),
         Some(Path::new("/workspace/userhome/.yamllint"))
     );
-    assert!(ctx.config.rule_names().iter().any(|r| r == "rel"));
+    assert!(ctx.config.rule_names().iter().any(|r| r == "colons"));
 }

--- a/tests/config_from_yaml_paths.rs
+++ b/tests/config_from_yaml_paths.rs
@@ -11,7 +11,7 @@ ignore:
 yaml-files:
   - "*.yml"
 rules:
-  new_rule: { enabled: true }
+  colons: enable
 "#;
     let ctx = discover_config(
         &[],
@@ -26,7 +26,7 @@ rules:
     assert!(pats.iter().any(|p| p == "a.yml"));
     assert!(pats.iter().any(|p| p == "b.yaml"));
 
-    assert!(ctx.config.rule_names().iter().any(|n| n == "new_rule"));
+    assert!(ctx.config.rule_names().iter().any(|n| n == "colons"));
     assert!(ctx.config.rule_names().iter().any(|n| n == "anchors"));
     assert_eq!(ctx.config.locale(), Some("en_US"));
 }

--- a/tests/config_ignore_errors.rs
+++ b/tests/config_ignore_errors.rs
@@ -69,68 +69,8 @@ fn ignore_patterns_non_string_errors() {
 }
 
 #[test]
-fn custom_rule_ignore_scalar_type_errors() {
-    let yaml = "rules:\n  custom-rule:\n    ignore: 1\n";
-    let err = discover_config(
-        &[],
-        &Overrides {
-            config_file: None,
-            config_data: Some(yaml.into()),
-        },
-    )
-    .expect_err("custom rule ignore should reject non-string scalars");
-    assert!(
-        err.contains(
-            "option \"ignore\" of \"custom-rule\" should contain file patterns"
-        ),
-        "{err}"
-    );
-}
-
-#[test]
-fn custom_rule_ignore_from_file_non_string_sequence_errors() {
-    let yaml = "rules:\n  custom-rule:\n    ignore-from-file: [1]\n";
-    let err = discover_config(
-        &[],
-        &Overrides {
-            config_file: None,
-            config_data: Some(yaml.into()),
-        },
-    )
-    .expect_err("custom rule ignore-from-file should reject non-string entries");
-    assert!(
-        err.contains(
-            "option \"ignore-from-file\" of \"custom-rule\" should contain filename(s), either as a list or string"
-        ),
-        "{err}"
-    );
-}
-
-#[test]
-fn custom_toml_rule_ignore_scalar_type_errors() {
-    let td = tempdir().unwrap();
-    let path = td.path().join(".ryl.toml");
-    fs::write(path.clone(), "[rules.custom-rule]\nignore = 1\n").unwrap();
-
-    let err = discover_config(
-        &[],
-        &Overrides {
-            config_file: Some(path),
-            config_data: None,
-        },
-    )
-    .expect_err("custom TOML rule ignore should reject non-string scalars");
-    assert!(
-        err.contains(
-            "option \"ignore\" of \"custom-rule\" should contain file patterns"
-        ),
-        "{err}"
-    );
-}
-
-#[test]
-fn custom_rule_ignore_string_is_allowed() {
-    let yaml = "rules:\n  custom-rule:\n    ignore: docs/**\n";
+fn rule_ignore_string_is_honored() {
+    let yaml = "rules:\n  colons:\n    ignore: docs/**\n";
     let ctx = discover_config(
         &[],
         &Overrides {
@@ -138,19 +78,19 @@ fn custom_rule_ignore_string_is_allowed() {
             config_data: Some(yaml.into()),
         },
     )
-    .expect("custom rule ignore string should parse");
+    .expect("rule ignore string should parse");
     assert!(ctx.config.is_rule_ignored(
-        "custom-rule",
+        "colons",
         Path::new("docs/file.yaml"),
         Path::new("."),
     ));
 }
 
 #[test]
-fn custom_toml_rule_ignore_array_is_allowed() {
+fn toml_rule_ignore_array_is_honored() {
     let td = tempdir().unwrap();
     let path = td.path().join(".ryl.toml");
-    fs::write(path.clone(), "[rules.custom-rule]\nignore = ['docs/**']\n").unwrap();
+    fs::write(path.clone(), "[rules.colons]\nignore = ['docs/**']\n").unwrap();
 
     let ctx = discover_config(
         &[],
@@ -159,9 +99,9 @@ fn custom_toml_rule_ignore_array_is_allowed() {
             config_data: None,
         },
     )
-    .expect("custom TOML rule ignore array should parse");
+    .expect("TOML rule ignore array should parse");
     assert!(ctx.config.is_rule_ignored(
-        "custom-rule",
+        "colons",
         td.path().join("docs/file.yaml").as_path(),
         td.path(),
     ));

--- a/tests/config_rule_level.rs
+++ b/tests/config_rule_level.rs
@@ -4,6 +4,58 @@ use ryl::config::{Overrides, RuleLevel, YamlLintConfig, discover_config};
 use tempfile::tempdir;
 
 #[test]
+fn unknown_rule_name_is_rejected() {
+    // ryl does not support custom/unrecognised rules (matching yamllint): an unknown
+    // rule name — including a typo of a real one — is a config error, not a silent
+    // no-op. Covers both the YAML and TOML config paths.
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: None,
+            config_data: Some("rules:\n  not-a-real-rule: enable\n".into()),
+        },
+    )
+    .expect_err("an unknown rule name must be rejected");
+    assert_eq!(err, "invalid config: no such rule: \"not-a-real-rule\"");
+
+    let td = tempdir().unwrap();
+    let cfg = td.path().join(".ryl.toml");
+    fs::write(&cfg, "[rules]\ntariling-spaces = \"enable\"\n").unwrap();
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+    )
+    .expect_err("a typo'd rule name must be rejected, not silently ignored");
+    assert!(err.contains("no such rule: \"tariling-spaces\""), "{err}");
+}
+
+#[test]
+fn unknown_rule_with_float_and_datetime_options_is_rejected() {
+    // An unknown rule's option values still flow through TOML->YAML scalar
+    // conversion (including float and datetime) before the rule name is checked;
+    // the rejection must win regardless of those option value types.
+    let td = tempdir().unwrap();
+    let cfg = td.path().join(".ryl.toml");
+    fs::write(
+        &cfg,
+        "[rules.made-up-rule]\nratio = 1.5\nstamp = 1979-05-27T07:32:00Z\n",
+    )
+    .unwrap();
+    let err = discover_config(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+    )
+    .expect_err("an unknown rule with float/datetime options must still be rejected");
+    assert!(err.contains("no such rule: \"made-up-rule\""), "{err}");
+}
+
+#[test]
 fn rule_level_returns_none_for_disable() {
     let cfg = r#"
 rules:
@@ -139,27 +191,6 @@ rules:
     let err = YamlLintConfig::from_yaml_str(cfg).expect_err("invalid");
     assert!(err.contains("failed to parse config data:"), "{err}");
     assert!(err.contains("rules.new-line-at-end-of-file"), "{err}");
-}
-
-#[test]
-fn custom_toml_rule_level_defaults_to_error_for_unknown_string_value() {
-    let td = tempdir().unwrap();
-    let cfg = td.path().join(".ryl.toml");
-    fs::write(&cfg, "[rules]\ncustom-rule = 'other'\n").unwrap();
-
-    let context = discover_config(
-        &[],
-        &Overrides {
-            config_file: Some(cfg),
-            config_data: None,
-        },
-    )
-    .expect("config");
-
-    assert_eq!(
-        context.config.rule_level("custom-rule"),
-        Some(RuleLevel::Error)
-    );
 }
 
 #[test]

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -803,10 +803,14 @@ fn empty_project_toml_is_rejected_as_empty() {
 }
 
 #[test]
-fn empty_tool_ryl_in_pyproject_is_rejected_as_empty() {
-    let err = parse_toml_config_str("[tool.ryl]\n", true)
-        .expect_err("an empty [tool.ryl] table configures nothing and must error");
-    assert_eq!(err, "invalid config: configuration is empty");
+fn empty_tool_ryl_in_pyproject_is_treated_as_unconfigured() {
+    // An empty `[tool.ryl]` is treated like an absent one (Ok(None)) so config
+    // discovery falls back to defaults instead of aborting the whole run; an
+    // explicit `-c pyproject.toml` still rejects it ("missing [tool.ryl] section")
+    // via the caller, which is exercised in tests/cli_toml_config.rs.
+    let parsed = parse_toml_config_str("[tool.ryl]\n", true)
+        .expect("an empty [tool.ryl] is unconfigured, not an error");
+    assert!(parsed.is_none(), "empty [tool.ryl] should yield no config");
 }
 
 #[test]

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -791,6 +791,35 @@ fn typed_toml_parser_errors_for_invalid_pyproject_toml() {
 }
 
 #[test]
+fn empty_project_toml_is_rejected_as_empty() {
+    for input in ["", "   \n", "# only a comment\n"] {
+        let err = parse_toml_config_str(input, false)
+            .expect_err("an empty TOML config configures nothing and must error");
+        assert_eq!(
+            err, "invalid config: configuration is empty",
+            "input={input:?}"
+        );
+    }
+}
+
+#[test]
+fn empty_tool_ryl_in_pyproject_is_rejected_as_empty() {
+    let err = parse_toml_config_str("[tool.ryl]\n", true)
+        .expect_err("an empty [tool.ryl] table configures nothing and must error");
+    assert_eq!(err, "invalid config: configuration is empty");
+}
+
+#[test]
+fn pyproject_without_tool_ryl_is_not_empty_and_yields_no_config() {
+    let parsed = parse_toml_config_str("[project]\nname = 'demo'\n", true)
+        .expect("an absent [tool.ryl] is 'unconfigured', not an empty-config error");
+    assert!(
+        parsed.is_none(),
+        "no [tool.ryl] section should produce no config"
+    );
+}
+
+#[test]
 fn typed_toml_validation_rejects_ignore_and_ignore_from_file_together() {
     let parsed = parse_toml_config_str(
         "ignore = ['vendor/**']\nignore-from-file = ['.ignore-list']\n",

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -803,14 +803,12 @@ fn empty_project_toml_is_rejected_as_empty() {
 }
 
 #[test]
-fn empty_tool_ryl_in_pyproject_is_treated_as_unconfigured() {
-    // An empty `[tool.ryl]` is treated like an absent one (Ok(None)) so config
-    // discovery falls back to defaults instead of aborting the whole run; an
-    // explicit `-c pyproject.toml` still rejects it ("missing [tool.ryl] section")
-    // via the caller, which is exercised in tests/cli_toml_config.rs.
-    let parsed = parse_toml_config_str("[tool.ryl]\n", true)
-        .expect("an empty [tool.ryl] is unconfigured, not an error");
-    assert!(parsed.is_none(), "empty [tool.ryl] should yield no config");
+fn empty_tool_ryl_in_pyproject_is_rejected_as_empty() {
+    // A present-but-empty `[tool.ryl]` enables no rules, so it is an error — distinct
+    // from an *absent* `[tool.ryl]` (covered below), which lets discovery keep looking.
+    let err = parse_toml_config_str("[tool.ryl]\n", true)
+        .expect_err("an empty [tool.ryl] table configures nothing and must error");
+    assert_eq!(err, "invalid config: configuration is empty");
 }
 
 #[test]

--- a/tests/config_to_toml.rs
+++ b/tests/config_to_toml.rs
@@ -80,28 +80,6 @@ fn to_toml_errors_on_null_values() {
 }
 
 #[test]
-fn to_toml_converts_scalar_sequence_and_mapping_values() {
-    let ctx = discover_config(
-        &[],
-        &Overrides {
-            config_file: None,
-            config_data: Some(
-                "rules:\n  custom-rule:\n    flag: true\n    count: 3\n    ratio: 1.5\n    list: [1, false]\n    nested: { child: 1 }\n"
-                    .to_string(),
-            ),
-        },
-    )
-    .unwrap();
-    let toml = ctx.config.to_toml_string();
-    assert!(toml.contains("flag = true"));
-    assert!(toml.contains("count = 3"));
-    assert!(toml.contains("ratio = 1.5"));
-    assert!(toml.contains("list = ["));
-    assert!(toml.contains("false"));
-    assert!(toml.contains("[rules.custom-rule.nested]"));
-}
-
-#[test]
 fn to_toml_errors_on_non_string_mapping_keys() {
     let err = discover_config(
         &[],

--- a/tests/config_toml_discovery.rs
+++ b/tests/config_toml_discovery.rs
@@ -361,37 +361,6 @@ fn exact_typed_toml_splits_multiline_scalar_ignore_patterns() {
 }
 
 #[test]
-fn toml_custom_rule_entries_are_preserved() {
-    let cfg = PathBuf::from("/repo/.ryl.toml");
-    let env = FakeEnv::new().with_cwd(PathBuf::from("/repo")).with_file(
-        cfg.clone(),
-        "[rules]\nanchors = 'disable'\n[rules.custom-rule]\nflag = true\nratio = 1.5\nstamp = 1979-05-27T07:32:00Z\n",
-    );
-    let ctx = discover_config_with(
-        &[],
-        &Overrides {
-            config_file: Some(cfg),
-            config_data: None,
-        },
-        &env,
-    )
-    .expect("custom TOML rules should still parse");
-
-    assert!(
-        ctx.config
-            .rule_names()
-            .iter()
-            .any(|name| name == "custom-rule")
-    );
-    assert!(ctx.config.rule_names().iter().any(|name| name == "anchors"));
-    assert_eq!(
-        ctx.config.rule_option_int("custom-rule", "ratio", -1),
-        -1,
-        "custom float values should remain non-integer options"
-    );
-}
-
-#[test]
 fn toml_ignore_and_ignore_from_file_conflict_errors() {
     let cfg = PathBuf::from("/repo/.ryl.toml");
     let env = FakeEnv::new().with_cwd(PathBuf::from("/repo")).with_file(

--- a/tests/property_config.rs
+++ b/tests/property_config.rs
@@ -1,0 +1,127 @@
+//! Property tests for **configuration parsing** robustness (issue #246).
+//!
+//! The audit that motivated these turned up two config-path defects a property
+//! test would have caught: a panic on an empty config (`docs[0]`) and an
+//! out-of-memory on a billion-laughs config. This suite generates randomized
+//! configs — mixing valid settings with hostile ones (invalid regexes, ill-typed
+//! and out-of-range scalars, bogus locales) — renders them to both YAML and TOML,
+//! and asserts the oracle-free invariant that the whole pipeline **errors or
+//! succeeds but never panics**:
+//!
+//! - YAML configs are parsed with [`YamlLintConfig::from_yaml_str`] and, when they
+//!   parse, used to lint sample documents — driving the `.expect()` calls in the
+//!   regex-bearing rules' `resolve()` (`key-ordering`, `quoted-strings`).
+//! - TOML configs are pushed through `parse -> validate -> normalize`, the
+//!   TOML-specific surface.
+//!
+//! Deterministic siblings pin the empty-config, invalid-regex, billion-laughs, and
+//! valid-config cases so the random invariant cannot pass vacuously if the generator
+//! drifts.
+
+#[path = "property_config/strategy.rs"]
+mod strategy;
+
+use std::path::Path;
+
+use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+use ryl::config::YamlLintConfig;
+use ryl::config_schema::{
+    normalize_toml_config, parse_toml_config_str, validate_toml_config,
+};
+use ryl::lint::lint_str;
+
+use strategy::{arb_config, render_toml, render_yaml};
+
+/// Documents crafted to trigger the rules whose `resolve()` compiles config
+/// regexes or reads typed options, so a hostile option value reaches the rule.
+const SAMPLE_DOCS: &[&str] = &[
+    "b: 1\na: 2\n",
+    "name: value\nok_key: 'x'\n",
+    "list: [1,2 ,3]\n",
+    "flag: yes\n",
+];
+
+fn lint_with(yaml_config: &str) -> Option<YamlLintConfig> {
+    let cfg = YamlLintConfig::from_yaml_str(yaml_config).ok()?;
+    for doc in SAMPLE_DOCS {
+        // Panics here (e.g. a rule's resolve() `.expect()`) fail the property.
+        let _ = lint_str(doc, Path::new("in.yaml"), &cfg, Path::new("."));
+    }
+    Some(cfg)
+}
+
+fn parse_toml_without_panicking(toml_config: &str) {
+    if let Ok(Some(typed)) = parse_toml_config_str(toml_config, false)
+        && validate_toml_config(&typed).is_ok()
+    {
+        let _ = normalize_toml_config(&typed);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "tests/proptest-regressions/property_config.txt",
+        ))),
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn config_parsing_and_linting_never_panics(model in arb_config()) {
+        lint_with(&render_yaml(&model));
+        parse_toml_without_panicking(&render_toml(&model));
+    }
+}
+
+#[test]
+fn empty_yaml_config_errors_without_panicking() {
+    assert!(
+        YamlLintConfig::from_yaml_str("").is_err(),
+        "an empty YAML config is not a mapping and must error"
+    );
+}
+
+#[test]
+fn empty_toml_config_errors_without_panicking() {
+    assert!(
+        parse_toml_config_str("", false).is_err(),
+        "an empty TOML config configures nothing and must error"
+    );
+}
+
+#[test]
+fn invalid_regex_config_errors_without_panicking() {
+    let yaml = "rules:\n  key-ordering:\n    level: error\n    ignored-keys: [\"(\"]\n";
+    assert!(
+        YamlLintConfig::from_yaml_str(yaml).is_err(),
+        "an invalid regex must be rejected at parse time, not panic in resolve()"
+    );
+}
+
+#[test]
+fn billion_laughs_config_errors_without_panicking() {
+    let mut yaml = String::from("a0: &a0 \"x\"\n");
+    for level in 1..=9 {
+        let refs = vec![format!("*a{}", level - 1); 9].join(",");
+        yaml.push_str(&format!("a{level}: &a{level} [{refs}]\n"));
+    }
+    yaml.push_str(&format!("boom: [{}]\n", ["*a9"; 9].join(",")));
+    assert!(
+        YamlLintConfig::from_yaml_str(&yaml).is_err(),
+        "alias expansion must be capped and reported, not exhaust memory"
+    );
+}
+
+#[test]
+fn rich_valid_config_lints_without_panicking() {
+    let yaml = "ignore:\n  - \"vendor/**\"\nlocale: \"en_US.UTF-8\"\nrules:\n  \
+                key-ordering:\n    level: error\n    ignored-keys: [\"^ok$\"]\n  \
+                quoted-strings:\n    required: false\n  trailing-spaces: enable\n";
+    let cfg = lint_with(yaml);
+    assert!(
+        cfg.is_some(),
+        "a well-formed config must parse and lint cleanly"
+    );
+}

--- a/tests/property_config.rs
+++ b/tests/property_config.rs
@@ -9,8 +9,12 @@
 //! succeeds but never panics**:
 //!
 //! - YAML configs are parsed with [`YamlLintConfig::from_yaml_str`] and, when they
-//!   parse, used to lint sample documents — driving the `.expect()` calls in the
-//!   regex-bearing rules' `resolve()` (`key-ordering`, `quoted-strings`).
+//!   parse, used to lint sample documents. Config validation rejects hostile option
+//!   values (invalid regexes, wrong types) before a rule's `resolve()` runs, so the
+//!   `.expect()` calls in `key-ordering`/`quoted-strings` `resolve()` are not
+//!   reachable from a config that parses — the value here is the guard against a
+//!   future *validation gap*: were one introduced, a generated config would carry a
+//!   bad value into `resolve()` and panic the property.
 //! - TOML configs are pushed through `parse -> validate -> normalize`, the
 //!   TOML-specific surface.
 //!

--- a/tests/property_config/strategy.rs
+++ b/tests/property_config/strategy.rs
@@ -1,0 +1,239 @@
+//! Strategy for `property_config`: generate plausible-but-sometimes-invalid ryl
+//! configurations and render them to YAML and TOML.
+//!
+//! Option values are drawn from curated pools that deliberately mix the valid with
+//! the hostile — invalid regexes (`(`, `(a+)+$`), out-of-range and wrong-typed
+//! scalars, bogus locales — so the parse -> validate -> rule-`resolve()` pipeline is
+//! exercised with inputs that must produce an error or a clean config, never a
+//! panic. The regex-bearing rules (`key-ordering`, `quoted-strings`) are generated
+//! with their real option keys so generation reaches the `.expect()` calls in their
+//! `resolve()` paths rather than bouncing off `deny_unknown_fields` at parse time.
+
+use proptest::prelude::*;
+
+/// A single option value, renderable to both YAML and TOML scalar/array syntax. The
+/// string pools never contain quotes, backslashes, or newlines, so naive quoting is
+/// valid in both formats.
+#[derive(Debug, Clone)]
+pub enum OptVal {
+    Bool(bool),
+    Int(i64),
+    Str(&'static str),
+    List(Vec<&'static str>),
+}
+
+#[derive(Debug, Clone)]
+pub enum Setting {
+    Disable,
+    Enable,
+    Leveled {
+        level: &'static str,
+        options: Vec<(&'static str, OptVal)>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct RuleCfg {
+    pub id: &'static str,
+    pub setting: Setting,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigModel {
+    pub rules: Vec<RuleCfg>,
+    pub ignore: Option<Vec<&'static str>>,
+    pub locale: Option<&'static str>,
+}
+
+/// Regex strings spanning valid, invalid, and pathological-but-valid (the last to
+/// confirm the linear `regex` engine, not catastrophic backtracking).
+const REGEX_POOL: &[&str] = &["^ok$", "(", "[", "(a+)+$", ".*", "[0-9]+"];
+const LEVELS: &[&str] = &["error", "warning", "bogus"];
+const LOCALES: &[&str] = &["en_US.UTF-8", "C", "garbage", "xx_XX"];
+const INTS: &[i64] = &[-1, 0, 1, 2, 80, 9999];
+
+/// What kind of value an option accepts; `arb` yields both well-typed and
+/// deliberately ill-typed values so validation is stressed.
+#[derive(Debug, Clone, Copy)]
+pub enum OptValKind {
+    Bool,
+    Int,
+    RegexList,
+    StrEnum(&'static [&'static str]),
+}
+
+impl OptValKind {
+    fn arb(self) -> BoxedStrategy<OptVal> {
+        match self {
+            Self::Bool => any::<bool>().prop_map(OptVal::Bool).boxed(),
+            Self::Int => prop::sample::select(INTS).prop_map(OptVal::Int).boxed(),
+            Self::RegexList => {
+                prop::collection::vec(prop::sample::select(REGEX_POOL), 0..3)
+                    .prop_map(OptVal::List)
+                    .boxed()
+            }
+            Self::StrEnum(choices) => {
+                prop::sample::select(choices).prop_map(OptVal::Str).boxed()
+            }
+        }
+    }
+}
+
+/// Rules paired with a couple of their real option keys and the value kinds those
+/// keys accept. Keeping keys real lets generation reach each rule's `resolve()`.
+const CATALOG: &[(&str, &[(&str, OptValKind)])] = &[
+    ("key-ordering", &[("ignored-keys", OptValKind::RegexList)]),
+    (
+        "quoted-strings",
+        &[
+            ("extra-required", OptValKind::RegexList),
+            ("extra-allowed", OptValKind::RegexList),
+            (
+                "quote-type",
+                OptValKind::StrEnum(&["single", "double", "any", "bogus"]),
+            ),
+        ],
+    ),
+    (
+        "line-length",
+        &[
+            ("max", OptValKind::Int),
+            ("allow-non-breakable-words", OptValKind::Bool),
+        ],
+    ),
+    ("comments", &[("min-spaces-from-content", OptValKind::Int)]),
+    ("braces", &[("max-spaces-inside", OptValKind::Int)]),
+    ("truthy", &[("check-keys", OptValKind::Bool)]),
+    ("anchors", &[("forbid-unused-anchors", OptValKind::Bool)]),
+    ("document-start", &[("present", OptValKind::Bool)]),
+    ("trailing-spaces", &[]),
+    (
+        "octal-values",
+        &[("forbid-implicit-octal", OptValKind::Bool)],
+    ),
+];
+
+fn arb_rule() -> impl Strategy<Value = RuleCfg> {
+    prop::sample::select(CATALOG).prop_flat_map(|(id, opts)| {
+        let options: BoxedStrategy<Vec<(&'static str, OptVal)>> = if opts.is_empty() {
+            Just(Vec::new()).boxed()
+        } else {
+            prop::collection::vec(
+                prop::sample::select(opts.to_vec())
+                    .prop_flat_map(|(key, kind)| arb_optval_for(key, kind)),
+                0..=opts.len(),
+            )
+            .boxed()
+        };
+        prop_oneof![
+            Just(Setting::Disable),
+            Just(Setting::Enable),
+            (prop::sample::select(LEVELS), options)
+                .prop_map(|(level, options)| Setting::Leveled { level, options }),
+        ]
+        .prop_map(move |setting| RuleCfg { id, setting })
+    })
+}
+
+fn arb_optval_for(
+    key: &'static str,
+    kind: OptValKind,
+) -> impl Strategy<Value = (&'static str, OptVal)> {
+    kind.arb().prop_map(move |value| (key, value))
+}
+
+pub fn arb_config() -> impl Strategy<Value = ConfigModel> {
+    (
+        prop::collection::vec(arb_rule(), 0..6),
+        prop::option::of(prop::collection::vec(
+            prop::sample::select(&["vendor/**", "*.gen.yaml", "[", ""][..]),
+            0..3,
+        )),
+        prop::option::of(prop::sample::select(LOCALES)),
+    )
+        .prop_map(|(rules, ignore, locale)| ConfigModel {
+            rules,
+            ignore: ignore.map(|patterns| patterns.into_iter().collect()),
+            locale,
+        })
+}
+
+fn render_optval_yaml(value: &OptVal) -> String {
+    match value {
+        OptVal::Bool(b) => b.to_string(),
+        OptVal::Int(i) => i.to_string(),
+        OptVal::Str(s) => format!("\"{s}\""),
+        OptVal::List(items) => {
+            let inner: Vec<String> = items.iter().map(|s| format!("\"{s}\"")).collect();
+            format!("[{}]", inner.join(", "))
+        }
+    }
+}
+
+fn render_optval_toml(value: &OptVal) -> String {
+    // Same shapes as YAML for these pools; booleans/ints/strings/arrays render
+    // identically in TOML scalar syntax.
+    render_optval_yaml(value)
+}
+
+pub fn render_yaml(model: &ConfigModel) -> String {
+    let mut out = String::new();
+    if let Some(patterns) = &model.ignore {
+        out.push_str("ignore:\n");
+        for pattern in patterns {
+            out.push_str(&format!("  - \"{pattern}\"\n"));
+        }
+    }
+    if let Some(locale) = model.locale {
+        out.push_str(&format!("locale: \"{locale}\"\n"));
+    }
+    out.push_str("rules:\n");
+    for rule in &model.rules {
+        match &rule.setting {
+            Setting::Disable => out.push_str(&format!("  {}: disable\n", rule.id)),
+            Setting::Enable => out.push_str(&format!("  {}: enable\n", rule.id)),
+            Setting::Leveled { level, options } => {
+                out.push_str(&format!("  {}:\n", rule.id));
+                out.push_str(&format!("    level: \"{level}\"\n"));
+                for (key, value) in options {
+                    out.push_str(&format!(
+                        "    {key}: {}\n",
+                        render_optval_yaml(value)
+                    ));
+                }
+            }
+        }
+    }
+    out
+}
+
+pub fn render_toml(model: &ConfigModel) -> String {
+    let mut out = String::new();
+    if let Some(patterns) = &model.ignore {
+        let inner: Vec<String> = patterns.iter().map(|p| format!("\"{p}\"")).collect();
+        out.push_str(&format!("ignore = [{}]\n", inner.join(", ")));
+    }
+    if let Some(locale) = model.locale {
+        out.push_str(&format!("locale = \"{locale}\"\n"));
+    }
+    // Scalar toggles belong under the inline [rules] table; leveled rules each get
+    // their own [rules.<id>] table emitted afterwards so TOML stays well-formed.
+    out.push_str("[rules]\n");
+    for rule in &model.rules {
+        match &rule.setting {
+            Setting::Disable => out.push_str(&format!("{} = \"disable\"\n", rule.id)),
+            Setting::Enable => out.push_str(&format!("{} = \"enable\"\n", rule.id)),
+            Setting::Leveled { .. } => {}
+        }
+    }
+    for rule in &model.rules {
+        if let Setting::Leveled { level, options } = &rule.setting {
+            out.push_str(&format!("[rules.{}]\n", rule.id));
+            out.push_str(&format!("level = \"{level}\"\n"));
+            for (key, value) in options {
+                out.push_str(&format!("{key} = {}\n", render_optval_toml(value)));
+            }
+        }
+    }
+    out
+}

--- a/tests/property_config/strategy.rs
+++ b/tests/property_config/strategy.rs
@@ -152,10 +152,26 @@ pub fn arb_config() -> impl Strategy<Value = ConfigModel> {
         prop::option::of(prop::sample::select(LOCALES)),
     )
         .prop_map(|(rules, ignore, locale)| ConfigModel {
-            rules,
+            // Drop duplicate rule ids: rendering the same id twice produces a
+            // duplicate `[rules.<id>]` table (a hard TOML error) or a duplicate YAML
+            // key, which would bounce a chunk of generated configs off the parser
+            // before they reach validation/normalisation/linting.
+            rules: dedup_rules(rules),
             ignore: ignore.map(|patterns| patterns.into_iter().collect()),
             locale,
         })
+}
+
+fn dedup_rules(rules: Vec<RuleCfg>) -> Vec<RuleCfg> {
+    let mut seen: Vec<&'static str> = Vec::new();
+    let mut deduped = Vec::new();
+    for rule in rules {
+        if !seen.contains(&rule.id) {
+            seen.push(rule.id);
+            deduped.push(rule);
+        }
+    }
+    deduped
 }
 
 fn render_optval_yaml(value: &OptVal) -> String {

--- a/tests/yaml_dom.rs
+++ b/tests/yaml_dom.rs
@@ -105,6 +105,12 @@ fn resolves_core_schema_int_tag() {
         doc.as_mapping_get("v").and_then(YamlOwned::as_integer),
         Some(42)
     );
+    assert!(
+        doc.as_mapping_get("v")
+            .and_then(YamlOwned::as_floating_point)
+            .is_none(),
+        "an integer scalar must not be coerced into a float",
+    );
 }
 
 #[test]

--- a/tests/yamllint_compat_colons.rs
+++ b/tests/yamllint_compat_colons.rs
@@ -263,7 +263,14 @@ fn inline_comment_after_value_matches_yamllint() {
     let dir = tempdir().unwrap();
 
     let cfg_path = dir.path().join("colons.yaml");
-    fs::write(&cfg_path, "rules:\n  document-start: disable\n").unwrap();
+    // key-duplicates (enabled, never firing on this input) keeps the config from
+    // resolving to zero rules, which ryl rejects; both tools run the same config so
+    // the differential is unchanged.
+    fs::write(
+        &cfg_path,
+        "rules:\n  document-start: disable\n  key-duplicates: enable\n",
+    )
+    .unwrap();
 
     let yaml_path = dir.path().join("inline.yaml");
     fs::write(

--- a/tests/yamllint_compat_syntax.rs
+++ b/tests/yamllint_compat_syntax.rs
@@ -55,8 +55,15 @@ fn yamllint_exit_behavior_matches_for_syntax_only() {
     let ok = write_file(dir.path(), "ok.yaml", "a: 1\n");
     let bad = write_file(dir.path(), "bad.yaml", "a: [1, 2\n");
 
-    // Disable yamllint rules so we only compare syntax behavior.
-    let cfg = write_file(dir.path(), ".yamllint.yml", "rules: {}\n");
+    // Enable one rule that never fires on these inputs so we effectively compare
+    // syntax behavior only. (A truly rule-less config is rejected by ryl, which is
+    // stricter than yamllint here; both tools run the same single-rule config so the
+    // differential is unaffected.)
+    let cfg = write_file(
+        dir.path(),
+        ".yamllint.yml",
+        "rules:\n  key-duplicates: enable\n",
+    );
 
     let ryl = env!("CARGO_BIN_EXE_ryl");
 

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #246.

Audits ryl for robustness to malicious YAML/config payloads and fixes every
exploitable issue found, plus the write-to-unintended-location concern. All changes
are confined to lint/config handling and output; the crate stays
`#![forbid(unsafe_code)]`, and CI's zero-missed-region coverage gate is green.

## Vulnerabilities fixed

| # | Class | Vector | Fix |
| --- | --- | --- | --- |
| 1 | Billion-laughs DoS (OOM) | alias-bomb in a YAML config (`-c`/`-d`/discovered `.yamllint`) — 472 bytes → ~3.5B nodes, 14.7 GB | cap alias expansion in `yaml_dom::loader` (`MAX_EXPANDED_NODES`); rejected at 0.2 s / 135 MB. The lint path was already immune (no DOM built) — guarded by a test. |
| 2 | Write-to-unintended-file | `--fix` follows symlinks → an untrusted tree's `innocent.yaml -> ~/.bashrc` gets rewritten | `fix::refuse_symlink` skips symlinked inputs (still linted); write target is always the input path |
| 3 | Crash (panic) | empty / comment-only config → `docs[0]` panic | graceful "invalid config: not a mapping" / "configuration is empty" |
| 4 | Lockup (O(n²)) | a Markdown file with many embedded YAML blocks (~300 KB → 24 s) | line offsets via binary search over precomputed newline positions → linear |
| 5 | Crash (stack overflow) | cyclic `extends` (`a → b → a`) | depth guard (`MAX_EXTENDS_DEPTH`) → clean error |
| 6 | CI command injection | a crafted key/anchor/filename in the GitHub Actions output (`::error::`, `::group::`, `file=`) | escape per `@actions/core` (data + property), single pass, control-char-safe |
| 7 | Terminal-escape injection | control chars in keys/values/paths in standard/colored/parsable output | `sanitize_control` on every user-controlled output sink (messages, errors, notices, `--list-files`, migration paths) |

## Notable behavior changes (intentionally stricter than yamllint)

- **A config that enables zero rules is now an error** (exit 2) — e.g. `rules: {}`,
  an empty `[rules]`/`[tool.ryl]`, a `[files]`-only TOML config, or one that
  disables everything. Such a config would silently lint nothing; ryl rejects it
  loudly. yamllint accepts it and exits 0. This is the explicit-enable model
  (a rule runs only if a config enables it). `--list-files` and `--migrate-configs`
  are exempt; the no-config path still uses the default preset (see follow-up below).
- **An unknown / misspelled rule name is now rejected** (exit 2,
  `invalid config: no such rule: "<name>"`), for both YAML and TOML configs. ryl
  does not support custom/unrecognised rules (matching yamllint) — `lint_str` never
  dispatches them, so a typo like `tariling-spaces` would otherwise silently lint
  nothing (and could even slip past the zero-rules guard above). This also closes the
  Codex P2 finding on the empty-config guard at its root. Side effect: an unknown rule
  with a malformed `ignore`/`ignore-from-file` option now reports `no such rule`
  rather than an option-specific message, which let me delete the now-dead custom-rule
  option-validation and value-conversion plumbing (net code reduction).
- These are the only divergences from yamllint; whenever a config that enables rules
  is used, ryl resolves and lints identically.

## Probed and cleared (no action needed)

Deep nesting (granit caps recursion ~256), huge scalars/files (linear throughput,
not amplification), ReDoS via config regexes (validated at parse time; the `regex`
crate is linear-time), recursive/self anchors (resolve to `BadValue`), merge-key
alias bombs (covered by the alias cap), and content-driven `--fix` path traversal
(impossible — the write target is never derived from content).

## Tests

New CLI/property regression suites: `cli_alias_bomb` (config bomb rejected + lint
path immune), `cli_fix_symlink` (explicit/dir-walk/markdown + warning sanitized),
`cli_format_options` (GitHub + terminal escaping), `cli_markdown_embed` (linear
many-block mapping), `config_extends_inline` (cyclic extends), and a randomized
`property_config` suite asserting config parse/lint never panics. Unknown-rule
rejection is covered by `config_rule_level` (YAML + TOML, including an unknown rule
whose option values still flow through scalar conversion). prek clean, coverage
reports no uncovered regions.

## Docs / policy

- `SECURITY.md` added: private reporting via GitHub Private Vulnerability Reporting,
  best-effort/no-SLA wording (unpaid project), threat-model scope, coordinated
  disclosure. Private Vulnerability Reporting is enabled in repo settings, so the
  "Report a vulnerability" button it points to works.
- `AGENTS.md` + `docs/getting-started/quickstart.md` updated for the new behaviors.

## Follow-up

- #248 — drop the auto-applied `default` preset on the no-config path (extend the
  explicit-enable model so no-config also errors). Deliberately scoped as a separate
  config-model change, not part of this security PR.

## Review notes

The fixes were reviewed adversarially (a high-effort internal pass) and iterated
through several rounds of an independent Codex review to convergence (latest review:
no major issues). Findings with merit were actioned — notably the zero-rules error,
an additional unsanitized `--fix` warning sink, and rejecting unknown rule names at
config resolution (root-cause fix for the empty-config-guard finding).
