### PR TITLE
docs: fix incorrect yaml-files key in TOML config examples

### DIFF
--- a/docs/config-presets.md
+++ b/docs/config-presets.md
@@ -6,7 +6,12 @@ These TOML presets mirror the built-in YAML presets in `ryl` (`default`,
 ## `default` (TOML equivalent)
 
 ```toml
-yaml-files = ["*.yaml", "*.yml", ".yamllint"]
+[files]
+yaml = [
+    "*.yaml",
+    "*.yml",
+    ".yamllint",
+]
 
 [rules]
 anchors = "enable"
@@ -45,7 +50,12 @@ level = "warning"
 ## `relaxed` (TOML equivalent, fully expanded)
 
 ```toml
-yaml-files = ["*.yaml", "*.yml", ".yamllint"]
+[files]
+yaml = [
+    "*.yaml",
+    "*.yml",
+    ".yamllint",
+]
 
 [rules]
 anchors = "enable"

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -93,7 +93,12 @@ migrated config ends up enabling no rules.
 === "ryl (.ryl.toml)"
 
     ```toml
-    yaml-files = ["*.yaml", "*.yml", ".yamllint"]
+    [files]
+    yaml = [
+        "*.yaml",
+        "*.yml",
+        ".yamllint",
+    ]
 
     [rules]
     anchors = "enable"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -87,7 +87,12 @@ configuration is flat &mdash; copy the preset you want from
 [Configuration presets](../config-presets.md) and customise from there:
 
 ```toml
-yaml-files = ["*.yaml", "*.yml", ".yamllint"]
+[files]
+yaml = [
+    "*.yaml",
+    "*.yml",
+    ".yamllint",
+]
 
 # ... rule enable/disable table from the preset ...
 


### PR DESCRIPTION
## Summary

The [config presets documentation](https://ryl-docs.pages.dev/config-presets/) shows TOML examples using the `yaml-files` top-level key. Copying them verbatim produces:

```console
$ ryl --version
ryl 0.12.0
$ ryl ./
invalid config: `yaml-files` is not valid in TOML; use `[files]` with `yaml = [...]` instead
```

The `[files]` table was introduced in #237 but the preset examples in `docs/config-presets.md` were not updated. This PR corrects them to use `[files].yaml`.

## Out of scope

Two related inconsistencies exist but are left unchanged, as I lack the knowledge to judge whether they need fixing:

- `tests/config_schema.rs` — `generated_schema_accepts_valid_sample_config` and `typed_toml_parser_reads_project_toml` pass `yaml-files` in a TOML fixture and expect success, whereas the high-level config resolver rejects it.
  https://github.com/owenlamont/ryl/blob/e6d97904ded8d736c7f5efe0b0baf7e5b6d16b9e/tests/config_schema.rs#L90-L99
- `tests/fixtures/schemastore/ryl-valid.toml` — contains `yaml-files = [...]` and is asserted valid by `schemastore_toml_schema_validates_repo_fixtures`, meaning the SchemaStore TOML schema currently accepts a key that the runtime rejects.
  https://github.com/owenlamont/ryl/blob/e6d97904ded8d736c7f5efe0b0baf7e5b6d16b9e/tests/fixtures/schemastore/ryl-valid.toml#L2