### PR TITLE
docs: correct stale `empty` preset references for TOML

### DIFF
--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -54,8 +54,9 @@ produced.
   directory.
 - The three built-in presets &mdash; `default`, `relaxed`, and `empty` &mdash;
   match yamllint's behaviour. YAML configs can still use `extends:` to
-  reference them; TOML configs must inline the preset content (see the
-  example below). The full preset content is in
+  reference them; TOML configs must inline the `default`/`relaxed` content (see
+  the example below). `empty` has no usable TOML form because ryl rejects a
+  config that enables no rules. The full preset content is in
   [Configuration presets](../config-presets.md).
 - Inline `# yamllint disable` / `disable-line` / `enable` comments are honoured
   with the same grammar and semantics, so existing in-file suppressions keep

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,6 +109,6 @@ behaviour.
 
 -   [:octicons-gear-24: __Configuration presets__](config-presets.md)
 
-    `default`, `relaxed`, and `empty` as TOML or YAML.
+    `default` and `relaxed` as TOML or YAML, plus the YAML-only `empty`.
 
 </div>

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -92,9 +92,10 @@ truthy = "disable"
 key-ordering = "enable"
 ```
 
-Enabling a rule without options applies its defaults. The three built-in
-presets &mdash; `default`, `relaxed`, and `empty` &mdash; cover the common
-starting points; see [Configuration presets](config-presets.md).
+Enabling a rule without options applies its defaults. The built-in `default`
+and `relaxed` presets cover the common starting points (the `empty` preset is
+YAML-`extends:` only, with no usable TOML form); see
+[Configuration presets](config-presets.md).
 
 To switch rules off for part of a file with `# ryl disable` /
 `# yamllint disable` comments, see [Inline directives](directives.md).


### PR DESCRIPTION
## What

Since v0.12.0 ryl rejects any config that enables no rules, so the `empty`
preset has **no usable TOML form** — it survives only as a base for `extends:`
in YAML config (`extends: empty` plus at least one rule). Three docs still
implied `empty` was usable in TOML.

Behavior confirmed against the repo binary (0.13.0):

- `extends: empty` alone → exit 2, *"configuration enables no rules"*
- `extends: empty` + ≥1 rule → works
- TOML empty `[rules]` / `[tool.ryl]` → rejected

## Changes

- **`docs/index.md`** — preset card claimed `empty` works "as TOML or YAML" →
  now "`default` and `relaxed` as TOML or YAML, plus the YAML-only `empty`".
- **`docs/rules.md`** — the TOML config reference listed `empty` as a TOML
  starting point → now notes it is YAML-`extends:` only, with no usable TOML
  form.
- **`docs/getting-started/migrating-from-yamllint.md`** — "TOML configs must
  inline the preset content" didn't hold for `empty` → added the caveat that
  `empty` has no usable TOML form.

Docs-only; no behavior change. `docs/config-presets.md`, `quickstart.md`, and
`README.md` already described `empty` correctly and were left untouched.

`prek run --all-files` passes (rumdl, ryl, typos, …).