### PR TITLE
Require explicit rule enablement; drop auto-applied default preset (closes #248)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,11 +480,23 @@ sticking to the quick-status step above.
   Markdown. Match yamllint's semantics exactly (validate with
   `tests/yamllint_compat_directives.rs`); the bare rule ids live in
   `rules::ALL_RULE_IDS`. User docs: `docs/directives.md`.
-- A resolved config that enables no rules would lint nothing while exiting 0, so the
-  lint commands reject it loudly (`main::NO_RULES_ENABLED_ERROR`, exit 2) via
-  `YamlLintConfig::enables_any_rule`. This is intentionally stricter than yamllint
-  (which silently accepts a rule-less config) and fires only on an explicit/discovered
-  config that turns everything off — the no-config path uses the default preset, which
-  enables rules. `--migrate-configs` (converts configs, does not lint) and
+- ryl never enables a rule that wasn't explicitly turned on — there are no
+  "default-on" rules. Two cases converge on this, both rejected loudly by the lint
+  commands (exit 2) and both intentionally stricter than yamllint:
+  - **No config found anywhere** (no `-c`/`-d`, no `YAMLLINT_CONFIG_FILE`, no
+    discovered project/user-global config): resolution falls back to an *empty*
+    config (`config::ConfigContext::config_found == false`) rather than the `default`
+    preset, and the lint paths report `main::NO_CONFIG_ERROR`. yamllint instead lints
+    with `extends: default`.
+  - **A resolved config that enables no rules** (`rules: {}`, an empty
+    `[rules]`/`[tool.ryl]`, a `[files]`-only TOML config, or one disabling
+    everything): reported as `main::NO_RULES_ENABLED_ERROR`. yamllint silently lints
+    nothing.
+  Both checks live in the lint entrypoints via `YamlLintConfig::enables_any_rule`;
+  `main::no_rules_error(config_found)` picks the message. `config_found` flows from
+  `ConfigContext` through `resolve_ctx`/`gather_lint_files` (run-level) and
+  `resolve_stdin_ctx`. The `default`/`relaxed`/`empty` presets stay available as
+  explicit opt-ins via `extends:` (YAML config only). `--migrate-configs` (converts
+  configs, does not lint — it warns when a migrated config enables no rules) and
   `--list-files` (a file query) are exempt; only the actual lint paths enforce it.
 - Exit codes: `0` (ok/none), `1` (invalid YAML), `2` (usage error).

--- a/README.md
+++ b/README.md
@@ -24,12 +24,17 @@ Full documentation lives at <https://ryl-docs.pages.dev/>.
 
 ## Quick start
 
+ryl enables no rules by default, so it needs a configuration that turns rules on.
+`-d 'extends: default'` opts into yamllint's standard rule set for a one-off run;
+for a project, drop a `.ryl.toml` at the root (see
+[Configuration](https://ryl-docs.pages.dev/getting-started/quickstart/)).
+
 ```bash
 # Using uv (Python)
-uvx ryl .
+uvx ryl -d 'extends: default' .
 
 # Using npx (Node.js)
-npx @owenlamont/ryl .
+npx @owenlamont/ryl -d 'extends: default' .
 ```
 
 For `prek` / `pre-commit` integration, see

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -62,6 +62,17 @@ produced.
   working. The equivalent `# ryl …` spelling is preferred for new files; see
   [Inline directives](../directives.md).
 
+## What differs
+
+ryl never enables a rule unless a configuration explicitly turns it on. yamllint,
+run with no configuration, lints with its `default` preset; ryl instead exits `2`
+with `no configuration found`. The presets stay available as explicit opt-ins, so
+the one-line equivalent of yamllint's out-of-the-box behaviour is a YAML config
+containing `extends: default` (or the corresponding TOML preset from
+[Configuration presets](../config-presets.md)). The migration converter flattens an
+`extends: default` source into the generated TOML automatically, and warns when a
+migrated config ends up enabling no rules.
+
 ## Side-by-side example
 
 === "yamllint (.yamllint)"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,6 +12,17 @@ ryl path/to/file.yaml
 ryl .
 ```
 
+ryl does not enable any rules by default, so these commands report `no
+configuration found` (exit `2`) until a configuration enables at least one rule.
+To lint with yamllint's standard rule set straight away, pass it inline:
+
+```bash
+ryl -d 'extends: default' .
+```
+
+or drop a config in your project (see [Configure for your
+project](#configure-for-your-project) below).
+
 ## Lint from stdin
 
 Pass `-` as the input to read YAML from standard input &mdash; useful for
@@ -39,10 +50,19 @@ Exit codes:
 - `2` &mdash; CLI usage error (no inputs provided, bad flags), or
   `--strict` was set and only warnings were produced.
 
-A configuration that enables no rules would lint nothing, so ryl rejects it with
-exit `2` rather than silently passing. Enable at least one rule, or remove the
-configuration to fall back to the default rule set. (This is stricter than yamllint,
-which silently accepts a rule-less config.)
+ryl never enables a rule unless a configuration explicitly turns it on, so two
+cases exit `2` rather than silently linting nothing:
+
+- **No configuration found** anywhere (no `-c`/`-d`, no `YAMLLINT_CONFIG_FILE`, no
+  discovered `.ryl.toml`/`.yamllint`). Create a config that enables rules, or pass a
+  YAML config with `extends: default` for yamllint's standard rule set.
+- **A configuration that enables no rules** (`rules: {}`, an empty
+  `[rules]`/`[tool.ryl]`, or one disabling everything). Enable at least one rule, or
+  use `extends: default`.
+
+This is stricter than yamllint, which lints with the `default` preset when no config
+is found and silently accepts a rule-less config. Give ryl a config containing
+`extends: default` to reproduce yamllint's out-of-the-box behaviour.
 
 ## Apply auto-fixes
 

--- a/src/cli_support.rs
+++ b/src/cli_support.rs
@@ -42,27 +42,32 @@ pub fn resolve_ctx<S: BuildHasher>(
     path: &Path,
     global_cfg: Option<&ConfigContext>,
     markdown: bool,
-    cache: &mut HashMap<PathBuf, (PathBuf, YamlLintConfig), S>,
-) -> Result<(PathBuf, YamlLintConfig, Vec<String>), String> {
+    cache: &mut HashMap<PathBuf, (PathBuf, YamlLintConfig, bool), S>,
+) -> Result<(PathBuf, YamlLintConfig, Vec<String>, bool), String> {
     // The global config is markdown-enabled once by the caller, so per-file clones
     // here inherit the built matcher; only freshly-discovered configs need enabling
     // (done before caching, so the matcher is built once per directory).
     if let Some(gc) = global_cfg {
-        return Ok((gc.base_dir.clone(), gc.config.clone(), Vec::new()));
+        return Ok((
+            gc.base_dir.clone(),
+            gc.config.clone(),
+            Vec::new(),
+            gc.config_found,
+        ));
     }
     let start = path
         .parent()
         .map_or_else(|| PathBuf::from("."), PathBuf::from);
-    if let Some(pair) = cache.get(&start).cloned() {
-        return Ok((pair.0, pair.1, Vec::new()));
+    if let Some(entry) = cache.get(&start).cloned() {
+        return Ok((entry.0, entry.1, Vec::new(), entry.2));
     }
     let ctx = discover_per_file(path)?;
     let mut cfg = ctx.config;
     if markdown {
         cfg.enable_default_markdown(&ctx.base_dir);
     }
-    let pair = (ctx.base_dir.clone(), cfg);
+    let entry = (ctx.base_dir.clone(), cfg, ctx.config_found);
     let notices = ctx.notices;
-    cache.insert(start, pair.clone());
-    Ok((pair.0, pair.1, notices))
+    cache.insert(start, entry.clone());
+    Ok((entry.0, entry.1, notices, entry.2))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1157,6 +1157,12 @@ pub struct ConfigContext {
     pub base_dir: PathBuf,
     pub source: Option<PathBuf>,
     pub notices: Vec<String>,
+    /// Whether an actual configuration source was used (inline data, a config file,
+    /// a discovered project/user-global config, or an env-var config). `false` only
+    /// when nothing was found and resolution fell back to an empty config, which lets
+    /// the lint CLI distinguish "no configuration found" from "a configuration that
+    /// enables no rules".
+    pub config_found: bool,
 }
 
 fn finalize_context(
@@ -1165,6 +1171,7 @@ fn finalize_context(
     base_dir: impl Into<PathBuf>,
     source: Option<PathBuf>,
     notices: Vec<String>,
+    config_found: bool,
 ) -> Result<ConfigContext, String> {
     let base_dir = base_dir.into();
     cfg.finalize(envx, &base_dir)?;
@@ -1173,6 +1180,7 @@ fn finalize_context(
         base_dir,
         source,
         notices,
+        config_found,
     })
 }
 
@@ -1194,7 +1202,8 @@ pub fn discover_config(
 /// Returns an error when a configuration file cannot be read or parsed.
 ///
 /// # Panics
-/// Panics only if built-in preset YAML cannot be parsed, which indicates a programming error.
+/// Panics only if a built-in preset referenced via `extends:` cannot be parsed,
+/// which indicates a programming error.
 pub fn discover_config_with(
     inputs: &[PathBuf],
     overrides: &Overrides,
@@ -1205,7 +1214,7 @@ pub fn discover_config_with(
         let base_dir = envx.current_dir();
         let cfg =
             YamlLintConfig::from_yaml_str_with_env(data, Some(envx), Some(&base_dir))?;
-        return finalize_context(envx, cfg, base_dir, None, Vec::new());
+        return finalize_context(envx, cfg, base_dir, None, Vec::new(), true);
     }
     if let Some(ref file) = overrides.config_file {
         return ctx_from_config_path_core(envx, file, false, Vec::new());
@@ -1227,11 +1236,11 @@ pub fn discover_config_with(
         move || {
             finalize_context(
                 envx,
-                YamlLintConfig::from_yaml_str(conf::builtin("default").unwrap())
-                    .expect("builtin preset must parse"),
+                YamlLintConfig::default(),
                 cwd,
                 None,
                 Vec::new(),
+                false,
             )
         },
         Ok,
@@ -1244,7 +1253,8 @@ pub fn discover_config_with(
 /// Returns an error when a config file cannot be read or parsed.
 ///
 /// # Panics
-/// Panics only if the built-in default preset is not embedded (programming error).
+/// Panics only if a built-in preset referenced via `extends:` cannot be parsed
+/// (a programming error).
 pub fn discover_config_with_env(
     inputs: &[PathBuf],
     overrides: &Overrides,
@@ -1255,7 +1265,7 @@ pub fn discover_config_with_env(
 
 /// Discover the config for a single file path, ignoring env/global overrides.
 /// Precedence: nearest project config up-tree (TOML-first, YAML fallback),
-/// then user-global, then defaults.
+/// then user-global, then an empty config (no rules enabled).
 ///
 /// # Errors
 /// Returns an error when a config file cannot be read or parsed.
@@ -1265,7 +1275,8 @@ pub fn discover_config_with_env(
 /// Returns an error when a config file cannot be read or parsed.
 ///
 /// # Panics
-/// Panics only if the built-in default preset is not embedded (programming error).
+/// Panics only if a built-in preset referenced via `extends:` cannot be parsed
+/// (a programming error).
 pub fn discover_per_file(path: &Path) -> Result<ConfigContext, String> {
     discover_per_file_with(path, &SystemEnv)
 }
@@ -1276,7 +1287,8 @@ pub fn discover_per_file(path: &Path) -> Result<ConfigContext, String> {
 /// Returns an error when a configuration file cannot be read or parsed.
 ///
 /// # Panics
-/// Panics only if the built-in default preset cannot be parsed.
+/// Panics only if a built-in preset referenced via `extends:` cannot be parsed
+/// (a programming error).
 pub fn discover_per_file_with(
     path: &Path,
     envx: &dyn Env,
@@ -1300,11 +1312,11 @@ pub fn discover_per_file_with(
         || {
             finalize_context(
                 envx,
-                YamlLintConfig::from_yaml_str(conf::builtin("default").unwrap())
-                    .expect("builtin preset must parse"),
+                YamlLintConfig::default(),
                 envx.current_dir(),
                 None,
                 Vec::new(),
+                false,
             )
         },
         Ok,
@@ -1323,7 +1335,7 @@ fn ctx_from_config_path_core(
         .map_or_else(|| envx.current_dir(), Path::to_path_buf);
     let cfg = load_config_from_path_core(envx, p, &base, allow_missing_pyproject)?
         .expect("missing [tool.ryl] should be filtered or returned as an error before this point");
-    finalize_context(envx, cfg, base, Some(p.to_path_buf()), notices)
+    finalize_context(envx, cfg, base, Some(p.to_path_buf()), notices, true)
 }
 
 fn expand_user_path(envx: &dyn Env, raw: &str) -> PathBuf {
@@ -1360,7 +1372,14 @@ fn try_user_global_core(
                 Some(envx),
                 Some(base_dir),
             )?;
-            finalize_context(envx, cfg, base_dir.to_path_buf(), Some(p), Vec::new())
+            finalize_context(
+                envx,
+                cfg,
+                base_dir.to_path_buf(),
+                Some(p),
+                Vec::new(),
+                true,
+            )
         })
         .transpose()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,21 @@ const STDIN_LABEL: &str = "<stdin>";
 // convert a rule-less config, and `--list-files` still answers its file query). ryl
 // is deliberately stricter than yamllint here, which accepts a rule-less config.
 const NO_RULES_ENABLED_ERROR: &str = "error: configuration enables no rules, so nothing would be linted; enable at \
-     least one rule, or remove the configuration to use the default rule set";
+     least one rule, or use 'extends: default' for the standard rule set";
+
+const NO_CONFIG_ERROR: &str = "error: no configuration found and ryl enables no rules by default; create a \
+     config that enables rules, or use 'extends: default' for the standard rule set";
+
+/// Pick the error for a config that would lint nothing: distinguish "no
+/// configuration was found anywhere" from "a configuration was provided/discovered
+/// but enables no rules". Both name `extends: default` as the escape hatch.
+fn no_rules_error(config_found: bool) -> String {
+    if config_found {
+        NO_RULES_ENABLED_ERROR.to_string()
+    } else {
+        NO_CONFIG_ERROR.to_string()
+    }
+}
 
 fn gather_inputs(inputs: &[PathBuf]) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let mut explicit_files = Vec::new();
@@ -409,10 +423,10 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
     let (candidates, explicit_files) = gather_inputs(&inputs);
 
     // Filter directory candidates via ignores, respecting global vs per-file behavior.
-    let mut cache: HashMap<PathBuf, (PathBuf, YamlLintConfig)> = HashMap::new();
+    let mut cache: HashMap<PathBuf, (PathBuf, YamlLintConfig, bool)> = HashMap::new();
     let mut emitted_notices: HashSet<String> = HashSet::new();
     let mut files: Vec<(PathBuf, PathBuf, YamlLintConfig, SourceKind)> = Vec::new();
-    gather_lint_files(
+    let ruleless_config_found = gather_lint_files(
         &candidates,
         &explicit_files,
         global_cfg.as_ref(),
@@ -433,8 +447,8 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    if files.iter().any(|(_, _, cfg, _)| !cfg.enables_any_rule()) {
-        return Err(NO_RULES_ENABLED_ERROR.to_string());
+    if let Some(config_found) = ruleless_config_found {
+        return Err(no_rules_error(config_found));
     }
 
     let mut initial_problem_count = 0usize;
@@ -481,7 +495,7 @@ fn summary_to_exit(summary: &LintSummary, strict: bool) -> ExitCode {
 }
 
 fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
-    let (path, base_dir, cfg, apply_yaml_files) = resolve_stdin_ctx(cli)?;
+    let (path, base_dir, cfg, apply_yaml_files, config_found) = resolve_stdin_ctx(cli)?;
 
     let Some(kind) = resolve_stdin_kind(cli, &cfg, &path, &base_dir, apply_yaml_files)?
     else {
@@ -494,7 +508,7 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     }
 
     if !cfg.enables_any_rule() {
-        return Err(NO_RULES_ENABLED_ERROR.to_string());
+        return Err(no_rules_error(config_found));
     }
 
     let outcome = read_and_lint_stdin(&path, &base_dir, &cfg, kind);
@@ -564,7 +578,7 @@ fn read_and_lint_stdin(
 
 fn resolve_stdin_ctx(
     cli: &Cli,
-) -> Result<(PathBuf, PathBuf, YamlLintConfig, bool), String> {
+) -> Result<(PathBuf, PathBuf, YamlLintConfig, bool, bool), String> {
     let (path, apply_yaml_files) = match cli.stdin_filename.clone() {
         Some(name) => (name, true),
         None => (PathBuf::from(STDIN_LABEL), false),
@@ -585,7 +599,7 @@ fn resolve_stdin_ctx(
     if !apply_yaml_files {
         cfg.disable_path_based_rule_ignores();
     }
-    Ok((path, ctx.base_dir, cfg, apply_yaml_files))
+    Ok((path, ctx.base_dir, cfg, apply_yaml_files, ctx.config_found))
 }
 
 fn lint_files(
@@ -612,12 +626,18 @@ fn gather_lint_files(
     explicit_files: &[PathBuf],
     global_cfg: Option<&ConfigContext>,
     markdown: bool,
-    cache: &mut HashMap<PathBuf, (PathBuf, YamlLintConfig)>,
+    cache: &mut HashMap<PathBuf, (PathBuf, YamlLintConfig, bool)>,
     emitted_notices: &mut HashSet<String>,
     files: &mut Vec<(PathBuf, PathBuf, YamlLintConfig, SourceKind)>,
-) -> Result<(), String> {
+) -> Result<Option<bool>, String> {
+    // `config_found` of the first selected file that enables no rules, so a run that
+    // would lint nothing reports the right message *for that file* — "no config
+    // found" vs "config enables no rules" — even when other files did find a config.
+    // `None` means every selected file enables at least one rule.
+    let mut ruleless_config_found = None;
     for f in candidates {
-        let (base_dir, cfg, notices) = resolve_ctx(f, global_cfg, markdown, cache)?;
+        let (base_dir, cfg, notices, found) =
+            resolve_ctx(f, global_cfg, markdown, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
                 eprintln!("{}", sanitize_control(notice.as_str()));
@@ -627,12 +647,16 @@ fn gather_lint_files(
             continue;
         }
         if let Some(kind) = cfg.source_kind(f, &base_dir)? {
+            if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
+                ruleless_config_found = Some(found);
+            }
             files.push((f.clone(), base_dir, cfg, kind));
         }
     }
 
     for ef in explicit_files {
-        let (base_dir, cfg, notices) = resolve_ctx(ef, global_cfg, markdown, cache)?;
+        let (base_dir, cfg, notices, found) =
+            resolve_ctx(ef, global_cfg, markdown, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
                 eprintln!("{}", sanitize_control(notice.as_str()));
@@ -642,7 +666,12 @@ fn gather_lint_files(
             continue;
         }
         match cfg.source_kind(ef, &base_dir)? {
-            Some(kind) => files.push((ef.clone(), base_dir, cfg, kind)),
+            Some(kind) => {
+                if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
+                    ruleless_config_found = Some(found);
+                }
+                files.push((ef.clone(), base_dir, cfg, kind));
+            }
             None => {
                 return Err(format!(
                     "{}: no source kind matches; add a matching glob under \
@@ -653,7 +682,7 @@ fn gather_lint_files(
         }
     }
 
-    Ok(())
+    Ok(ruleless_config_found)
 }
 
 fn process_results(

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -192,6 +192,13 @@ fn build_migration_entries(root: &Path) -> Result<MigrationPlan, String> {
                 config_data: None,
             },
         )?;
+        if !ctx.config.enables_any_rule() {
+            plan.warnings.push(format!(
+                "warning: migrated config {} enables no rules; ryl will not lint with it \
+                 \u{2014} enable at least one rule, or use 'extends: default' for the standard rule set",
+                dir.join(".ryl.toml").display()
+            ));
+        }
         let rendered = ctx.config.to_toml_string();
         let toml = format!("{}\n", rendered.trim_end());
         plan.entries.push(MigrationEntry {

--- a/tests/cli_alias_bomb.rs
+++ b/tests/cli_alias_bomb.rs
@@ -63,7 +63,10 @@ fn linting_alias_bomb_file_does_not_expand_aliases() {
     fs::write(&target, alias_bomb()).unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, _out, err) = run(Command::new(exe).arg(&target));
+    let (code, _out, err) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  key-duplicates: enable\n")
+        .arg(&target));
     assert!(
         code == 0 || code == 1,
         "linting a billion-laughs file should finish cleanly (no DOM built), got {code}: {err}"

--- a/tests/cli_anchors_rule.rs
+++ b/tests/cli_anchors_rule.rs
@@ -18,7 +18,10 @@ fn anchors_reports_error() {
     fs::write(&file, "---\n- *missing\n- &missing value\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  anchors: enable\n")
+        .arg(&file));
     assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
     let output = if stderr.is_empty() { stdout } else { stderr };
     assert!(
@@ -133,7 +136,10 @@ fn alias_value_with_only_indent_prefix_is_supported() {
     fs::write(&file, "---\nvalue: &anchor literal\nalias:\n  *anchor\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  anchors: enable\n")
+        .arg(&file));
     assert_eq!(
         code, 0,
         "alias resolved successfully: stdout={stdout} stderr={stderr}"

--- a/tests/cli_commas_rule.rs
+++ b/tests/cli_commas_rule.rs
@@ -18,7 +18,10 @@ fn commas_reports_errors() {
     fs::write(&file, "---\n[1,2]\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  commas: enable\n")
+        .arg(&file));
     assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
     let output = if stderr.is_empty() { stdout } else { stderr };
     assert!(

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -180,6 +180,11 @@ fn fix_with_no_warnings_hides_warning_only_summary() {
 fn fix_missing_file_reports_read_error() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("missing.yaml");
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\nnew-line-at-end-of-file = 'enable'\n",
+    )
+    .unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, stdout, stderr) = run(Command::new(exe).arg("--fix").arg(&file));

--- a/tests/cli_fix_symlink.rs
+++ b/tests/cli_fix_symlink.rs
@@ -35,7 +35,11 @@ fn fix_symlink_warning_sanitizes_the_path() {
     symlink(&secret, &link).unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (_code, _out, err) = run(Command::new(exe).arg("--fix").arg(&link));
+    let (_code, _out, err) = run(Command::new(exe)
+        .arg("--fix")
+        .arg("-d")
+        .arg("rules:\n  trailing-spaces: enable\n")
+        .arg(&link));
     assert!(
         err.contains("refusing to apply --fix through a symlink"),
         "expected the symlink skip warning: {err:?}"
@@ -60,7 +64,11 @@ fn fix_skips_explicit_symlink_arg_and_leaves_target_untouched() {
     symlink(&secret, &link).unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (_code, _out, err) = run(Command::new(exe).arg("--fix").arg(&link));
+    let (_code, _out, err) = run(Command::new(exe)
+        .arg("--fix")
+        .arg("-d")
+        .arg("rules:\n  trailing-spaces: enable\n")
+        .arg(&link));
     assert!(
         err.contains("refusing to apply --fix through a symlink"),
         "expected the symlink skip warning: {err}"
@@ -82,7 +90,11 @@ fn fix_skips_symlink_pointing_outside_the_scanned_directory() {
     symlink(&secret, repo.join("innocent.yaml")).unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (_code, _out, err) = run(Command::new(exe).arg("--fix").arg(&repo));
+    let (_code, _out, err) = run(Command::new(exe)
+        .arg("--fix")
+        .arg("-d")
+        .arg("rules:\n  trailing-spaces: enable\n")
+        .arg(&repo));
     assert!(
         err.contains("refusing to apply --fix through a symlink"),
         "directory-walk --fix must skip symlinks: {err}"
@@ -104,8 +116,12 @@ fn fix_skips_symlinked_markdown_target() {
     symlink(&secret, &link).unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (_code, _out, err) =
-        run(Command::new(exe).arg("--fix").arg("--markdown").arg(&link));
+    let (_code, _out, err) = run(Command::new(exe)
+        .arg("--fix")
+        .arg("--markdown")
+        .arg("-d")
+        .arg("rules:\n  trailing-spaces: enable\n")
+        .arg(&link));
     assert!(
         err.contains("refusing to apply --fix through a symlink"),
         "embedded-markdown --fix must skip symlinks: {err}"

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -264,8 +264,12 @@ fn error_message_paths_are_escaped_in_github_format() {
     fs::write(&file, [0x80u8]).unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (_code, _stdout, stderr) =
-        run(Command::new(exe).arg("--format").arg("github").arg(&file));
+    let (_code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("github")
+        .arg("-d")
+        .arg("rules:\n  document-start: enable\n")
+        .arg(&file));
     assert!(
         !stderr.contains("\n::error::ARM_INJECT"),
         "an error-message path must not inject a workflow command: {stderr:?}"
@@ -359,8 +363,12 @@ fn colored_format_matches_reference_layout() {
     fs::write(&file, "list: [1,2]\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) =
-        run(Command::new(exe).arg("--format").arg("colored").arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("colored")
+        .arg("-d")
+        .arg("extends: default")
+        .arg(&file));
     assert_eq!(code, 1, "colored format should exit 1 when errors occur");
     assert!(
         stdout.is_empty(),

--- a/tests/cli_hyphens_rule.rs
+++ b/tests/cli_hyphens_rule.rs
@@ -18,7 +18,10 @@ fn hyphens_reports_error() {
     fs::write(&file, "---\n-  item\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  hyphens: enable\n")
+        .arg(&file));
     assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
     let output = if stderr.is_empty() { stdout } else { stderr };
     assert!(

--- a/tests/cli_indentation_rule.rs
+++ b/tests/cli_indentation_rule.rs
@@ -18,7 +18,10 @@ fn indentation_reports_error() {
     fs::write(&file, "root:\n- item\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  indentation: enable\n")
+        .arg(&file));
     assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
     let output = if stderr.is_empty() { &stdout } else { &stderr };
     assert!(output.contains("indentation"), "missing rule id: {output}");

--- a/tests/cli_line_length_rule.rs
+++ b/tests/cli_line_length_rule.rs
@@ -22,7 +22,10 @@ fn line_length_reports_error() {
     .unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  line-length: enable\n")
+        .arg(&file));
     assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
     let output = if stderr.is_empty() { &stdout } else { &stderr };
     assert!(

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -57,6 +57,8 @@ fn many_fenced_blocks_map_to_correct_host_lines() {
 
     let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl"))
         .arg("--markdown")
+        .arg("-d")
+        .arg("rules:\n  trailing-spaces: enable\n")
         .arg(&file));
 
     assert_eq!(code, 1, "trailing spaces should be reported: {err}");

--- a/tests/cli_new_line_rule.rs
+++ b/tests/cli_new_line_rule.rs
@@ -18,7 +18,10 @@ fn missing_newline_reports_error() {
     fs::write(&file, "key: value").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  new-line-at-end-of-file: enable\n")
+        .arg(&file));
     assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
     let output = if stderr.is_empty() { &stdout } else { &stderr };
     assert!(
@@ -38,7 +41,10 @@ fn newline_present_succeeds() {
     fs::write(&file, "key: value\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  new-line-at-end-of-file: enable\n")
+        .arg(&file));
     assert_eq!(code, 0, "expected success: stdout={stdout} stderr={stderr}");
 }
 

--- a/tests/cli_no_config.rs
+++ b/tests/cli_no_config.rs
@@ -1,0 +1,109 @@
+//! No configuration found is a loud error (#248).
+//!
+//! ryl has no default-on rules, so a run that resolves no configuration at all
+//! enables nothing and must exit 2 with a message that names the `extends: default`
+//! escape hatch — rather than silently linting with a preset (yamllint's behaviour)
+//! or silently passing. This is distinct from the "configuration enables no rules"
+//! error, which fires when a config *is* present but turns everything off.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tempfile::tempdir;
+
+/// Build a command whose `HOME`/`XDG_CONFIG_HOME` point at an isolated empty dir and
+/// whose env carries no `YAMLLINT_CONFIG_FILE`, so neither a user-global nor an
+/// env-var config can be discovered and the run genuinely sees no configuration.
+fn isolated(home: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_ryl"));
+    cmd.current_dir(home)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join("xdg"))
+        .env_remove("YAMLLINT_CONFIG_FILE");
+    cmd
+}
+
+#[test]
+fn no_config_found_is_rejected_with_escape_hatch() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("f.yaml");
+    std::fs::write(&file, "key: value\n").unwrap();
+
+    let out = isolated(dir.path()).arg(&file).output().expect("process");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a run with no configuration must be a usage error: {err}"
+    );
+    assert!(
+        err.contains("no configuration found") && err.contains("extends: default"),
+        "expected the no-config error naming the escape hatch: {err}"
+    );
+}
+
+#[test]
+fn no_config_found_via_stdin_is_rejected() {
+    let dir = tempdir().unwrap();
+    let mut child = isolated(dir.path())
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(b"key: value\n")
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "stdin with no configuration must be a usage error: {err}"
+    );
+    assert!(
+        err.contains("no configuration found"),
+        "stdin must report the same no-config error: {err}"
+    );
+}
+
+#[test]
+fn mixed_run_reports_no_config_for_the_unconfigured_file() {
+    // One file resolves a config that enables a rule; another resolves no config at
+    // all. The run can't lint the unconfigured file, and the error must reflect THAT
+    // file ("no configuration found") rather than the other file's config — the
+    // message is chosen per offending file, not per run.
+    let configured = tempdir().unwrap();
+    std::fs::write(
+        configured.path().join(".ryl.toml"),
+        "[rules]\nanchors = \"enable\"\n",
+    )
+    .unwrap();
+    let with_config = configured.path().join("a.yaml");
+    std::fs::write(&with_config, "key: value\n").unwrap();
+
+    let bare = tempdir().unwrap();
+    let without_config = bare.path().join("b.yaml");
+    std::fs::write(&without_config, "key: value\n").unwrap();
+
+    let out = isolated(bare.path())
+        .arg(&with_config)
+        .arg(&without_config)
+        .output()
+        .expect("process");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a file that resolves no config must fail the run: {err}"
+    );
+    assert!(
+        err.contains("no configuration found"),
+        "the unconfigured file's message must win over the configured file: {err}"
+    );
+}

--- a/tests/cli_trailing_spaces_rule.rs
+++ b/tests/cli_trailing_spaces_rule.rs
@@ -18,7 +18,10 @@ fn trailing_spaces_reports_error() {
     fs::write(&file, "key: value \n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, stdout, stderr) = run(Command::new(exe).arg(&file));
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  trailing-spaces: enable\n")
+        .arg(&file));
     assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
     let output = if stderr.is_empty() { &stdout } else { &stderr };
     assert!(

--- a/tests/config_env_missing.rs
+++ b/tests/config_env_missing.rs
@@ -15,9 +15,11 @@ fn env_points_to_missing_file_is_ignored() {
         }
     })
     .expect("discover should succeed");
-    // Missing env config falls back to default preset
+    // A missing env config is ignored; with nothing else found, resolution falls back
+    // to an empty config (explicit-enable model), not the default preset.
     assert!(ctx.source.is_none());
-    assert!(ctx.config.rule_names().iter().any(|r| r == "anchors"));
+    assert!(!ctx.config_found);
+    assert!(ctx.config.rule_names().is_empty());
 }
 
 #[test]
@@ -58,6 +60,7 @@ fn env_tilde_path_without_home_falls_back_to_system_home() {
     })
     .expect("discover should succeed");
 
-    // No config file found; default preset applies.
+    // No config file found; resolution falls back to an empty config.
     assert!(ctx.source.is_none());
+    assert!(!ctx.config_found);
 }

--- a/tests/config_find_project_home_boundary.rs
+++ b/tests/config_find_project_home_boundary.rs
@@ -24,8 +24,14 @@ fn project_search_respects_home_boundary() {
     )
     .expect("config discovery should succeed");
     assert!(ctx.source.is_none(), "project config should not cross HOME");
-    assert!(ctx.config.rule_names().iter().any(|r| r == "anchors"));
-    assert!(!ctx.config.rule_names().iter().any(|r| r == "custom"));
+    assert!(
+        !ctx.config_found,
+        "no in-boundary config exists, so the search falls back to an empty config",
+    );
+    assert!(
+        !ctx.config.rule_names().iter().any(|r| r == "custom"),
+        "the out-of-boundary .yamllint must not be applied across the HOME boundary",
+    );
 }
 
 #[test]

--- a/tests/discover_per_file_dir.rs
+++ b/tests/discover_per_file_dir.rs
@@ -4,7 +4,15 @@ use tempfile::tempdir;
 #[test]
 fn discover_per_file_handles_directory_input() {
     let td = tempdir().unwrap();
-    // No project or user config; falls back to built-in default.
-    let ctx = discover_per_file(td.path()).expect("discover default for dir");
-    assert!(ctx.config.rule_names().iter().any(|r| r == "anchors"));
+    // No project or user config: resolution falls back to an empty config (the
+    // explicit-enable model), not the built-in default preset.
+    let ctx = discover_per_file(td.path()).expect("discover for dir");
+    assert!(
+        !ctx.config_found,
+        "an empty temp dir has no config to discover"
+    );
+    assert!(
+        ctx.config.rule_names().is_empty(),
+        "the no-config fallback must enable no rules",
+    );
 }

--- a/tests/flow_collection_cli.rs
+++ b/tests/flow_collection_cli.rs
@@ -41,7 +41,10 @@ fn run_cli_suite(suite: CliSuite) {
     let bad = dir.path().join("bad.yaml");
     fs::write(&bad, suite.spaced_input).unwrap();
     assert_command_output(
-        Command::new(exe).arg(&bad),
+        Command::new(exe)
+            .arg("-d")
+            .arg(format!("rules:\n  {}: enable\n", suite.rule_name))
+            .arg(&bad),
         1,
         &[suite.spacing_message, suite.rule_name],
     );

--- a/tests/lint_multi_errors.rs
+++ b/tests/lint_multi_errors.rs
@@ -19,12 +19,12 @@ fn multiple_invalid_files_print_multiple_errors() {
     fs::write(root.join("b.yaml"), "b: [2\n").unwrap();
 
     let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, _out, err) = run(Command::new(exe).arg(root));
+    let (code, _out, err) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  document-start: enable\n")
+        .arg(root));
     assert_eq!(code, 1, "expected failure");
-    let count = err
-        .lines()
-        .filter(|l| l.trim().ends_with("(syntax)"))
-        .count();
+    let count = err.lines().filter(|l| l.contains("syntax")).count();
     assert!(
         count >= 2,
         "expected at least two syntax error lines, got: {err}"

--- a/tests/migrate_module.rs
+++ b/tests/migrate_module.rs
@@ -110,8 +110,18 @@ fn migrate_write_mode_with_rename_suffix_renames_source_file() {
 #[test]
 fn migrate_warns_on_multiple_same_directory_configs() {
     let td = tempdir().unwrap();
-    fs::write(td.path().join(".yamllint.yaml"), "rules: {}\n").unwrap();
-    fs::write(td.path().join(".yamllint.yml"), "rules: {}\n").unwrap();
+    // Both enable a rule so the only warning is the lower-precedence dedup, not the
+    // separate "enables no rules" warning (exercised by its own test below).
+    fs::write(
+        td.path().join(".yamllint.yaml"),
+        "rules:\n  anchors: enable\n",
+    )
+    .unwrap();
+    fs::write(
+        td.path().join(".yamllint.yml"),
+        "rules:\n  anchors: enable\n",
+    )
+    .unwrap();
     let opts = MigrateOptions {
         root: td.path().to_path_buf(),
         write_mode: WriteMode::Preview,
@@ -123,6 +133,26 @@ fn migrate_warns_on_multiple_same_directory_configs() {
     assert_eq!(res.cleanup_only_sources.len(), 1);
     assert_eq!(res.warnings.len(), 1);
     assert!(res.warnings[0].contains("lower-precedence"));
+}
+
+#[test]
+fn migrate_warns_when_migrated_config_enables_no_rules() {
+    let td = tempdir().unwrap();
+    fs::write(td.path().join(".yamllint"), "rules: {}\n").unwrap();
+    let opts = MigrateOptions {
+        root: td.path().to_path_buf(),
+        write_mode: WriteMode::Preview,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert_eq!(res.entries.len(), 1);
+    assert_eq!(res.warnings.len(), 1);
+    assert!(
+        res.warnings[0].contains("enables no rules"),
+        "a migrated rule-less config must warn it will not lint: {:?}",
+        res.warnings,
+    );
 }
 
 #[test]

--- a/tests/resolve_ctx_empty_parent.rs
+++ b/tests/resolve_ctx_empty_parent.rs
@@ -6,11 +6,16 @@ use ryl::config::YamlLintConfig;
 
 #[test]
 fn resolve_ctx_handles_path_without_parent() {
-    let mut cache: HashMap<PathBuf, (PathBuf, YamlLintConfig)> = HashMap::new();
-    let (base_dir, cfg, notices) = resolve_ctx(Path::new(""), None, false, &mut cache)
-        .expect("resolve_ctx should fall back to current directory");
+    let mut cache: HashMap<PathBuf, (PathBuf, YamlLintConfig, bool)> = HashMap::new();
+    let (base_dir, cfg, notices, config_found) =
+        resolve_ctx(Path::new(""), None, false, &mut cache)
+            .expect("resolve_ctx should fall back to current directory");
     assert_eq!(base_dir, PathBuf::from("."));
     assert!(notices.is_empty());
     assert!(cache.contains_key(&PathBuf::from(".")));
+    assert!(
+        config_found,
+        "the repo's own .ryl.toml is discovered for the current directory",
+    );
     assert!(cfg.rule_names().iter().any(|r| r == "anchors"));
 }

--- a/tests/yamllint_compat_colors.rs
+++ b/tests/yamllint_compat_colors.rs
@@ -27,10 +27,16 @@ fn colored_diagnostics_match_yamllint_across_formats() {
     let warning_cfg = dir.path().join("layout-warning.yml");
     fs::write(&warning_cfg, "rules:\n  commas:\n    level: warning\n").unwrap();
 
+    // ryl errors on no config (it has no default-on rules), so give both tools the
+    // default preset explicitly via `extends: default` — yamllint's own no-config
+    // fallback is literally `extends: default`, so the comparison stays valid.
+    let default_cfg = dir.path().join("layout-default.yml");
+    fs::write(&default_cfg, "extends: default\n").unwrap();
+
     let cases = [
         Case {
-            label: "default-config",
-            config_path: None,
+            label: "extends-default",
+            config_path: Some(default_cfg.clone()),
             expected_exit: 1,
         },
         Case {


### PR DESCRIPTION
Closes #248.

Makes ryl **never enable a rule that wasn't explicitly turned on** — the last
place "default-on" rules appeared was the no-config fallback, which auto-applied
the built-in `default` preset. That fallback is removed: when no configuration is
resolved, ryl now reports an error instead of silently linting with a preset.

This converges the three "nothing would be linted" cases onto one rule (you must
explicitly enable at least one rule), building on the zero-rule-config and
empty-config errors shipped in #246 (closes #248).

## Behaviour change (intentionally stricter than yamllint)

Two cases exit `2` rather than silently linting nothing; both name the
`extends: default` escape hatch:

| Situation | Before | Now |
| --- | --- | --- |
| No config found anywhere | lint with `default` preset | `error: no configuration found and ryl enables no rules by default; …` |
| Config enables 0 rules | (already) error | unchanged (message reworded — see below) |
| `extends: default` / explicit rules | lint those rules | unchanged |
| `--list-files`, `--migrate-configs` | run | unchanged (exempt; they don't lint) |

The pre-existing zero-rule-config message dropped its now-false *"remove the
configuration to use the default rule set"* advice (removing the config no longer
falls back to a preset) in favour of *"use 'extends: default' for the standard
rule set"*.

### yamllint compatibility

Compatible whenever a config is used: yamllint's own no-config fallback is literally
`extends: default`, so a user who writes `extends: default` (YAML config) gets
byte-identical behaviour — the default rule set stays available, it just becomes
opt-in. The only divergences are the two intentional "stricter" cases above.

## Implementation

- The two no-config fallbacks (`discover_config_with`, `discover_per_file_with`)
  return an empty `YamlLintConfig::default()` instead of the `default` preset.
- `ConfigContext` gained `config_found: bool` (false only in those fallbacks),
  threaded through `resolve_ctx` (per-directory cache) and `resolve_stdin_ctx`.
- `gather_lint_files` returns the `config_found` of the **first** selected file that
  enables no rules (`Option<bool>`), so a mixed run (one configured file + one
  unconfigured file) reports the *unconfigured* file's "no configuration found"
  message rather than the other file's. `main::no_rules_error` picks the wording.
- `--migrate-configs` is unaffected (it resolves explicit config files and already
  flattens `extends: default`), but now **warns** when a migrated config enables no
  rules, so a thin source config doesn't silently produce one that won't lint.

## Tests & docs

- New `tests/cli_no_config.rs` (no-config file, stdin, and mixed-run regression);
  config-discovery unit tests updated to the empty-fallback contract; ~16 CLI tests
  given explicit configs (rule-specific where they test one rule; `extends: default`
  for the format/differential tests); a migrate zero-rules-warning test.
- Docs: `AGENTS.md`, `docs/getting-started/quickstart.md` (first-run note +
  behaviour), `docs/getting-started/migrating-from-yamllint.md` ("What differs").
- prek clean, **1212 tests** pass, coverage reports zero uncovered regions.

## Review

Reviewed at high effort internally (9 finder angles + verification + sweep) and
iterated through an independent Codex review to convergence. Findings actioned:
the per-file no-rules message (above), un-masking a github-format escaping test that
the new no-config gate had made vacuous, and correcting now-stale `# Panics`
doc-comments (the no-config fallback no longer parses a preset; the only remaining
panic is via `extends:` builtin resolution).
