### PR TITLE
Add opt-in `tags` rule for unsafe and non-portable YAML tags (closes #251)

### DIFF
--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -135,6 +135,12 @@ allow-quoted-quotes = true
 allow-double-quotes-for-escaping = false
 check-keys = true
 
+[rules.tags]
+level = "warning"
+forbid-unsafe-tags = true
+forbid-removed-types = true
+allowed-tags = ["!env", "!include"]
+
 [rules.trailing-spaces]
 level = "warning"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,10 @@ ryl is a CLI tool for linting yaml files
 - Keep YAML configuration strictly aligned with functionality that yamllint currently
   supports. Put any ryl-only settings, experimental rule options, or ahead-of-upstream
   behaviour in TOML configuration so future yamllint additions cannot clash with
-  existing YAML semantics.
+  existing YAML semantics. A whole ryl-only *rule* (one yamllint lacks, e.g. `tags`)
+  goes in `rules::RYL_ONLY_RULE_IDS`: the YAML config path rejects those rules and
+  `config_schema::yaml_schema` prunes them from the YAML schema, so they are
+  configurable only via TOML (`[rules.<id>]`).
 
 ## Code Change Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,15 @@ ryl is a CLI tool for linting yaml files
   summary threads and `gh api repos/<owner>/<repo>/pulls/<number>/comments` when you
   need inline review details without guesswork. Avoid flags that the GitHub CLI does not
   support (e.g., `--review-comments`).
+- Codex auto-reviews PRs here; re-trigger one by commenting `@codex review` (it takes
+  minutes). It signals its verdict in one of three forms — a new PR review (when it has
+  findings), a new issue comment (often its "no major issues" all-clear), or a 👍
+  reaction on the triggering comment — so poll for **any** of them; watching only one
+  misses the result. Capture baseline counts of Codex reviews, Codex issue comments, and
+  the trigger comment's reactions, then poll (~45s) for any to change, running the poller
+  as a background command since a thorough review can exceed a 10-minute foreground
+  timeout. The bot login is `chatgpt-codex-connector` in reviews and
+  `chatgpt-codex-connector[bot]` in inline review comments.
 - When referencing another repository's issues/PRs in GitHub issues, PRs, or comments
   (e.g. an upstream `yamllint` issue), always use the fully-qualified
   `adrienverge/yamllint#123` form. A bare `#123` auto-links to *this* repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,11 @@ ryl is a CLI tool for linting yaml files
   summary threads and `gh api repos/<owner>/<repo>/pulls/<number>/comments` when you
   need inline review details without guesswork. Avoid flags that the GitHub CLI does not
   support (e.g., `--review-comments`).
+- When referencing another repository's issues/PRs in GitHub issues, PRs, or comments
+  (e.g. an upstream `yamllint` issue), always use the fully-qualified
+  `adrienverge/yamllint#123` form. A bare `#123` auto-links to *this* repo
+  (`owenlamont/ryl#123`) and silently points at the wrong issue. Use a bare `#123` only
+  for ryl's own issues/PRs.
 - Linters and tests may write outside the workspace (e.g., `~/.cache/prek`). If
   sandboxed, request permission escalation when running `prek`, `cargo test`,
   or coverage commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,9 @@ the unsafe-trigger subset in that rule's module-level doc comment instead.
 - `octal-values` — Resolving `010` requires knowing whether the user meant
   the integer `8`, the integer `10`, or the string `"010"`; the YAML source
   alone cannot disambiguate.
+- `tags` — Rewriting or removing a flagged tag changes the node's resolved
+  type (`!!omap` to a plain mapping, `!env` to a string, …) or requires
+  guessing the intended value, so no rewrite is universally safe.
 - `truthy` — Rewriting `Yes/No/On/Off` requires choosing between quoting them
   (preserves the string), normalising to `true/false` (changes type), or
   rewording — all of which depend on the user's intent.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "clap",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ cargo install ryl                   # cargo
 
 ## Status and scope
 
-- All 23 yamllint rules are implemented. The current rule reference and
-  per-rule pages are at
+- All 23 yamllint rules are implemented, plus a ryl-only `tags` rule (forbids
+  unsafe and non-portable YAML tags; configured in TOML only). The current rule
+  reference and per-rule pages are at
   <https://ryl-docs.pages.dev/rules/>.
 - Auto-fixing (`--fix`) is supported for `braces`, `brackets`, `commas`,
   `comments`, `comments-indentation`, `new-line-at-end-of-file`,

--- a/docs/config-presets.md
+++ b/docs/config-presets.md
@@ -103,8 +103,9 @@ level = "warning"
 allow-non-breakable-inline-mappings = true
 ```
 
-## `empty` (TOML equivalent)
+## `empty`
 
-```toml
-[rules]
-```
+There is no usable TOML equivalent: ryl requires at least one rule to be
+enabled, so an empty `[rules]` table is rejected with "configuration enables no
+rules". The `empty` preset survives only as a base to `extends:` in YAML config;
+in TOML, list the rules you want under `[rules]` directly.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-ryl implements 23 rules for checking YAML files. This page is a categorised
+ryl implements 24 rules for checking YAML files. This page is a categorised
 index of every rule with a brief description and a link to its detailed
 documentation. Each rule page covers what the rule does, why it matters,
 configuration options, and (where applicable) automatic fix behaviour.
@@ -18,7 +18,7 @@ For configuration discovery, presets, and file selection, see
 - [Layout and spacing](#layout-and-spacing) &mdash; whitespace, indentation,
   line endings, line length
 - [Document structure](#document-structure) &mdash; document markers, empty
-  values, anchors, keys
+  values, anchors, tags, keys
 - [Comments](#comments) &mdash; comment placement and spacing
 - [Values](#values) &mdash; numeric, string, and boolean value formats
 
@@ -50,6 +50,7 @@ Rules that auto-fix are marked with :wrench: in the **Fix** column.
 | [`empty-values`](rules/empty-values.md) | Empty values in mappings and sequences. |  |
 | [`key-duplicates`](rules/key-duplicates.md) | Duplicate keys in mappings. |  |
 | [`key-ordering`](rules/key-ordering.md) | Alphabetical ordering of mapping keys. |  |
+| [`tags`](rules/tags.md) | Unsafe and non-portable YAML tags. |  |
 
 ## Comments
 

--- a/docs/rules/tags.md
+++ b/docs/rules/tags.md
@@ -1,0 +1,92 @@
+# tags
+
+## What this rule does
+
+Inspects the YAML tags attached to nodes (`!!python/object/apply`, `!!omap`,
+`!env`, …) for safety and portability. The rule bundles three independent
+checks, all **off by default**; enable only the ones your project needs.
+
+## Why this matters
+
+- **Unsafe construction tags.** Language-specific tags such as
+  `!!python/object/apply`, `!ruby/object:`, or `!!java/…` drive
+  arbitrary-object construction in some loaders. PyYAML's documentation warns
+  that `yaml.load` "is as powerful as `pickle.load`" and recommends
+  `safe_load`; authoring YAML that depends on such tags is a recognised
+  anti-pattern.
+- **Removed YAML 1.1 types.** `!!omap`, `!!pairs`, `!!set`, `!!timestamp`, and
+  `!!binary` were removed in YAML 1.2. ryl targets YAML 1.2, so flagging them
+  keeps documents portable.
+- **Local / non-core tags.** Local tags such as `!env` or `!include` are
+  application-specific and "may even have different semantics in different
+  documents" (YAML 1.2.2 spec). An allowlist lets a team permit only the
+  handles it actually uses.
+
+Sources: YAML 1.2.2 spec (tags); YAML 1.2.2 changes page; PyYAML docs; The
+YAML Company.
+
+## Configuration
+
+```toml
+[rules.tags]
+level = "error"
+forbid-unsafe-tags = false
+forbid-removed-types = false
+allowed-tags = []
+```
+
+| Option | Default | Description |
+| :--- | :--- | :--- |
+| `forbid-unsafe-tags` | `false` | Forbid language-specific construction tags whose suffix begins with a known namespace: `python/`, `ruby/`, `perl/`, `php/`, `java/`, `java.`, or `javax.`. This list is a curated best-effort, not an exhaustive denylist. |
+| `forbid-removed-types` | `false` | Forbid the YAML 1.1 types removed in 1.2: `!!omap`, `!!pairs`, `!!set`, `!!timestamp`, `!!binary`. |
+| `allowed-tags` | `[]` | When non-empty, report any other local / non-core tag (e.g. `!env`) that is not listed. Core-schema tags (`!!str`, `!!omap`, …) are governed by the other two options, not by this allowlist. |
+
+List `allowed-tags` entries in shorthand form (e.g. `!env`). Tag spelling is
+normalised before matching, so shorthand, local, and verbatim (`!<…>`) forms
+are treated alike and core-schema tags always compare as their `!!type` form.
+The non-specific `!` tag is never reported.
+
+When more than one check matches the same node, a single diagnostic is
+reported in the order: unsafe, removed type, not allowed.
+
+## Examples
+
+### :x: Reported (with `forbid-unsafe-tags: true`)
+
+```yaml
+payload: !!python/object/apply:os.system ["id"]
+record: !ruby/object:Account {}
+```
+
+### :x: Reported (with `forbid-removed-types: true`)
+
+```yaml
+ordered: !!omap [{a: 1}]
+unique: !!set {a, b}
+```
+
+### :x: Reported (with `allowed-tags: ["!keep"]`)
+
+```yaml
+database: !env DATABASE_URL
+```
+
+### :white_check_mark: Allowed (with `allowed-tags: ["!keep"]`)
+
+```yaml
+secret: !keep VALUE
+name: !!str 42
+```
+
+## Automatic fixing
+
+This rule does not auto-fix. Rewriting or removing a tag would change the
+node's resolved type (or require guessing the intended value), so no single
+rewrite is universally safe.
+
+## Related rules
+
+- [`anchors`](anchors.md) &mdash; the analogous rule for the other piece of
+  node metadata, anchors and aliases.
+- [`quoted-strings`](quoted-strings.md) &mdash; useful when you want to pin a
+  value to a string instead of relying on a tag.

--- a/docs/rules/tags.md
+++ b/docs/rules/tags.md
@@ -57,6 +57,10 @@ non-specific `!` tag is never reported.
 When more than one check matches the same node, a single diagnostic is
 reported in the order: unsafe, removed type, not allowed.
 
+A tag heading a block collection is reported at the collection, which may begin
+on the next line, so a `# ryl disable-line` for it must sit on that line, not the
+tag's line.
+
 ## Examples
 
 ### :x: Reported (with `forbid-unsafe-tags: true`)

--- a/docs/rules/tags.md
+++ b/docs/rules/tags.md
@@ -27,6 +27,12 @@ YAML Company.
 
 ## Configuration
 
+`tags` is a ryl-only rule (yamllint has no equivalent), so it is configured
+**only in TOML** &mdash; `[rules.tags]` in `.ryl.toml`/`ryl.toml` or
+`[tool.ryl.rules.tags]` in `pyproject.toml`. It is rejected in
+yamllint-compatible YAML config (including `-d` data) so the YAML `tags`
+namespace stays reserved for any future yamllint rule.
+
 ```toml
 [rules.tags]
 level = "error"
@@ -44,7 +50,9 @@ allowed-tags = []
 List `allowed-tags` entries in shorthand form (e.g. `!env`). Tag spelling is
 normalised before matching, so shorthand, local, and verbatim (`!<…>`) forms
 are treated alike and core-schema tags always compare as their `!!type` form.
-The non-specific `!` tag is never reported.
+A tag written with a custom `%TAG` handle is matched by its resolved URI (e.g.
+`tag:example.com,2002:env`), not the `!handle!suffix` shorthand. The
+non-specific `!` tag is never reported.
 
 When more than one check matches the same node, a single diagnostic is
 reported in the order: unsafe, removed type, not allowed.

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.12.0"
+  "version": "0.13.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.12.0"
+version = "0.13.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -414,6 +414,20 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
+    "RuleEntryForTagsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/RuleSwitch"
+        },
+        {
+          "$ref": "#/$defs/RuleOptionsForTagsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
     "RuleEntryForTomlQuotedStringsOptions": {
       "anyOf": [
         {
@@ -474,6 +488,7 @@
         "new-lines",
         "octal-values",
         "quoted-strings",
+        "tags",
         "trailing-spaces",
         "truthy"
       ],
@@ -1376,6 +1391,64 @@
       },
       "type": "object"
     },
+    "RuleOptionsForTagsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "allowed-tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "forbid-removed-types": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "forbid-unsafe-tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "RuleOptionsForTomlQuotedStringsOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1736,6 +1809,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RuleEntryForTomlQuotedStringsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleEntryForTagsOptions"
             },
             {
               "type": "null"

--- a/ryl.yaml.schema.json
+++ b/ryl.yaml.schema.json
@@ -318,20 +318,6 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
-    "RuleEntryForTagsOptions": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/RuleSwitch"
-        },
-        {
-          "$ref": "#/$defs/RuleOptionsForTagsOptions"
-        }
-      ],
-      "description": "Common rule entry shape used by TOML config."
-    },
     "RuleEntryForTruthyOptions": {
       "anyOf": [
         {
@@ -1338,64 +1324,6 @@
       },
       "type": "object"
     },
-    "RuleOptionsForTagsOptions": {
-      "additionalProperties": false,
-      "description": "Common rule fields plus rule-specific options.",
-      "properties": {
-        "allowed-tags": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "forbid-removed-types": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "forbid-unsafe-tags": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "ignore": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "ignore-from-file": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "level": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RuleLevel"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
-    },
     "RuleOptionsForTruthyOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1663,16 +1591,6 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RuleEntryForQuotedStringsOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RuleEntryForTagsOptions"
             },
             {
               "type": "null"

--- a/ryl.yaml.schema.json
+++ b/ryl.yaml.schema.json
@@ -318,6 +318,20 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
+    "RuleEntryForTagsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/RuleSwitch"
+        },
+        {
+          "$ref": "#/$defs/RuleOptionsForTagsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
     "RuleEntryForTruthyOptions": {
       "anyOf": [
         {
@@ -1324,6 +1338,64 @@
       },
       "type": "object"
     },
+    "RuleOptionsForTagsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "allowed-tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "forbid-removed-types": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "forbid-unsafe-tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "RuleOptionsForTruthyOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1591,6 +1663,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RuleEntryForQuotedStringsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleEntryForTagsOptions"
             },
             {
               "type": "null"

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,6 +409,21 @@ impl YamlLintConfig {
         Self::from_yaml_str_with_env(s, None, None)
     }
 
+    /// Build a config from standalone TOML configuration text.
+    ///
+    /// # Errors
+    /// Returns an error when the TOML is empty or cannot be parsed into a valid
+    /// config.
+    ///
+    /// # Panics
+    /// Cannot panic in practice: the `None` result is reserved for an absent
+    /// `[tool.ryl]` table in `pyproject.toml`, which standalone parsing
+    /// (`pyproject = false`) never produces &mdash; an empty config is an error.
+    pub fn from_toml_str(s: &str) -> Result<Self, String> {
+        Self::from_toml_str_with_env(s, None, None, false)
+            .map(|config| config.expect("standalone TOML config is never absent"))
+    }
+
     fn extend_from_entry(
         &mut self,
         entry: &str,

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -264,6 +264,8 @@ pub enum RuleName {
     OctalValues,
     #[serde(rename = "quoted-strings")]
     QuotedStrings,
+    #[serde(rename = "tags")]
+    Tags,
     #[serde(rename = "trailing-spaces")]
     TrailingSpaces,
     #[serde(rename = "truthy")]
@@ -295,6 +297,7 @@ impl RuleName {
             Self::NewLines => "new-lines",
             Self::OctalValues => "octal-values",
             Self::QuotedStrings => "quoted-strings",
+            Self::Tags => "tags",
             Self::TrailingSpaces => "trailing-spaces",
             Self::Truthy => "truthy",
         }
@@ -338,6 +341,7 @@ pub struct RulesTable<Q = QuotedStringsOptions> {
     pub octal_values: Option<RuleEntry<OctalValuesOptions>>,
     #[serde(rename = "quoted-strings")]
     pub quoted_strings: Option<RuleEntry<Q>>,
+    pub tags: Option<RuleEntry<TagsOptions>>,
     #[serde(rename = "trailing-spaces")]
     pub trailing_spaces: Option<RuleEntry<NoOptions>>,
     pub truthy: Option<RuleEntry<TruthyOptions>>,
@@ -512,6 +516,17 @@ pub struct KeyDuplicatesOptions {
 pub struct KeyOrderingOptions {
     #[serde(rename = "ignored-keys")]
     pub ignored_keys: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TagsOptions {
+    #[serde(rename = "forbid-unsafe-tags")]
+    pub forbid_unsafe_tags: Option<bool>,
+    #[serde(rename = "forbid-removed-types")]
+    pub forbid_removed_types: Option<bool>,
+    #[serde(rename = "allowed-tags")]
+    pub allowed_tags: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -697,7 +697,85 @@ pub fn yaml_schema() -> Schema {
             }
         ])
     });
+    prune_ryl_only_rules(root);
     schema
+}
+
+/// Remove the ryl-only rule properties (and any `$defs` they leave
+/// unreferenced) from the generated YAML schema, so it advertises only the
+/// yamllint-compatible rule surface. The rules themselves are still rejected at
+/// parse time; see `crate::rules::RYL_ONLY_RULE_IDS`.
+fn prune_ryl_only_rules(root: &mut serde_json::Map<String, Value>) {
+    // Only the rules-table definition carries rule-id-named properties, so
+    // dropping the ryl-only ids from every definition's `properties` targets it
+    // without depending on schemars' generated definition name.
+    let defs = root
+        .get_mut("$defs")
+        .and_then(Value::as_object_mut)
+        .expect("generated YAML schema always has a $defs table");
+    for def in defs.values_mut() {
+        if let Some(properties) =
+            def.get_mut("properties").and_then(Value::as_object_mut)
+        {
+            for rule in crate::rules::RYL_ONLY_RULE_IDS {
+                properties.remove(rule);
+            }
+        }
+    }
+    remove_unreferenced_defs(root);
+}
+
+/// Drop `$defs` entries no longer reachable by any `$ref`, iterating until the
+/// set is stable so reference chains collapse fully.
+fn remove_unreferenced_defs(root: &mut serde_json::Map<String, Value>) {
+    loop {
+        let mut referenced = std::collections::BTreeSet::new();
+        for value in root.values() {
+            collect_defs_refs(value, &mut referenced);
+        }
+        let defs = root
+            .get_mut("$defs")
+            .and_then(Value::as_object_mut)
+            .expect("generated YAML schema always has a $defs table");
+        let orphans: Vec<String> = defs
+            .keys()
+            .filter(|name| !referenced.contains(name.as_str()))
+            .cloned()
+            .collect();
+        if orphans.is_empty() {
+            return;
+        }
+        for orphan in orphans {
+            defs.remove(&orphan);
+        }
+    }
+}
+
+fn collect_defs_refs(
+    value: &Value,
+    referenced: &mut std::collections::BTreeSet<String>,
+) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if key == "$ref" {
+                    let name = child
+                        .as_str()
+                        .and_then(|reference| reference.strip_prefix("#/$defs/"))
+                        .expect("schema $ref always targets a local $defs entry");
+                    referenced.insert(name.to_string());
+                } else {
+                    collect_defs_refs(child, referenced);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_defs_refs(item, referenced);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Deserialize TOML configuration text into the typed schema model.
@@ -898,9 +976,21 @@ pub(crate) fn parse_yaml_config(doc: &YamlOwned) -> Result<ParsedYamlConfig, Str
     let typed = parse_typed_yaml_config(doc)?;
     validate_yaml_config(&typed)?;
 
+    let normalized = normalize_typed_yaml_config(doc, &typed);
+    if let Some(rule) = normalized
+        .rules
+        .keys()
+        .find(|name| crate::rules::RYL_ONLY_RULE_IDS.contains(&name.as_str()))
+    {
+        return Err(format!(
+            "invalid config: `{rule}` is a ryl-only rule and is not available in \
+             yamllint-compatible YAML config; configure it in TOML (`[rules.{rule}]`)"
+        ));
+    }
+
     Ok(ParsedYamlConfig {
         extends: typed.extends.iter().cloned().collect(),
-        normalized: normalize_typed_yaml_config(doc, &typed),
+        normalized,
     })
 }
 

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -228,6 +228,7 @@ fn rules_table_to_value<Q: Serialize>(rules: &RulesTable<Q>) -> toml::Value {
     insert_serialized(&mut table, "new-lines", rules.new_lines.as_ref());
     insert_serialized(&mut table, "octal-values", rules.octal_values.as_ref());
     insert_serialized(&mut table, "quoted-strings", rules.quoted_strings.as_ref());
+    insert_serialized(&mut table, "tags", rules.tags.as_ref());
     insert_serialized(
         &mut table,
         "trailing-spaces",

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -6,7 +6,7 @@ use crate::rules::{
     anchors, braces, brackets, colons, commas, comments, comments_indentation,
     document_end, document_start, empty_lines, empty_values, float_values, hyphens,
     indentation, key_duplicates, key_ordering, line_length, new_line_at_end_of_file,
-    new_lines, octal_values, quoted_strings, trailing_spaces, truthy,
+    new_lines, octal_values, quoted_strings, tags, trailing_spaces, truthy,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -144,6 +144,8 @@ pub fn lint_str(
     collect_comments_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
     collect_anchors_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
+
+    collect_tags_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
     collect_octal_values_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
@@ -500,6 +502,29 @@ fn collect_anchors_diagnostics(
                 level: level.into(),
                 message: hit.message,
                 rule: Some(anchors::ID),
+            });
+        }
+    }
+}
+
+fn collect_tags_diagnostics(
+    diagnostics: &mut Vec<LintProblem>,
+    content: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+) {
+    if let Some(level) = cfg.rule_level(tags::ID)
+        && !cfg.is_rule_ignored(tags::ID, path, base_dir)
+    {
+        let rule_cfg = tags::Config::resolve(cfg);
+        for hit in tags::check(content, &rule_cfg) {
+            diagnostics.push(LintProblem {
+                line: hit.line,
+                column: hit.column,
+                level: level.into(),
+                message: hit.message,
+                rule: Some(tags::ID),
             });
         }
     }

--- a/src/rules/empty_values.rs
+++ b/src/rules/empty_values.rs
@@ -50,7 +50,20 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     let mut parser = Parser::new_from_str(buffer);
     let mut receiver = EmptyValuesReceiver::new(cfg);
     let _ = parser.load(&mut receiver, true);
-    receiver.diagnostics
+    // A tagged/anchored empty value (e.g. `a: !!str`) is an implicit scalar
+    // that granit positions at a virtual spot which can fall past the document;
+    // keep the report on a real position.
+    let mut diagnostics = receiver.diagnostics;
+    for violation in &mut diagnostics {
+        let (line, column) = crate::rules::support::span_utils::clamp_position(
+            buffer,
+            violation.line,
+            violation.column,
+        );
+        violation.line = line;
+        violation.column = column;
+    }
+    diagnostics
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -20,12 +20,13 @@ pub mod new_lines;
 pub mod octal_values;
 pub mod quoted_strings;
 pub(crate) mod support;
+pub mod tags;
 pub mod trailing_spaces;
 pub mod truthy;
 
 /// Every rule id, used by the directive engine to expand a bare `disable`/`enable`
 /// (no `rule:` token) to "all rules". Extend this when adding a rule.
-pub const ALL_RULE_IDS: [&str; 23] = [
+pub const ALL_RULE_IDS: [&str; 24] = [
     anchors::ID,
     braces::ID,
     brackets::ID,
@@ -47,6 +48,7 @@ pub const ALL_RULE_IDS: [&str; 23] = [
     new_lines::ID,
     octal_values::ID,
     quoted_strings::ID,
+    tags::ID,
     trailing_spaces::ID,
     truthy::ID,
 ];

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -52,3 +52,10 @@ pub const ALL_RULE_IDS: [&str; 24] = [
     trailing_spaces::ID,
     truthy::ID,
 ];
+
+/// Rules that are ryl-only (no yamllint equivalent) and therefore configurable
+/// only via TOML. They are rejected in yamllint-compatible YAML config and kept
+/// out of the YAML schema so the YAML `rules` namespace stays reserved for
+/// yamllint's own definitions (see `AGENTS.md`). Extend this when adding a rule
+/// that yamllint does not have.
+pub const RYL_ONLY_RULE_IDS: [&str; 1] = [tags::ID];

--- a/src/rules/support/span_utils.rs
+++ b/src/rules/support/span_utils.rs
@@ -72,6 +72,32 @@ pub fn containing_scalar_range<'a>(
         .filter(|range| idx >= range.start.get() && idx < range.end.get())
 }
 
+/// Clamp a 1-based `(line, column)` onto a real position within `buffer`.
+///
+/// granit reports an implicit empty scalar (the node after a tag or anchor that
+/// has no written value) at a *virtual* position — the column the value would
+/// occupy, on the line after its property. When such a node ends the document
+/// that position can be past end-of-line or on the empty segment a trailing
+/// newline leaves behind. Rules that surface these nodes (`tags`,
+/// `empty-values`) clamp here so a diagnostic never points outside the document.
+#[must_use]
+pub fn clamp_position(buffer: &str, line: usize, column: usize) -> (usize, usize) {
+    let line_lengths: Vec<usize> = buffer
+        .split('\n')
+        .map(|text| text.strip_suffix('\r').unwrap_or(text).chars().count())
+        .collect();
+    let last_line = line_lengths
+        .len()
+        .saturating_sub(usize::from(buffer.ends_with('\n')));
+    let line = line.min(last_line);
+    let max_column = line_lengths
+        .get(line - 1)
+        .copied()
+        .expect("clamped line always indexes the precomputed line lengths")
+        + 1;
+    (line, column.min(max_column))
+}
+
 #[must_use]
 pub fn apply_replacements(
     buffer: &str,

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -128,15 +128,20 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     diagnostics
 }
 
-/// granit positions a tag on an implicit/empty scalar at the start of the
-/// following line, which is one past the last line when the input has no
-/// trailing newline. Clamp that overshoot back onto the last real line so a
-/// diagnostic never points outside the document.
+/// granit positions a tag on an implicit/empty scalar at the start of the line
+/// after its content. When that scalar ends the document the start lands on a
+/// line that does not really exist: the final empty segment a trailing newline
+/// produces, or one past the last line when there is no trailing newline.
+/// Clamp such overshoot back onto the last real line so a diagnostic never
+/// points at a phantom line (or outside the document).
 fn clamp_overshoot(buffer: &str, diagnostics: &mut [Violation]) {
-    let line_count = buffer.split('\n').count();
+    let last_line = buffer
+        .split('\n')
+        .count()
+        .saturating_sub(usize::from(buffer.ends_with('\n')));
     for violation in diagnostics {
-        if violation.line > line_count {
-            violation.line = line_count;
+        if violation.line > last_line {
+            violation.line = last_line;
         }
     }
 }

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -81,8 +81,10 @@ impl Config {
 
     fn diagnose(&self, tag: &Tag) -> Option<String> {
         // The non-specific "!" tag forces local resolution and carries no
-        // safety or portability signal, so no check applies.
-        if tag.handle.is_empty() && tag.suffix == "!" {
+        // safety or portability signal. A `%TAG` directive can resolve a
+        // non-empty handle onto it while leaving the suffix as "!", so key the
+        // exemption on the suffix rather than the handle representation.
+        if tag.suffix == "!" {
             return None;
         }
         let core = core_suffix(tag);

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -1,0 +1,205 @@
+//! `tags` rule &mdash; flags unsafe and non-portable YAML tags (issue #251).
+//!
+//! Three independent, off-by-default concerns share one tag-inspection pass over
+//! the parser's resolved `Scalar`/`SequenceStart`/`MappingStart` tags:
+//!
+//! * `forbid-unsafe-tags` &mdash; language-specific construction tags whose
+//!   suffix begins with a known construction namespace (`python/`, `ruby/`,
+//!   `perl/`, `php/`, `java/`, `java.`, `javax.`); the curated list is
+//!   best-effort, not exhaustive. These drive arbitrary-object construction in
+//!   some loaders; `PyYAML`'s docs warn `yaml.load` "is as powerful as
+//!   `pickle.load`" and recommend `safe_load`, and Ruby's Psych and `SnakeYAML`
+//!   expose the same pattern via `!ruby/object:` and `!!`-prefixed class tags.
+//! * `forbid-removed-types` &mdash; the YAML 1.1 types removed in 1.2 (`!!omap`,
+//!   `!!pairs`, `!!set`, `!!timestamp`, `!!binary`; YAML 1.2.2 changes page).
+//!   ryl targets YAML 1.2, so these are non-portable.
+//! * `allowed-tags` &mdash; when non-empty, any other local / non-core tag
+//!   (`!env`, `!include`, …) is flagged. Local tags "may even have different
+//!   semantics in different documents" (YAML 1.2.2 spec, tags), so an allowlist
+//!   lets a team permit only the handles it actually uses.
+//!
+//! Detection normalises tag spelling, so shorthand (`!!omap`), local
+//! (`!ruby/object:`), and verbatim (`!<tag:yaml.org,2002:omap>`) forms map to
+//! the same identity and cannot be used to evade a check.
+//!
+//! Sources: YAML 1.2.2 spec (tags); YAML 1.2.2 changes page; `PyYAML` docs; The
+//! YAML Company. There is no safe `--fix`: rewriting or dropping a tag changes
+//! the node's resolved type (see AGENTS.md "Rules Without A Safe `--fix`").
+
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver, Tag};
+
+use crate::config::YamlLintConfig;
+use crate::yaml_dom::YamlOwned;
+
+pub const ID: &str = "tags";
+
+const CORE_SCHEMA_PREFIX: &str = "tag:yaml.org,2002:";
+const UNSAFE_TAG_PREFIXES: [&str; 7] = [
+    "python/", "ruby/", "perl/", "php/", "java/", "java.", "javax.",
+];
+const REMOVED_TYPE_SUFFIXES: [&str; 5] =
+    ["omap", "pairs", "set", "timestamp", "binary"];
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    forbid_unsafe_tags: bool,
+    forbid_removed_types: bool,
+    allowed_tags: Vec<String>,
+}
+
+impl Config {
+    #[must_use]
+    /// Resolve the `tags` configuration from the parsed yamllint config.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `allowed-tags` holds a non-string entry; typed config
+    /// validation rejects such configs before `resolve` runs.
+    pub fn resolve(cfg: &YamlLintConfig) -> Self {
+        let mut allowed_tags = Vec::new();
+        if let Some(YamlOwned::Sequence(seq)) = cfg.rule_option(ID, "allowed-tags") {
+            for entry in seq {
+                allowed_tags.push(
+                    entry
+                        .as_str()
+                        .expect("typed config validation guarantees string allowed-tags items")
+                        .to_string(),
+                );
+            }
+        }
+        Self {
+            forbid_unsafe_tags: cfg.rule_option_bool(ID, "forbid-unsafe-tags", false),
+            forbid_removed_types: cfg.rule_option_bool(
+                ID,
+                "forbid-removed-types",
+                false,
+            ),
+            allowed_tags,
+        }
+    }
+
+    fn diagnose(&self, tag: &Tag) -> Option<String> {
+        // The non-specific "!" tag forces local resolution and carries no
+        // safety or portability signal, so no check applies.
+        if tag.handle.is_empty() && tag.suffix == "!" {
+            return None;
+        }
+        let core = core_suffix(tag);
+        if self.forbid_unsafe_tags
+            && unsafe_namespace(tag, core).is_some_and(is_unsafe_suffix)
+        {
+            return Some(format!("forbidden unsafe tag \"{}\"", shorthand(tag)));
+        }
+        if self.forbid_removed_types
+            && core.is_some_and(|suffix| REMOVED_TYPE_SUFFIXES.contains(&suffix))
+        {
+            return Some(format!(
+                "forbidden removed YAML 1.1 type \"{}\"",
+                shorthand(tag)
+            ));
+        }
+        if !self.allowed_tags.is_empty() && core.is_none() {
+            let shorthand = shorthand(tag);
+            if !self.allowed_tags.contains(&shorthand) {
+                return Some(format!("tag \"{shorthand}\" is not in allowed-tags"));
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+#[must_use]
+pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
+    let mut parser = Parser::new_from_str(buffer);
+    let mut receiver = TagsReceiver {
+        cfg,
+        diagnostics: Vec::new(),
+    };
+    let _ = parser.load(&mut receiver, true);
+    let mut diagnostics = receiver.diagnostics;
+    clamp_overshoot(buffer, &mut diagnostics);
+    diagnostics
+}
+
+/// granit positions a tag on an implicit/empty scalar at the start of the
+/// following line, which is one past the last line when the input has no
+/// trailing newline. Clamp that overshoot back onto the last real line so a
+/// diagnostic never points outside the document.
+fn clamp_overshoot(buffer: &str, diagnostics: &mut [Violation]) {
+    let line_count = buffer.split('\n').count();
+    for violation in diagnostics {
+        if violation.line > line_count {
+            violation.line = line_count;
+        }
+    }
+}
+
+struct TagsReceiver<'cfg> {
+    cfg: &'cfg Config,
+    diagnostics: Vec<Violation>,
+}
+
+impl<'input> SpannedEventReceiver<'input> for TagsReceiver<'_> {
+    fn on_event(&mut self, event: Event<'input>, span: Span) {
+        if let Some(tag) = event.tag()
+            && let Some(message) = self.cfg.diagnose(tag)
+        {
+            self.diagnostics.push(Violation {
+                line: span.start.line(),
+                column: span.start.col() + 1,
+                message,
+            });
+        }
+    }
+}
+
+fn is_unsafe_suffix(suffix: &str) -> bool {
+    UNSAFE_TAG_PREFIXES
+        .iter()
+        .any(|prefix| suffix.starts_with(prefix))
+}
+
+/// The core-schema type suffix this tag resolves to regardless of spelling
+/// (`!!omap` and verbatim `!<tag:yaml.org,2002:omap>` both yield `omap`), or
+/// `None` for any non-core tag.
+fn core_suffix(tag: &Tag) -> Option<&str> {
+    if tag.handle == CORE_SCHEMA_PREFIX {
+        Some(tag.suffix.as_str())
+    } else if tag.handle.is_empty() {
+        tag.suffix.strip_prefix(CORE_SCHEMA_PREFIX)
+    } else {
+        None
+    }
+}
+
+/// The construction namespace this tag could match, or `None` when its handle
+/// is a custom `%TAG` prefix (whose suffix is a local name in an unrelated
+/// namespace, so it must not be namespace-matched). Only core-schema (`!!`) and
+/// local (`!`/verbatim) tags carry a construction namespace in their suffix, so
+/// `!!python/…`, `!python/…`, and `!<!python/…>` all reduce to `python/…`.
+fn unsafe_namespace<'a>(tag: &'a Tag, core: Option<&'a str>) -> Option<&'a str> {
+    if let Some(core) = core {
+        Some(core)
+    } else if tag.handle == "!" || tag.handle.is_empty() {
+        Some(tag.suffix.strip_prefix('!').unwrap_or(&tag.suffix))
+    } else {
+        None
+    }
+}
+
+/// Render a tag in shorthand for diagnostics: `!!type` for core-schema tags
+/// however they were spelled, otherwise the parser's resolved `!handle`/prefix
+/// form (a custom `%TAG` handle renders as its resolved prefix).
+fn shorthand(tag: &Tag) -> String {
+    match core_suffix(tag) {
+        Some(suffix) => format!("!!{suffix}"),
+        None => tag.to_string(),
+    }
+}

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -29,6 +29,7 @@
 use granit_parser::{Event, Parser, Span, SpannedEventReceiver, Tag};
 
 use crate::config::YamlLintConfig;
+use crate::rules::support::span_utils;
 use crate::yaml_dom::YamlOwned;
 
 pub const ID: &str = "tags";
@@ -128,21 +129,15 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     diagnostics
 }
 
-/// granit positions a tag on an implicit/empty scalar at the start of the line
-/// after its content. When that scalar ends the document the start lands on a
-/// line that does not really exist: the final empty segment a trailing newline
-/// produces, or one past the last line when there is no trailing newline.
-/// Clamp such overshoot back onto the last real line so a diagnostic never
-/// points at a phantom line (or outside the document).
+/// A tag on an implicit/empty scalar that ends the document is positioned by
+/// granit at a virtual location that can fall outside the document (see
+/// [`span_utils::clamp_position`]); clamp it back onto a real position.
 fn clamp_overshoot(buffer: &str, diagnostics: &mut [Violation]) {
-    let last_line = buffer
-        .split('\n')
-        .count()
-        .saturating_sub(usize::from(buffer.ends_with('\n')));
     for violation in diagnostics {
-        if violation.line > last_line {
-            violation.line = last_line;
-        }
+        let (line, column) =
+            span_utils::clamp_position(buffer, violation.line, violation.column);
+        violation.line = line;
+        violation.column = column;
     }
 }
 

--- a/tests/cli_tags_rule.rs
+++ b/tests/cli_tags_rule.rs
@@ -192,6 +192,24 @@ fn non_specific_bare_tag_is_not_flagged() {
 }
 
 #[test]
+fn non_specific_bare_tag_stays_exempt_under_tag_directive() {
+    // A `%TAG` directive must not turn the non-specific `!` into a flagged
+    // custom tag; the exemption keys on the suffix, not the handle.
+    let (code, output) = lint_with_toml_config(
+        "%TAG ! tag:example.com,2000:\n---\na: ! plain\n",
+        "[rules.tags]\nallowed-tags = [\"!keep\"]\n",
+    );
+    assert_eq!(
+        code, 0,
+        "bare ! must stay exempt under a %TAG directive: {output}"
+    );
+    assert!(
+        output.trim().is_empty(),
+        "expected no diagnostics: {output}"
+    );
+}
+
+#[test]
 fn tag_on_trailing_empty_scalar_points_at_its_content_line() {
     // granit positions the empty scalar on the blank segment after the final
     // newline; the diagnostic must clamp back to the tag's content line so it

--- a/tests/cli_tags_rule.rs
+++ b/tests/cli_tags_rule.rs
@@ -188,6 +188,29 @@ fn non_specific_bare_tag_is_not_flagged() {
 }
 
 #[test]
+fn tag_on_trailing_empty_scalar_points_at_its_content_line() {
+    // granit positions the empty scalar on the blank segment after the final
+    // newline; the diagnostic must clamp back to the tag's content line so it
+    // is suppressible with a `disable-line` on that line.
+    let (code, output) = lint_with_inline_config(
+        "x: 1\nb: !!omap\n",
+        "rules: {tags: {forbid-removed-types: true}}",
+    );
+    assert_eq!(
+        code, 1,
+        "trailing empty tagged scalar should fail: {output}"
+    );
+    assert!(
+        output.contains("2:1"),
+        "must point at the content line (2), not the phantom trailing line 3: {output}"
+    );
+    assert!(
+        !output.contains("3:1"),
+        "must not overshoot onto the trailing empty segment: {output}"
+    );
+}
+
+#[test]
 fn tag_on_implicit_scalar_without_trailing_newline_stays_in_bounds() {
     let (code, output) = lint_with_inline_config(
         "!!python/object",

--- a/tests/cli_tags_rule.rs
+++ b/tests/cli_tags_rule.rs
@@ -15,21 +15,25 @@ fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
     if stderr.is_empty() { stdout } else { stderr }
 }
 
-fn lint_with_inline_config(content: &str, config: &str) -> (i32, String) {
+/// `tags` is a ryl-only rule, so it is configured through TOML rather than the
+/// yamllint-compatible YAML config that `-d` carries.
+fn lint_with_toml_config(content: &str, config: &str) -> (i32, String) {
     let dir = tempdir().unwrap();
     let file = dir.path().join("doc.yaml");
     fs::write(&file, content).unwrap();
+    let config_path = dir.path().join(".ryl.toml");
+    fs::write(&config_path, config).unwrap();
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, stdout, stderr) =
-        run(Command::new(exe).arg("-d").arg(config).arg(&file));
+        run(Command::new(exe).arg("-c").arg(&config_path).arg(&file));
     (code, command_output(&stdout, &stderr).to_string())
 }
 
 #[test]
 fn unsafe_tags_flagged_for_core_and_local_namespaces() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "exec: !!python/object/apply:os.system [\"id\"]\nobj: !ruby/object:Foo {}\nplain: !!str value\n",
-        "rules: {tags: {forbid-unsafe-tags: true}}",
+        "[rules.tags]\nforbid-unsafe-tags = true\n",
     );
     assert_eq!(code, 1, "unsafe tags should fail: {output}");
     assert!(
@@ -51,9 +55,9 @@ fn unsafe_tags_flagged_for_core_and_local_namespaces() {
 
 #[test]
 fn removed_yaml_1_1_types_flagged_for_core_schema_only() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "a: !!omap []\nb: !!set {}\nc: !env X\nd: !!str s\n",
-        "rules: {tags: {forbid-removed-types: true}}",
+        "[rules.tags]\nforbid-removed-types = true\n",
     );
     assert_eq!(code, 1, "removed types should fail: {output}");
     assert!(
@@ -78,9 +82,9 @@ fn removed_yaml_1_1_types_flagged_for_core_schema_only() {
 
 #[test]
 fn allowed_tags_flags_only_unlisted_custom_tags() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "a: !env X\nb: !keep Y\nc: !!omap []\nd: !!str s\n",
-        "rules: {tags: {allowed-tags: [\"!keep\"]}}",
+        "[rules.tags]\nallowed-tags = [\"!keep\"]\n",
     );
     assert_eq!(code, 1, "unlisted custom tag should fail: {output}");
     assert!(
@@ -100,9 +104,9 @@ fn allowed_tags_flags_only_unlisted_custom_tags() {
 
 #[test]
 fn enabled_with_all_options_off_reports_nothing() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "a: !env X\nb: !!omap []\nc: !!python/object:Foo {}\n",
-        "rules: {tags: enable}",
+        "[rules]\ntags = \"enable\"\n",
     );
     assert_eq!(code, 0, "no option enabled means no diagnostics: {output}");
     assert!(output.trim().is_empty(), "expected no output: {output}");
@@ -110,9 +114,9 @@ fn enabled_with_all_options_off_reports_nothing() {
 
 #[test]
 fn multibyte_key_column_is_char_based() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "café: !!omap []\n",
-        "rules: {tags: {forbid-removed-types: true}}",
+        "[rules.tags]\nforbid-removed-types = true\n",
     );
     assert_eq!(code, 1, "removed type should fail: {output}");
     assert!(
@@ -123,9 +127,9 @@ fn multibyte_key_column_is_char_based() {
 
 #[test]
 fn tags_rule_does_not_fire_when_not_enabled() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "exec: !!python/object/apply:os.system [\"id\"]\n",
-        "rules: {truthy: enable}",
+        "[rules]\ntruthy = \"enable\"\n",
     );
     assert_eq!(code, 0, "tags off by default: {output}");
     assert!(
@@ -136,9 +140,9 @@ fn tags_rule_does_not_fire_when_not_enabled() {
 
 #[test]
 fn verbatim_and_javax_tag_spellings_are_normalised_and_detected() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "a: !<tag:yaml.org,2002:omap> []\nb: !<!python/object> {}\nc: !!javax.script.ScriptEngineManager {}\n",
-        "rules: {tags: {forbid-unsafe-tags: true, forbid-removed-types: true}}",
+        "[rules.tags]\nforbid-unsafe-tags = true\nforbid-removed-types = true\n",
     );
     assert_eq!(code, 1, "verbatim/javax tags should fail: {output}");
     assert!(
@@ -157,9 +161,9 @@ fn verbatim_and_javax_tag_spellings_are_normalised_and_detected() {
 
 #[test]
 fn custom_tag_directive_handle_is_not_namespace_matched() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "%TAG !e! tag:example.com,2000:\n---\nx: !e!python/object value\n",
-        "rules: {tags: {forbid-unsafe-tags: true}}",
+        "[rules.tags]\nforbid-unsafe-tags = true\n",
     );
     assert_eq!(
         code, 0,
@@ -173,9 +177,9 @@ fn custom_tag_directive_handle_is_not_namespace_matched() {
 
 #[test]
 fn non_specific_bare_tag_is_not_flagged() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "a: ! plain\n",
-        "rules: {tags: {allowed-tags: [\"!keep\"]}}",
+        "[rules.tags]\nallowed-tags = [\"!keep\"]\n",
     );
     assert_eq!(
         code, 0,
@@ -192,9 +196,9 @@ fn tag_on_trailing_empty_scalar_points_at_its_content_line() {
     // granit positions the empty scalar on the blank segment after the final
     // newline; the diagnostic must clamp back to the tag's content line so it
     // is suppressible with a `disable-line` on that line.
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "x: 1\nb: !!omap\n",
-        "rules: {tags: {forbid-removed-types: true}}",
+        "[rules.tags]\nforbid-removed-types = true\n",
     );
     assert_eq!(
         code, 1,
@@ -212,9 +216,9 @@ fn tag_on_trailing_empty_scalar_points_at_its_content_line() {
 
 #[test]
 fn tag_on_implicit_scalar_without_trailing_newline_stays_in_bounds() {
-    let (code, output) = lint_with_inline_config(
+    let (code, output) = lint_with_toml_config(
         "!!python/object",
-        "rules: {tags: {forbid-unsafe-tags: true}}",
+        "[rules.tags]\nforbid-unsafe-tags = true\n",
     );
     assert_eq!(code, 1, "unsafe tag should fail: {output}");
     assert!(
@@ -224,6 +228,34 @@ fn tag_on_implicit_scalar_without_trailing_newline_stays_in_bounds() {
     assert!(
         !output.contains("2:1"),
         "must not report an out-of-bounds line: {output}"
+    );
+}
+
+#[test]
+fn tags_rule_is_rejected_in_yaml_config() {
+    // `tags` is ryl-only; yamllint-compatible YAML config (here via `-d`) must
+    // reject it rather than silently linting or clashing with a future yamllint
+    // `tags` rule.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "a: !!omap []\n").unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules: {tags: {forbid-removed-types: true}}")
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "a ryl-only rule in YAML config is a usage error: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert!(
+        output.contains("tags"),
+        "error should name the rule: {output}"
+    );
+    assert!(
+        output.to_lowercase().contains("toml"),
+        "error should point to TOML config: {output}"
     );
 }
 
@@ -258,10 +290,10 @@ fn rule_ignore_skips_file() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("ignored.yaml");
     fs::write(&file, "value: !!omap []\n").unwrap();
-    let config = dir.path().join("config.yml");
+    let config = dir.path().join(".ryl.toml");
     fs::write(
         &config,
-        "rules:\n  tags:\n    forbid-removed-types: true\n    ignore:\n      - ignored.yaml\n",
+        "[rules.tags]\nforbid-removed-types = true\nignore = [\"ignored.yaml\"]\n",
     )
     .unwrap();
 

--- a/tests/cli_tags_rule.rs
+++ b/tests/cli_tags_rule.rs
@@ -1,0 +1,254 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
+    if stderr.is_empty() { stdout } else { stderr }
+}
+
+fn lint_with_inline_config(content: &str, config: &str) -> (i32, String) {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, content).unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-d").arg(config).arg(&file));
+    (code, command_output(&stdout, &stderr).to_string())
+}
+
+#[test]
+fn unsafe_tags_flagged_for_core_and_local_namespaces() {
+    let (code, output) = lint_with_inline_config(
+        "exec: !!python/object/apply:os.system [\"id\"]\nobj: !ruby/object:Foo {}\nplain: !!str value\n",
+        "rules: {tags: {forbid-unsafe-tags: true}}",
+    );
+    assert_eq!(code, 1, "unsafe tags should fail: {output}");
+    assert!(
+        output.contains("forbidden unsafe tag \"!!python/object/apply:os.system\""),
+        "core-schema python tag message missing: {output}"
+    );
+    assert!(output.contains("1:39"), "python tag position: {output}");
+    assert!(
+        output.contains("forbidden unsafe tag \"!ruby/object:Foo\""),
+        "local ruby tag message missing: {output}"
+    );
+    assert!(output.contains("2:23"), "ruby tag position: {output}");
+    assert!(output.contains("tags"), "rule id missing: {output}");
+    assert!(
+        !output.contains("!!str"),
+        "standard core tag must not be flagged as unsafe: {output}"
+    );
+}
+
+#[test]
+fn removed_yaml_1_1_types_flagged_for_core_schema_only() {
+    let (code, output) = lint_with_inline_config(
+        "a: !!omap []\nb: !!set {}\nc: !env X\nd: !!str s\n",
+        "rules: {tags: {forbid-removed-types: true}}",
+    );
+    assert_eq!(code, 1, "removed types should fail: {output}");
+    assert!(
+        output.contains("forbidden removed YAML 1.1 type \"!!omap\""),
+        "omap message missing: {output}"
+    );
+    assert!(output.contains("1:11"), "omap position: {output}");
+    assert!(
+        output.contains("forbidden removed YAML 1.1 type \"!!set\""),
+        "set message missing: {output}"
+    );
+    assert!(output.contains("2:10"), "set position: {output}");
+    assert!(
+        !output.contains("!env"),
+        "local tag is not a removed core type: {output}"
+    );
+    assert!(
+        !output.contains("!!str"),
+        "standard core type must not be flagged: {output}"
+    );
+}
+
+#[test]
+fn allowed_tags_flags_only_unlisted_custom_tags() {
+    let (code, output) = lint_with_inline_config(
+        "a: !env X\nb: !keep Y\nc: !!omap []\nd: !!str s\n",
+        "rules: {tags: {allowed-tags: [\"!keep\"]}}",
+    );
+    assert_eq!(code, 1, "unlisted custom tag should fail: {output}");
+    assert!(
+        output.contains("tag \"!env\" is not in allowed-tags"),
+        "unlisted tag message missing: {output}"
+    );
+    assert!(output.contains("1:9"), "!env position: {output}");
+    assert!(
+        !output.contains("!keep"),
+        "allowlisted tag must not be flagged: {output}"
+    );
+    assert!(
+        !output.contains("!!omap"),
+        "core-schema tag is not policed by allowed-tags: {output}"
+    );
+}
+
+#[test]
+fn enabled_with_all_options_off_reports_nothing() {
+    let (code, output) = lint_with_inline_config(
+        "a: !env X\nb: !!omap []\nc: !!python/object:Foo {}\n",
+        "rules: {tags: enable}",
+    );
+    assert_eq!(code, 0, "no option enabled means no diagnostics: {output}");
+    assert!(output.trim().is_empty(), "expected no output: {output}");
+}
+
+#[test]
+fn multibyte_key_column_is_char_based() {
+    let (code, output) = lint_with_inline_config(
+        "café: !!omap []\n",
+        "rules: {tags: {forbid-removed-types: true}}",
+    );
+    assert_eq!(code, 1, "removed type should fail: {output}");
+    assert!(
+        output.contains("1:14"),
+        "char-based column past the multibyte key: {output}"
+    );
+}
+
+#[test]
+fn tags_rule_does_not_fire_when_not_enabled() {
+    let (code, output) = lint_with_inline_config(
+        "exec: !!python/object/apply:os.system [\"id\"]\n",
+        "rules: {truthy: enable}",
+    );
+    assert_eq!(code, 0, "tags off by default: {output}");
+    assert!(
+        !output.contains("tags"),
+        "tags must not run unless enabled: {output}"
+    );
+}
+
+#[test]
+fn verbatim_and_javax_tag_spellings_are_normalised_and_detected() {
+    let (code, output) = lint_with_inline_config(
+        "a: !<tag:yaml.org,2002:omap> []\nb: !<!python/object> {}\nc: !!javax.script.ScriptEngineManager {}\n",
+        "rules: {tags: {forbid-unsafe-tags: true, forbid-removed-types: true}}",
+    );
+    assert_eq!(code, 1, "verbatim/javax tags should fail: {output}");
+    assert!(
+        output.contains("forbidden removed YAML 1.1 type \"!!omap\""),
+        "verbatim core tag should normalise to !!omap: {output}"
+    );
+    assert!(
+        output.contains("forbidden unsafe tag \"!python/object\""),
+        "verbatim local construction tag should be flagged: {output}"
+    );
+    assert!(
+        output.contains("forbidden unsafe tag \"!!javax.script.ScriptEngineManager\""),
+        "javax gadget namespace should be flagged: {output}"
+    );
+}
+
+#[test]
+fn custom_tag_directive_handle_is_not_namespace_matched() {
+    let (code, output) = lint_with_inline_config(
+        "%TAG !e! tag:example.com,2000:\n---\nx: !e!python/object value\n",
+        "rules: {tags: {forbid-unsafe-tags: true}}",
+    );
+    assert_eq!(
+        code, 0,
+        "a custom %TAG handle resolves its suffix into an unrelated namespace and must not be flagged: {output}"
+    );
+    assert!(
+        output.trim().is_empty(),
+        "expected no diagnostics: {output}"
+    );
+}
+
+#[test]
+fn non_specific_bare_tag_is_not_flagged() {
+    let (code, output) = lint_with_inline_config(
+        "a: ! plain\n",
+        "rules: {tags: {allowed-tags: [\"!keep\"]}}",
+    );
+    assert_eq!(
+        code, 0,
+        "the non-specific '!' tag carries no signal: {output}"
+    );
+    assert!(
+        output.trim().is_empty(),
+        "expected no diagnostics: {output}"
+    );
+}
+
+#[test]
+fn tag_on_implicit_scalar_without_trailing_newline_stays_in_bounds() {
+    let (code, output) = lint_with_inline_config(
+        "!!python/object",
+        "rules: {tags: {forbid-unsafe-tags: true}}",
+    );
+    assert_eq!(code, 1, "unsafe tag should fail: {output}");
+    assert!(
+        output.contains("1:1"),
+        "position must stay on the only line, not overshoot to line 2: {output}"
+    );
+    assert!(
+        !output.contains("2:1"),
+        "must not report an out-of-bounds line: {output}"
+    );
+}
+
+#[test]
+fn per_file_ignores_accept_the_tags_rule_name() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ignored.yaml");
+    fs::write(&file, "a: !!omap []\n").unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        format!(
+            "[rules.tags]\nforbid-removed-types = true\n[per-file-ignores]\n'{}' = ['tags']\n",
+            file.display()
+        ),
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "per-file-ignores should suppress tags: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+}
+
+#[test]
+fn rule_ignore_skips_file() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ignored.yaml");
+    fs::write(&file, "value: !!omap []\n").unwrap();
+    let config = dir.path().join("config.yml");
+    fs::write(
+        &config,
+        "rules:\n  tags:\n    forbid-removed-types: true\n    ignore:\n      - ignored.yaml\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "ignored file should pass: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+}

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -94,6 +94,7 @@ const RULE_TRIGGERS: &[(&str, &str)] = &[
     ("new-lines", "a: 1\r\n"),
     ("octal-values", "a: 010\n"),
     ("quoted-strings", "a: 'plain'\n"),
+    ("tags", "a: !!omap []\n"),
     ("trailing-spaces", "a: 1   \n"),
     ("truthy", "a: Yes\n"),
 ];

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -46,10 +46,6 @@ const TRIGGER_ALL_RULES: &str = "rules:
   quoted-strings:
     quote-type: single
     required: only-when-needed
-  tags:
-    forbid-unsafe-tags: true
-    forbid-removed-types: true
-    allowed-tags: ['!keep']
   trailing-spaces: enable
   truthy: enable
 ";
@@ -59,6 +55,23 @@ pub fn trigger_all_config() -> &'static YamlLintConfig {
     static CONFIG: LazyLock<YamlLintConfig> = LazyLock::new(|| {
         YamlLintConfig::from_yaml_str(TRIGGER_ALL_RULES)
             .expect("property-check trigger config must parse")
+    });
+    &CONFIG
+}
+
+// `tags` is ryl-only, so it is configured through TOML rather than the YAML
+// trigger above (yamllint-compatible YAML config rejects ryl-only rules).
+const TAGS_RULE_TOML: &str = "[rules.tags]
+forbid-unsafe-tags = true
+forbid-removed-types = true
+allowed-tags = [\"!keep\"]
+";
+
+#[must_use]
+pub fn tags_config() -> &'static YamlLintConfig {
+    static CONFIG: LazyLock<YamlLintConfig> = LazyLock::new(|| {
+        YamlLintConfig::from_toml_str(TAGS_RULE_TOML)
+            .expect("property-check tags trigger config must parse")
     });
     &CONFIG
 }
@@ -99,7 +112,7 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     collect_standard!(spans, cfg, content, ryl::rules::line_length);
     collect_standard!(spans, cfg, content, ryl::rules::octal_values);
     collect_standard!(spans, cfg, content, ryl::rules::quoted_strings);
-    collect_standard!(spans, cfg, content, ryl::rules::tags);
+    collect_standard!(spans, tags_config(), content, ryl::rules::tags);
     collect_standard!(spans, cfg, content, ryl::rules::truthy);
 
     if let Some(violation) = new_line_at_end_of_file::check(content) {

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -46,6 +46,10 @@ const TRIGGER_ALL_RULES: &str = "rules:
   quoted-strings:
     quote-type: single
     required: only-when-needed
+  tags:
+    forbid-unsafe-tags: true
+    forbid-removed-types: true
+    allowed-tags: ['!keep']
   trailing-spaces: enable
   truthy: enable
 ";
@@ -95,6 +99,7 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     collect_standard!(spans, cfg, content, ryl::rules::line_length);
     collect_standard!(spans, cfg, content, ryl::rules::octal_values);
     collect_standard!(spans, cfg, content, ryl::rules::quoted_strings);
+    collect_standard!(spans, cfg, content, ryl::rules::tags);
     collect_standard!(spans, cfg, content, ryl::rules::truthy);
 
     if let Some(violation) = new_line_at_end_of_file::check(content) {

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -142,7 +142,7 @@ fn arb_key() -> impl Strategy<Value = String> {
     ]
 }
 
-fn arb_value() -> impl Strategy<Value = String> {
+fn arb_bare_value() -> impl Strategy<Value = String> {
     prop_oneof![
         Just(String::new()),
         Just("value".to_string()),
@@ -169,6 +169,40 @@ fn arb_value() -> impl Strategy<Value = String> {
         Just("word ".repeat(8)),
         arb_multibyte().prop_map(|ch| format!("v{ch}")),
     ]
+}
+
+// Tag tokens spanning shorthand, local, verbatim, and non-specific forms. They
+// are synthesized onto values so the no-panic / in-bounds-span invariants run
+// over tagged nodes — exercising `tags::check`, the spelling normalisation, and
+// `clamp_overshoot` across positions, multibyte chars, and LF/CRLF. This suite
+// only asserts those invariants; tag-handling correctness lives in the
+// deterministic CLI tests.
+fn arb_tag() -> impl Strategy<Value = &'static str> {
+    prop_oneof![
+        Just("!!str"),
+        Just("!!omap"),
+        Just("!!set"),
+        Just("!!python/object/apply:os.system"),
+        Just("!!javax.script.ScriptEngineManager"),
+        Just("!env"),
+        Just("!keep"),
+        Just("!ruby/object:Foo"),
+        Just("!<tag:yaml.org,2002:int>"),
+        Just("!<!python/object>"),
+        Just("!"),
+    ]
+}
+
+fn arb_value() -> impl Strategy<Value = String> {
+    (prop::option::weighted(0.35, arb_tag()), arb_bare_value()).prop_map(
+        |(tag, base)| match tag {
+            None => base,
+            // An empty base leaves the tag on an implicit scalar — the
+            // `clamp_overshoot` hot path when it ends the document.
+            Some(tag) if base.is_empty() => tag.to_string(),
+            Some(tag) => format!("{tag} {base}"),
+        },
+    )
 }
 
 fn arb_text() -> impl Strategy<Value = String> {

--- a/tests/property_config/strategy.rs
+++ b/tests/property_config/strategy.rs
@@ -111,6 +111,14 @@ const CATALOG: &[(&str, &[(&str, OptValKind)])] = &[
         "octal-values",
         &[("forbid-implicit-octal", OptValKind::Bool)],
     ),
+    (
+        "tags",
+        &[
+            ("forbid-unsafe-tags", OptValKind::Bool),
+            ("forbid-removed-types", OptValKind::Bool),
+            ("allowed-tags", OptValKind::RegexList),
+        ],
+    ),
 ];
 
 fn arb_rule() -> impl Strategy<Value = RuleCfg> {

--- a/tests/proptest-regressions/property_check.txt
+++ b/tests/proptest-regressions/property_check.txt
@@ -4,3 +4,5 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
+cc afbed5030bb188e9fdcea91e51ced44ea1d3a5f12d2eecdcc118368136501a98 # shrinks to document = Document { lines: [(Entry { indent: 0, key: "a", spaces_before_colon: 0, spaces_after_colon: 1, value: "!!str", comment: None, trailing_spaces: 0 }, Lf)], has_final_newline: false }
+cc 8c31c9ffc16f374378a2b5ed23a75f1658e8a29b0b354ed9d8d8e09a53c09427 # shrinks to document = Document { lines: [(Entry { indent: 2, key: "a", spaces_before_colon: 0, spaces_after_colon: 1, value: "!!str", comment: None, trailing_spaces: 0 }, Lf), (Blank { spaces: 1 }, Lf)], has_final_newline: false }

--- a/tests/rule_empty_values.rs
+++ b/tests/rule_empty_values.rs
@@ -97,6 +97,25 @@ fn handles_alias_nodes() {
 }
 
 #[test]
+fn clamps_tagged_empty_value_at_eof_into_bounds() {
+    // `a: !!str` is a tagged but empty value; granit positions the implicit
+    // scalar on a non-existent next line. Without a trailing newline the report
+    // must clamp onto the only real line, not overshoot to line 2 (found by the
+    // property-check fuzzer once it began synthesizing tags).
+    let yaml = "a: !!str";
+    let cfg = resolve_config("rules:\n  empty-values: enable\n");
+    let hits = empty_values::check(yaml, &cfg);
+    assert_eq!(
+        hits,
+        vec![Violation {
+            line: 1,
+            column: 2,
+            message: "empty value in block mapping".to_string(),
+        }]
+    );
+}
+
+#[test]
 fn covers_nothing_event_branch() {
     empty_values::coverage_touch_nothing_branch();
 }

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Implements the first Tier-1 sub-issue of the rule-backlog epic (#261): a new
opt-in `tags` rule that inspects each node's resolved YAML tag.

## Rule (all options off by default)

- **`forbid-unsafe-tags`** — language-specific construction tags whose suffix
  begins with a curated namespace (`python/`, `ruby/`, `perl/`, `php/`,
  `java/`, `java.`, `javax.`). Detection normalises tag spelling, so shorthand
  (`!!python/object`), local (`!ruby/object:`), and verbatim
  (`!<!python/object>`) forms all match; a custom `%TAG`-remapped handle whose
  suffix merely *looks* like a namespace is **not** flagged.
- **`forbid-removed-types`** — the YAML 1.1 types removed in 1.2: `!!omap`,
  `!!pairs`, `!!set`, `!!timestamp`, `!!binary` (matched however spelled).
- **`allowed-tags`** — when non-empty, any other local / non-core tag (e.g.
  `!env`) not on the list is reported.

## Wiring & tests

- Dispatched from `lint_str`; registered in `ALL_RULE_IDS` (so inline
  `# ryl disable` covers it); added to the TOML + YAML config schema
  (`TagsOptions`), the serializer, the regenerated JSON schemas, and the
  `.ryl.toml.example`.
- No safe `--fix` (rewriting a tag changes the node's resolved type) — listed
  in `AGENTS.md` "Rules Without A Safe `--fix`".
- Documented in `docs/rules/tags.md` with multi-source citations.
- Covered by CLI/system tests, `property_check` (bounds + trigger), and
  `property_config` (config robustness); `coverage-missing.sh` reports zero
  missed lines/regions.

## Review

Reviewed at extra-high effort (`/code-review`) and iterated with a local Codex
review until it reported no remaining actionable findings. Fixes that landed:
out-of-bounds position on tags attached to an empty/implicit scalar; verbatim
`!<...>` tags evading the unsafe/removed checks; `javax.` gadget namespace;
bare non-specific `!` false positive; and `%TAG`-remapped-handle false positive.

Bumps the version `0.12.0` → `0.13.0` (minor: new feature).