### PR TITLE
ci: request workflows permission for the SchemaStore-sync app token

### DIFF
--- a/.github/workflows/sync-schemastore.yml
+++ b/.github/workflows/sync-schemastore.yml
@@ -122,6 +122,10 @@ jobs:
           owner: owenlamont
           repositories: schemastore
           permission-contents: write
+          # The branch is built on upstream/master, so it carries upstream's
+          # .github/workflows files; pushing them needs workflows write even
+          # though only ryl's own files change in the commit.
+          permission-workflows: write
 
       - name: Update SchemaStore fork branch
         if: steps.compare.outputs.schemas_match == 'false' && inputs.dry_run != true


### PR DESCRIPTION
## Why

The v0.13.0 release's `Sync SchemaStore` job failed at the fork push:

```
remote rejected ryl-schema-update -> ryl-schema-update
  (refusing to allow a GitHub App to create or update workflow
   .github/workflows/auto-update.yml without `workflows` permission)
```

`sync-schemastore.yml` builds `ryl-schema-update` from `upstream/master` and force-pushes it, so the branch necessarily carries upstream's `.github/workflows/*` files. The app token was minted with only `permission-contents: write`, so GitHub blocks the push whenever the fork trails upstream across a workflow-file change (which it now does — the fork was ~114 commits behind).

## Change

Request `permission-workflows: write` when minting the token. The `Create PR Workflow Auth` app already holds this permission, so this only widens the minted token — no app-settings change needed. The push then succeeds regardless of how stale the fork's `master` is, so no manual fork-sync is required per release.

## Validation

The patch doesn't run on PR CI (the sync workflow is `workflow_call`/`workflow_dispatch`). After merge it's exercised by the next release, or by a manual `workflow_dispatch` of `Sync SchemaStore` on `main`.