### PR TITLE
Add `unicode-line-breaks` rule; gate `--fix` on parseable YAML (closes #253)

### DIFF
--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -150,3 +150,6 @@ level = "warning"
 level = "warning"
 allowed-values = ["true", "false", "yes", "no"]
 check-keys = false
+
+[rules.unicode-line-breaks]
+level = "warning"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,14 +182,18 @@ ryl is a CLI tool for linting yaml files
 ### Property Tests For Safe Fixes
 
 `tests/property_safe_fix.rs` runs `proptest`-generated YAML through `apply_safe_fixes`
-and asserts four invariants: idempotence, no remaining safe-fix-rule diagnostics
-after fixing, parse preservation (input that parses must produce output that
-parses to an equal `YamlOwned` value), and that a leading `# ryl disable` makes the
-fix a byte-for-byte no-op (the strongest form of "`--fix` never rewrites a disabled
-line"). Deterministic sibling tests pin known-dirty
+and asserts three *soundness* invariants: idempotence, parse preservation (input
+that parses must produce output that parses to an equal `YamlOwned` value), and
+that a leading `# ryl disable` makes the fix a byte-for-byte no-op (the strongest
+form of "`--fix` never rewrites a disabled line"). A safe fix must be **sound**
+(never change a document's meaning), not **complete** (it may leave some reported
+violations unfixed when the fixer must not touch their context — e.g. trailing
+spaces inside a block scalar), so the suite deliberately does *not* assert "no
+diagnostics remain after fixing." Deterministic sibling tests pin known-dirty
 documents and known production-bug patterns (issues #184 and #206) through the same
-checks so the property assertions cannot silently become a no-op if the generator
-drifts.
+checks — and assert effectiveness (`safe_fix_rule_diagnostics` clears) on concrete
+inputs the fixer fully cleans — so the property assertions cannot silently become a
+no-op if the generator drifts.
 
 The suite runs against a matrix of named configs to catch config-specific
 regressions: five YAML configs (`yamllint-default`, `best-practice`, `strict-single`,
@@ -235,9 +239,12 @@ suite; it targets ryl's historically fragile byte<->char offset arithmetic
 Layout mirrors the safe-fix suite: `property_check/strategy.rs` generates
 documents biased toward triggering every rule (truthy words, octal/float
 scalars, duplicate/unordered keys, flow spacing, anchors, over-long lines, odd
-indentation, trailing spaces) interleaved with multibyte characters and mixed
-LF/CRLF endings (never a bare `\r`, so line counting always agrees with the
-rules). `property_check/harness.rs` holds the trigger-all config (rule options
+indentation, trailing spaces) interleaved with multibyte characters, raw
+NEL/LS/PS (`unicode-line-breaks`, which are content not breaks in YAML 1.2), and
+mixed LF/CRLF endings (never a bare `\r`: ryl counts lines by `\n` only and does
+not support bare-CR endings — classic Mac OS, pre-2001 — so the generator omits
+them to keep line counting in agreement with the rules).
+`property_check/harness.rs` holds the trigger-all config (rule options
 are tuned so each rule actually emits), the per-rule `check()` dispatch, and the
 bounds invariant. The dispatch calls each `check()` directly rather than
 `lint_str` on purpose: `lint_str` discards every rule's spans in favour of the
@@ -333,6 +340,10 @@ the unsafe-trigger subset in that rule's module-level doc comment instead.
 - `truthy` — Rewriting `Yes/No/On/Off` requires choosing between quoting them
   (preserves the string), normalising to `true/false` (changes type), or
   rewording — all of which depend on the user's intent.
+- `unicode-line-breaks` — The `\N`/`\L`/`\P` escape is valid only inside a
+  double-quoted scalar; rewriting a raw NEL/LS/PS in a plain or single-quoted
+  scalar, a comment, or a block scalar would require changing the quoting style
+  or guessing intent, so no rewrite is universally safe.
 
 ## Coverage Workflow
 
@@ -515,6 +526,19 @@ sticking to the quick-status step above.
   reproduces the original bytes exactly (the reconstruct-and-verify guard) — a
   region whose lines lack a single shared prefix (ragged) is reported but left
   untouched, so write-back cannot corrupt a document. See `docs/markdown.md`.
+- `--fix` never mutates a file that does not fully parse:
+  `fix::apply_safe_fixes_filtered` gates the whole pipeline on `lint::parse_error`
+  (stricter than lint's `syntax_diagnostic` — it does *not* tolerate undefined
+  aliases), so *any* granit parse error ⇒ the input is returned byte-for-byte
+  unchanged, and even the pure source-transform fixers (`new-lines`,
+  `new-line-at-end-of-file`) leave such a file untouched. `apply_safe_fixes_in_place`
+  returns `FixOutcome::Skipped(problem)` for those files and the CLI prints a
+  `<path>:L:C skipped by --fix: <error>` notice, so the user always learns why a
+  file was not fixed — this also closes the hole where an undefined alias masked a
+  later syntax error. Lint behavior is unchanged: an undefined alias is still not a
+  lint syntax error (the `anchors` rule reports it, matching yamllint); only `--fix`
+  applies the stricter gate. The gate flows through the in-place and per-region
+  Markdown fix paths.
 - Malicious-payload hardening (issue #246): `--fix` never writes through a
   symlink — `fix::refuse_symlink` skips a symlinked input (still linted) with a
   warning, so an untrusted tree cannot redirect an in-place write outside itself.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-ryl implements 24 rules for checking YAML files. This page is a categorised
+ryl implements 25 rules for checking YAML files. This page is a categorised
 index of every rule with a brief description and a link to its detailed
 documentation. Each rule page covers what the rule does, why it matters,
 configuration options, and (where applicable) automatic fix behaviour.
@@ -39,6 +39,7 @@ Rules that auto-fix are marked with :wrench: in the **Fix** column.
 | [`new-line-at-end-of-file`](rules/new-line-at-end-of-file.md) | A single trailing newline at end of file. | :wrench: |
 | [`new-lines`](rules/new-lines.md) | Consistent line endings (LF vs CRLF). | :wrench: |
 | [`trailing-spaces`](rules/trailing-spaces.md) | Trailing whitespace at end of lines. | :wrench: |
+| [`unicode-line-breaks`](rules/unicode-line-breaks.md) | Raw NEL / LS / PS characters (not YAML 1.2 line breaks). |  |
 
 ## Document structure
 

--- a/docs/rules/unicode-line-breaks.md
+++ b/docs/rules/unicode-line-breaks.md
@@ -1,0 +1,90 @@
+# unicode-line-breaks
+
+## What this rule does
+
+Reports raw occurrences of three Unicode characters that YAML 1.1 treated as
+line breaks but YAML 1.2 does not:
+
+| Character | Name | YAML escape |
+| :--- | :--- | :--- |
+| `U+0085` | next line (NEL) | `\N` |
+| `U+2028` | line separator | `\L` |
+| `U+2029` | paragraph separator | `\P` |
+
+The rule scans the decoded source text and flags every raw occurrence, wherever
+it appears — inside a scalar, a key, or a comment. It is **off by default**.
+
+## Why this matters
+
+YAML 1.1 treated a broad Unicode set as line breaks, including NEL, LS, and PS.
+YAML 1.2 narrowed line breaks to just line feed (`\n`) and carriage return
+(`\r`), and the 1.2.2 changes page records that these three characters "are no
+longer considered line-break characters." ryl targets YAML 1.2.
+
+This makes a raw occurrence a portability trap: a YAML 1.1 parser splits the
+line where a 1.2 parser keeps the character as ordinary scalar content, so the
+same bytes can produce a different parsed structure depending on the tool. The
+characters are also invisible in virtually every editor, so a stray one — pasted
+in from a word processor, a PDF, or a web page — is almost impossible to spot by
+eye.
+
+If you genuinely need one of these characters, YAML 1.2 gives each a dedicated
+escape (`\N`, `\L`, `\P`) that includes it visibly and portably inside a
+double-quoted scalar.
+
+Sources: YAML 1.2.2 changes page; YAML 1.2.2 spec §5.1 (character set), §5.4
+(line-break characters), §5.7 (escaped characters).
+
+## Configuration
+
+`unicode-line-breaks` is a ryl-only rule (yamllint has no equivalent), so it is
+configured **only in TOML** &mdash; `[rules.unicode-line-breaks]` in
+`.ryl.toml`/`ryl.toml` or `[tool.ryl.rules.unicode-line-breaks]` in
+`pyproject.toml`. It is rejected in yamllint-compatible YAML config (including
+`-d` data) so the YAML namespace stays reserved for any future yamllint rule.
+
+```toml
+[rules.unicode-line-breaks]
+level = "error"
+```
+
+The rule has no options: when enabled it flags all three characters everywhere.
+
+## Examples
+
+### :x: Reported
+
+A double-quoted scalar containing a raw `U+2028` (shown here as `<LS>`; in a real
+file the character is invisible):
+
+```yaml
+title: "first line<LS>second line"
+```
+
+```text
+1:20  error  forbidden raw line separator U+2028; escape as "\L" in a double-quoted scalar  (unicode-line-breaks)
+```
+
+The rule also fires on a raw `U+0085`/`U+2029` in a plain scalar or a comment.
+
+### :white_check_mark: Allowed
+
+Use the dedicated escape inside a double-quoted scalar:
+
+```yaml
+title: "first line\Lsecond line"
+```
+
+## Automatic fixing
+
+This rule does not auto-fix. The escape (`\N`/`\L`/`\P`) is only valid inside a
+double-quoted scalar, so rewriting a plain or single-quoted scalar, a comment,
+or a block scalar would require changing the quoting style or guessing intent;
+no single rewrite is universally safe.
+
+## Related rules
+
+- [`new-lines`](new-lines.md) &mdash; enforces a consistent *line ending*
+  (LF vs CRLF) for the real line breaks.
+- [`quoted-strings`](quoted-strings.md) &mdash; governs the quoting style you
+  need in order to write a `\L`/`\N`/`\P` escape.

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -490,7 +490,8 @@
         "quoted-strings",
         "tags",
         "trailing-spaces",
-        "truthy"
+        "truthy",
+        "unicode-line-breaks"
       ],
       "type": "string"
     },
@@ -1851,6 +1852,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RuleEntryForTruthyOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unicode-line-breaks": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleEntryForNoOptions"
             },
             {
               "type": "null"

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -270,6 +270,8 @@ pub enum RuleName {
     TrailingSpaces,
     #[serde(rename = "truthy")]
     Truthy,
+    #[serde(rename = "unicode-line-breaks")]
+    UnicodeLineBreaks,
 }
 
 impl RuleName {
@@ -300,6 +302,7 @@ impl RuleName {
             Self::Tags => "tags",
             Self::TrailingSpaces => "trailing-spaces",
             Self::Truthy => "truthy",
+            Self::UnicodeLineBreaks => "unicode-line-breaks",
         }
     }
 }
@@ -345,6 +348,8 @@ pub struct RulesTable<Q = QuotedStringsOptions, K = KeyDuplicatesOptions> {
     #[serde(rename = "trailing-spaces")]
     pub trailing_spaces: Option<RuleEntry<NoOptions>>,
     pub truthy: Option<RuleEntry<TruthyOptions>>,
+    #[serde(rename = "unicode-line-breaks")]
+    pub unicode_line_breaks: Option<RuleEntry<NoOptions>>,
     #[serde(flatten, default)]
     #[schemars(skip)]
     extra: BTreeMap<String, toml::Value>,

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -237,6 +237,11 @@ fn rules_table_to_value<Q: Serialize, K: Serialize>(
         rules.trailing_spaces.as_ref(),
     );
     insert_serialized(&mut table, "truthy", rules.truthy.as_ref());
+    insert_serialized(
+        &mut table,
+        "unicode-line-breaks",
+        rules.unicode_line_breaks.as_ref(),
+    );
     table.extend(rules.extra.clone());
     toml::Value::Table(table)
 }

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -99,13 +99,14 @@ pub struct FixStats {
     pub skipped: Vec<(PathBuf, crate::lint::LintProblem)>,
 }
 
-/// The result of fixing a single file in place.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FixOutcome {
-    Changed,
-    Unchanged,
-    /// The file does not parse, so it was left untouched; carries the parse error.
-    Skipped(crate::lint::LintProblem),
+/// The result of fixing a single file in place. A file may both have changed and
+/// carry skips: a Markdown file can fix some embedded regions while skipping others
+/// that do not parse. For a plain YAML file `skipped` holds at most one entry (the
+/// whole file's parse error).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FixOutcome {
+    pub changed: bool,
+    pub skipped: Vec<crate::lint::LintProblem>,
 }
 
 /// `--fix` rewrites a path in place, and `std::fs::write` follows symlinks, so a
@@ -143,19 +144,25 @@ pub fn apply_safe_fixes_in_place(
     base_dir: &Path,
 ) -> Result<FixOutcome, String> {
     if refuse_symlink(path) {
-        return Ok(FixOutcome::Unchanged);
+        return Ok(FixOutcome::default());
     }
     let decoded = decoder::read_file_lossless(path)?;
     if let Some(problem) = crate::lint::parse_error(decoded.content()) {
-        return Ok(FixOutcome::Skipped(problem));
+        return Ok(FixOutcome {
+            changed: false,
+            skipped: vec![problem],
+        });
     }
     let fixed = apply_safe_fixes(decoded.content(), cfg, path, base_dir);
     if fixed == decoded.content() {
-        return Ok(FixOutcome::Unchanged);
+        return Ok(FixOutcome::default());
     }
 
     decoded.write(path, &fixed)?;
-    Ok(FixOutcome::Changed)
+    Ok(FixOutcome {
+        changed: true,
+        skipped: Vec::new(),
+    })
 }
 
 /// Apply all currently supported safe fixes to each discovered file in place.
@@ -174,12 +181,11 @@ pub fn apply_safe_fixes_to_files(
             }
             SourceKind::Yaml => apply_safe_fixes_in_place(path, cfg, base_dir)?,
         };
-        match outcome {
-            FixOutcome::Changed => stats.changed_files += 1,
-            FixOutcome::Unchanged => {}
-            FixOutcome::Skipped(problem) => {
-                stats.skipped.push((path.clone(), problem));
-            }
+        if outcome.changed {
+            stats.changed_files += 1;
+        }
+        for problem in outcome.skipped {
+            stats.skipped.push((path.clone(), problem));
         }
     }
     Ok(stats)
@@ -197,16 +203,21 @@ pub fn apply_markdown_safe_fixes_in_place(
     base_dir: &Path,
 ) -> Result<FixOutcome, String> {
     if refuse_symlink(path) {
-        return Ok(FixOutcome::Unchanged);
+        return Ok(FixOutcome::default());
     }
     let decoded = decoder::read_file_lossless(path)?;
-    match fix_markdown_str(decoded.content(), path, cfg, base_dir) {
+    // Regions that do not parse are skipped by the per-region gate in
+    // `fix_markdown_str`; collect their parse errors (mapped to host coordinates)
+    // so the CLI reports them, like a plain YAML file's whole-file skip.
+    let skipped = crate::markdown_embed::markdown_parse_skips(decoded.content(), cfg);
+    let changed = match fix_markdown_str(decoded.content(), path, cfg, base_dir) {
         Some(fixed) => {
             decoded.write(path, &fixed)?;
-            Ok(FixOutcome::Changed)
+            true
         }
-        None => Ok(FixOutcome::Unchanged),
-    }
+        None => false,
+    };
+    Ok(FixOutcome { changed, skipped })
 }
 
 /// Apply safe fixes to each embedded YAML region of `markdown` and splice the

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -206,11 +206,18 @@ pub fn apply_markdown_safe_fixes_in_place(
         return Ok(FixOutcome::default());
     }
     let decoded = decoder::read_file_lossless(path)?;
+    let fixed = fix_markdown_str(decoded.content(), path, cfg, base_dir);
     // Regions that do not parse are skipped by the per-region gate in
-    // `fix_markdown_str`; collect their parse errors (mapped to host coordinates)
-    // so the CLI reports them, like a plain YAML file's whole-file skip.
-    let skipped = crate::markdown_embed::markdown_parse_skips(decoded.content(), cfg);
-    let changed = match fix_markdown_str(decoded.content(), path, cfg, base_dir) {
+    // `fix_markdown_str`; collect their parse errors (mapped to host coordinates) so
+    // the CLI reports them, like a plain YAML file's whole-file skip. Read them from
+    // the *fixed* bytes (what gets written) so the reported line stays correct even
+    // when an earlier region's fix changed the line count; a skipped region is left
+    // untouched, so it still appears there at its post-fix position.
+    let skipped = crate::markdown_embed::markdown_parse_skips(
+        fixed.as_deref().unwrap_or_else(|| decoded.content()),
+        cfg,
+    );
+    let changed = match fixed {
         Some(fixed) => {
             decoded.write(path, &fixed)?;
             true

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -91,9 +91,21 @@ const EMPTY_LINES_FIX: RuleFix = RuleFix {
     safety: FixSafety::Safe,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct FixStats {
     pub changed_files: usize,
+    /// Files left untouched because they do not parse, with the parse error so the
+    /// caller can tell the user why `--fix` refused them.
+    pub skipped: Vec<(PathBuf, crate::lint::LintProblem)>,
+}
+
+/// The result of fixing a single file in place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FixOutcome {
+    Changed,
+    Unchanged,
+    /// The file does not parse, so it was left untouched; carries the parse error.
+    Skipped(crate::lint::LintProblem),
 }
 
 /// `--fix` rewrites a path in place, and `std::fs::write` follows symlinks, so a
@@ -129,18 +141,21 @@ pub fn apply_safe_fixes_in_place(
     path: &Path,
     cfg: &YamlLintConfig,
     base_dir: &Path,
-) -> Result<bool, String> {
+) -> Result<FixOutcome, String> {
     if refuse_symlink(path) {
-        return Ok(false);
+        return Ok(FixOutcome::Unchanged);
     }
     let decoded = decoder::read_file_lossless(path)?;
+    if let Some(problem) = crate::lint::parse_error(decoded.content()) {
+        return Ok(FixOutcome::Skipped(problem));
+    }
     let fixed = apply_safe_fixes(decoded.content(), cfg, path, base_dir);
     if fixed == decoded.content() {
-        return Ok(false);
+        return Ok(FixOutcome::Unchanged);
     }
 
     decoded.write(path, &fixed)?;
-    Ok(true)
+    Ok(FixOutcome::Changed)
 }
 
 /// Apply all currently supported safe fixes to each discovered file in place.
@@ -153,14 +168,18 @@ pub fn apply_safe_fixes_to_files(
 ) -> Result<FixStats, String> {
     let mut stats = FixStats::default();
     for (path, base_dir, cfg, kind) in files {
-        let changed = match kind {
+        let outcome = match kind {
             SourceKind::Markdown => {
                 apply_markdown_safe_fixes_in_place(path, cfg, base_dir)?
             }
             SourceKind::Yaml => apply_safe_fixes_in_place(path, cfg, base_dir)?,
         };
-        if changed {
-            stats.changed_files += 1;
+        match outcome {
+            FixOutcome::Changed => stats.changed_files += 1,
+            FixOutcome::Unchanged => {}
+            FixOutcome::Skipped(problem) => {
+                stats.skipped.push((path.clone(), problem));
+            }
         }
     }
     Ok(stats)
@@ -176,17 +195,17 @@ pub fn apply_markdown_safe_fixes_in_place(
     path: &Path,
     cfg: &YamlLintConfig,
     base_dir: &Path,
-) -> Result<bool, String> {
+) -> Result<FixOutcome, String> {
     if refuse_symlink(path) {
-        return Ok(false);
+        return Ok(FixOutcome::Unchanged);
     }
     let decoded = decoder::read_file_lossless(path)?;
     match fix_markdown_str(decoded.content(), path, cfg, base_dir) {
         Some(fixed) => {
             decoded.write(path, &fixed)?;
-            Ok(true)
+            Ok(FixOutcome::Changed)
         }
-        None => Ok(false),
+        None => Ok(FixOutcome::Unchanged),
     }
 }
 
@@ -290,7 +309,14 @@ pub fn apply_safe_fixes_filtered(
     base_dir: &Path,
     skip: &[&str],
 ) -> String {
-    if crate::directives::disables_file(input) {
+    // Never mutate a file that does not fully parse. `parse_error` is stricter than
+    // lint's `syntax_diagnostic` — it does not tolerate undefined aliases — so a
+    // file with any granit error (including an alias that masks a later syntax
+    // error) is left byte-for-byte unchanged. The CLI surfaces the reason via
+    // `apply_safe_fixes_in_place`'s `Skipped` outcome.
+    if crate::directives::disables_file(input)
+        || crate::lint::parse_error(input).is_some()
+    {
         return input.to_string();
     }
     let ctx = FixContext {

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -7,6 +7,7 @@ use crate::rules::{
     document_end, document_start, empty_lines, empty_values, float_values, hyphens,
     indentation, key_duplicates, key_ordering, line_length, new_line_at_end_of_file,
     new_lines, octal_values, quoted_strings, tags, trailing_spaces, truthy,
+    unicode_line_breaks,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,7 +35,7 @@ impl From<RuleLevel> for Severity {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintProblem {
     pub line: usize,
     pub column: usize,
@@ -285,6 +286,14 @@ pub fn lint_str(
         }
     }
 
+    collect_unicode_line_breaks_diagnostics(
+        &mut diagnostics,
+        content,
+        cfg,
+        path,
+        base_dir,
+    );
+
     let directives = crate::directives::Directives::parse(content);
     diagnostics.retain(|problem| {
         !problem
@@ -530,6 +539,28 @@ fn collect_tags_diagnostics(
     }
 }
 
+fn collect_unicode_line_breaks_diagnostics(
+    diagnostics: &mut Vec<LintProblem>,
+    content: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+) {
+    if let Some(level) = cfg.rule_level(unicode_line_breaks::ID)
+        && !cfg.is_rule_ignored(unicode_line_breaks::ID, path, base_dir)
+    {
+        for hit in unicode_line_breaks::check(content) {
+            diagnostics.push(LintProblem {
+                line: hit.line,
+                column: hit.column,
+                level: level.into(),
+                message: hit.message,
+                rule: Some(unicode_line_breaks::ID),
+            });
+        }
+    }
+}
+
 fn collect_comments_indentation_diagnostics(
     diagnostics: &mut Vec<LintProblem>,
     content: &str,
@@ -622,24 +653,40 @@ fn collect_line_length_diagnostics(
     }
 }
 
-fn syntax_diagnostic(content: &str) -> Option<LintProblem> {
+fn scan(content: &str) -> Result<(), granit_parser::ScanError> {
     let mut parser = granit_parser::Parser::new_from_str(content);
     let mut sink = NullSink;
-    match parser.load(&mut sink, true) {
+    parser.load(&mut sink, true)
+}
+
+fn syntax_problem(err: &granit_parser::ScanError) -> LintProblem {
+    let marker = err.marker();
+    LintProblem {
+        line: marker.line(),
+        column: marker.col() + 1,
+        level: Severity::Error,
+        message: format!("syntax error: {} (syntax)", err.info()),
+        rule: None,
+    }
+}
+
+/// Any granit parse error as a diagnostic, or `None` if `content` parses. Stricter
+/// than [`syntax_diagnostic`]: it does *not* suppress the undefined-alias error.
+/// The `--fix` gate uses this so it refuses to mutate any file granit cannot fully
+/// parse — and always reports why — rather than the lint view that tolerates
+/// undefined aliases.
+pub(crate) fn parse_error(content: &str) -> Option<LintProblem> {
+    scan(content).err().as_ref().map(syntax_problem)
+}
+
+/// The syntax error ryl reports for `content` during linting, or `None` if it
+/// lints cleanly. Deliberately suppresses granit's undefined-alias error (ryl
+/// reports that via the `anchors` rule, matching yamllint), so lint stays
+/// yamllint-compatible.
+fn syntax_diagnostic(content: &str) -> Option<LintProblem> {
+    match scan(content) {
         Ok(()) => None,
-        Err(err) => {
-            if err.info() == "while parsing node, found unknown anchor" {
-                return None;
-            }
-            let marker = err.marker();
-            let column = marker.col() + 1;
-            Some(LintProblem {
-                line: marker.line(),
-                column,
-                level: Severity::Error,
-                message: format!("syntax error: {} (syntax)", err.info()),
-                rule: None,
-            })
-        }
+        Err(err) if err.info() == "while parsing node, found unknown anchor" => None,
+        Err(err) => Some(syntax_problem(&err)),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,7 +458,16 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
             &initial_results,
             cli.lint.compatibility.no_warnings,
         );
-        apply_safe_fixes_to_files(&files)?;
+        let fix_stats = apply_safe_fixes_to_files(&files)?;
+        for (path, problem) in &fix_stats.skipped {
+            eprintln!(
+                "{}:{}:{} skipped by --fix: {}",
+                sanitize_control(&path.display().to_string()),
+                problem.line,
+                problem.column,
+                sanitize_control(&problem.message),
+            );
+        }
     }
 
     let results = lint_files(&files);

--- a/src/markdown_embed/lint.rs
+++ b/src/markdown_embed/lint.rs
@@ -51,6 +51,36 @@ pub fn lint_markdown_str(
     problems
 }
 
+/// For each embedded region that does not parse, the parse error mapped to the host
+/// document's coordinates. `--fix` uses this to tell the user which regions it
+/// refused to rewrite — the strict fix gate skips a region that does not parse, and
+/// (unlike a true syntax error, which [`lint_markdown_str`] already surfaces) an
+/// undefined alias is otherwise silent.
+#[must_use]
+pub fn markdown_parse_skips(markdown: &str, cfg: &YamlLintConfig) -> Vec<LintProblem> {
+    let sources = MarkdownSources {
+        front_matter: cfg.markdown_front_matter(),
+        fenced_blocks: cfg.markdown_fenced_blocks(),
+    };
+    let mut skips = Vec::new();
+    for region in extract_regions(markdown, sources) {
+        if region.content.trim().is_empty() {
+            continue;
+        }
+        let Some(mut problem) = crate::lint::parse_error(&region.content) else {
+            continue;
+        };
+        let stripped = stripped_indents(markdown, &region);
+        problem.column += stripped
+            .get(problem.line - 1)
+            .copied()
+            .unwrap_or(region.col_offset);
+        problem.line += region.line_offset;
+        skips.push(problem);
+    }
+    skips
+}
+
 /// Per content line, the number of characters the `CommonMark` parser stripped from
 /// its start — `chars(raw line) - chars(content line)` — which covers leading
 /// space/tab indentation, blockquote markers, and CRLF normalisation alike. Added

--- a/src/markdown_embed/mod.rs
+++ b/src/markdown_embed/mod.rs
@@ -10,7 +10,7 @@
 
 mod lint;
 
-pub use lint::lint_markdown_str;
+pub use lint::{lint_markdown_str, markdown_parse_skips};
 
 use std::ops::Range;
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -23,10 +23,11 @@ pub(crate) mod support;
 pub mod tags;
 pub mod trailing_spaces;
 pub mod truthy;
+pub mod unicode_line_breaks;
 
 /// Every rule id, used by the directive engine to expand a bare `disable`/`enable`
 /// (no `rule:` token) to "all rules". Extend this when adding a rule.
-pub const ALL_RULE_IDS: [&str; 24] = [
+pub const ALL_RULE_IDS: [&str; 25] = [
     anchors::ID,
     braces::ID,
     brackets::ID,
@@ -51,6 +52,7 @@ pub const ALL_RULE_IDS: [&str; 24] = [
     tags::ID,
     trailing_spaces::ID,
     truthy::ID,
+    unicode_line_breaks::ID,
 ];
 
 /// Rules that are ryl-only (no yamllint equivalent) and therefore configurable
@@ -58,4 +60,4 @@ pub const ALL_RULE_IDS: [&str; 24] = [
 /// out of the YAML schema so the YAML `rules` namespace stays reserved for
 /// yamllint's own definitions (see `AGENTS.md`). Extend this when adding a rule
 /// that yamllint does not have.
-pub const RYL_ONLY_RULE_IDS: [&str; 1] = [tags::ID];
+pub const RYL_ONLY_RULE_IDS: [&str; 2] = [tags::ID, unicode_line_breaks::ID];

--- a/src/rules/unicode_line_breaks.rs
+++ b/src/rules/unicode_line_breaks.rs
@@ -1,0 +1,76 @@
+//! `unicode-line-breaks` rule &mdash; flags raw NEL / LS / PS characters in the
+//! source (issue #253).
+//!
+//! YAML 1.1 treated a broad Unicode set as line breaks, including NEL (U+0085),
+//! LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029). YAML 1.2 narrowed
+//! line breaks to just LF and CR, and the 1.2.2 changes page records that these
+//! three "are no longer considered line-break characters." ryl targets YAML 1.2,
+//! so a raw occurrence is a portability trap: a 1.1 parser splits the line where a
+//! 1.2 parser keeps the character as ordinary scalar content, silently changing
+//! the parsed structure. The characters are also invisible in most editors, so a
+//! stray one (pasted from a word processor, PDF or web page) is hard to spot.
+//!
+//! The rule scans the decoded source and reports every raw occurrence regardless
+//! of context. The three characters each have a dedicated YAML escape (§5.7) that
+//! includes them intentionally and visibly inside a double-quoted scalar, so the
+//! diagnostic suggests that escape (`\N` / `\L` / `\P`).
+//!
+//! There is no safe `--fix`: the escape is only valid inside a double-quoted
+//! scalar, so rewriting a plain/single-quoted scalar, comment or block scalar
+//! would require changing the quoting style or guessing intent (see AGENTS.md
+//! "Rules Without A Safe `--fix`").
+//!
+//! Sources: YAML 1.2.2 changes page; YAML 1.2.2 spec §5.1 (character set), §5.4
+//! (line-break characters), §5.7 (escaped characters).
+
+pub const ID: &str = "unicode-line-breaks";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+/// Report every raw NEL / LS / PS character with a 1-based line/column.
+///
+/// Line counting splits on `\n` only (these characters are not YAML 1.2 line
+/// breaks and so never advance the line counter), matching every other ryl rule;
+/// the reported column is therefore the character's position on its `\n`-delimited
+/// line and is always in bounds. ryl does not treat a bare `\r` (classic Mac OS,
+/// pre-2001) as a line break anywhere, so files using that obsolete ending are
+/// unsupported and may report shifted line numbers.
+#[must_use]
+pub fn check(buffer: &str) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    let mut line = 1usize;
+    let mut column = 1usize;
+    for ch in buffer.chars() {
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+            continue;
+        }
+        if let Some((name, escape)) = classify(ch) {
+            violations.push(Violation {
+                line,
+                column,
+                message: format!(
+                    "forbidden raw {name} U+{:04X}; escape as \"{escape}\" in a double-quoted scalar",
+                    ch as u32
+                ),
+            });
+        }
+        column += 1;
+    }
+    violations
+}
+
+fn classify(ch: char) -> Option<(&'static str, &'static str)> {
+    match ch {
+        '\u{85}' => Some(("next line", "\\N")),
+        '\u{2028}' => Some(("line separator", "\\L")),
+        '\u{2029}' => Some(("paragraph separator", "\\P")),
+        _ => None,
+    }
+}

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -65,6 +65,64 @@ fn fix_respects_toml_unfixable_rules() {
 }
 
 #[test]
+fn fix_never_mutates_unparsable_yaml() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    // Two root-level flow sequences are not a valid YAML stream. The file also
+    // carries CRLF, trailing spaces and no final newline — each individually
+    // fixable — but `--fix` must leave a non-parsing file byte-for-byte intact.
+    let original = "[1,2 ,3]   \r\n[4,5 ,6]";
+    fs::write(&file, original).unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ncommas = 'enable'\ntrailing-spaces = 'enable'\nnew-lines = 'enable'\nnew-line-at-end-of-file = 'enable'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe).arg("--fix").arg(&file));
+    assert_eq!(
+        code, 1,
+        "a syntax error still fails: stdout={stdout} stderr={stderr}"
+    );
+    assert_eq!(
+        fs::read(&file).unwrap(),
+        original.as_bytes(),
+        "unparsable YAML must be left byte-for-byte unchanged by --fix"
+    );
+}
+
+#[test]
+fn fix_skips_and_reports_unparsable_file_with_undefined_alias() {
+    // An undefined alias is not a syntax error in lint (the `anchors` rule reports
+    // it, matching yamllint), but granit cannot resolve it — so the strict `--fix`
+    // gate refuses to mutate the file and prints why, rather than silently skipping
+    // it or rewriting an invalid document. The CRLF endings are NOT normalized.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    let original = "a: *missing\r\nb: 1\r\n";
+    fs::write(&file, original).unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\nnew-lines = 'enable'\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _stdout, stderr) = run(Command::new(exe).arg("--fix").arg(&file));
+
+    assert_eq!(
+        fs::read(&file).unwrap(),
+        original.as_bytes(),
+        "an unparsable file is left byte-for-byte unchanged by --fix"
+    );
+    assert!(
+        stderr.contains("skipped by --fix") && stderr.contains("unknown anchor"),
+        "the skip notice must explain why the file was not fixed: {stderr}"
+    );
+}
+
+#[test]
 fn fix_respects_toml_fixable_allowlist() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("input.yaml");

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -65,6 +65,29 @@ fn fix_preserves_crlf_in_fenced_block() {
 }
 
 #[test]
+fn fix_skips_and_reports_unparsable_embedded_region() {
+    // An embedded region with an undefined alias does not parse, so the strict gate
+    // skips it (its commas issue stays unfixed) and the CLI reports the skip mapped
+    // to the alias's line in the host markdown document.
+    let body = "# title\n\n```yaml\na: *missing\nb: [1,2]\n```\n";
+    let (_dir, file) = project(COMMAS, "doc.md", body);
+
+    let (_code, _out, err) = fix(&file);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        body,
+        "an unparsable embedded region is left unchanged"
+    );
+    assert!(
+        err.contains("skipped by --fix")
+            && err.contains("unknown anchor")
+            && err.contains("doc.md:4:"),
+        "skip notice maps to the alias's host line: {err}"
+    );
+}
+
+#[test]
 fn fix_handles_front_matter_and_multiple_fenced_blocks() {
     let body = "---\nfoo: [1,2]\n---\n\n```yaml\nbar: [3,4]\n```\n\nText\n\n```yaml\nbaz: [5,6]\n```\n";
     let (_dir, file) = project(COMMAS, "doc.md", body);

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -88,6 +88,27 @@ fn fix_skips_and_reports_unparsable_embedded_region() {
 }
 
 #[test]
+fn fix_skip_notice_uses_post_fix_line_after_earlier_region_shrinks() {
+    // An earlier region's empty-lines fix removes blank lines, shifting the later
+    // unparsable region up; the skip notice must point at the alias's line in the
+    // WRITTEN file (10), not its original line (12).
+    let config = "files = { markdown = [\"*.md\"] }\n[rules.empty-lines]\nmax = 1\n";
+    let body = "# t\n\n```yaml\na: 1\n\n\n\nb: 2\n```\n\n```yaml\nc: *missing\n```\n";
+    let (_dir, file) = project(config, "doc.md", body);
+
+    let (_code, _out, err) = fix(&file);
+
+    assert!(
+        err.contains("doc.md:10:") && err.contains("unknown anchor"),
+        "skip notice must use the post-fix line (10): {err}"
+    );
+    assert!(
+        !err.contains("doc.md:12:"),
+        "must not report the stale pre-fix line 12: {err}"
+    );
+}
+
+#[test]
 fn fix_handles_front_matter_and_multiple_fenced_blocks() {
     let body = "---\nfoo: [1,2]\n---\n\n```yaml\nbar: [3,4]\n```\n\nText\n\n```yaml\nbaz: [5,6]\n```\n";
     let (_dir, file) = project(COMMAS, "doc.md", body);

--- a/tests/cli_no_config.rs
+++ b/tests/cli_no_config.rs
@@ -53,12 +53,14 @@ fn no_config_found_via_stdin_is_rejected() {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn");
-    child
+    // ryl rejects the missing config before reading stdin, so the child may have
+    // already exited (closing the pipe) by the time we write — a broken pipe here is
+    // expected, not a failure; only the exit code and stderr matter.
+    let _ = child
         .stdin
         .take()
         .expect("stdin")
-        .write_all(b"key: value\n")
-        .expect("write stdin");
+        .write_all(b"key: value\n");
     let out = child.wait_with_output().expect("wait");
     let err = String::from_utf8_lossy(&out.stderr);
     assert_eq!(

--- a/tests/cli_unicode_line_breaks_rule.rs
+++ b/tests/cli_unicode_line_breaks_rule.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
+    if stderr.is_empty() { stdout } else { stderr }
+}
+
+/// `unicode-line-breaks` is a ryl-only rule, so it is configured through TOML
+/// rather than the yamllint-compatible YAML config that `-d` carries.
+fn lint_with_toml_config(content: &str, config: &str) -> (i32, String) {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, content).unwrap();
+    let config_path = dir.path().join(".ryl.toml");
+    fs::write(&config_path, config).unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config_path).arg(&file));
+    (code, command_output(&stdout, &stderr).to_string())
+}
+
+#[test]
+fn flags_nel_ls_ps_across_contexts_with_char_based_columns() {
+    // LS in a double-quoted scalar (1), NEL in a plain scalar (2), PS in a
+    // comment (3), and LS after a multibyte key (4) — proving the rule fires
+    // anywhere and that columns count characters, not bytes (col 8 past `café`).
+    let (code, output) = lint_with_toml_config(
+        "key: \"a\u{2028}b\"\nplain: x\u{85}y\n# c\u{2029}d\ncafé: \"\u{2028}\"\n",
+        "[rules]\nunicode-line-breaks = \"enable\"\n",
+    );
+    assert_eq!(code, 1, "raw line-break characters should fail: {output}");
+    assert!(
+        output.contains("1:8")
+            && output.contains("line separator")
+            && output.contains("\\L"),
+        "LS in a quoted scalar at 1:8 with its \\L escape: {output}"
+    );
+    assert!(
+        output.contains("2:9")
+            && output.contains("next line")
+            && output.contains("\\N"),
+        "NEL in a plain scalar at 2:9 with its \\N escape: {output}"
+    );
+    assert!(
+        output.contains("3:4")
+            && output.contains("paragraph separator")
+            && output.contains("\\P"),
+        "PS in a comment at 3:4 with its \\P escape: {output}"
+    );
+    assert!(
+        output.contains("4:8"),
+        "char-based column past the multibyte key café: {output}"
+    );
+    assert!(
+        output.contains("unicode-line-breaks"),
+        "rule id missing: {output}"
+    );
+}
+
+#[test]
+fn rule_does_not_fire_when_not_enabled() {
+    let (code, output) =
+        lint_with_toml_config("a: \"x\u{2028}y\"\n", "[rules]\ntruthy = \"enable\"\n");
+    assert_eq!(code, 0, "rule is off unless enabled: {output}");
+    assert!(
+        !output.contains("unicode-line-breaks"),
+        "rule must not run unless enabled: {output}"
+    );
+}
+
+#[test]
+fn rule_is_rejected_in_yaml_config() {
+    // ryl-only: yamllint-compatible YAML config (here via `-d`) must reject it
+    // rather than silently linting or clashing with a future yamllint rule.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "a: \"x\u{2028}y\"\n").unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules: {unicode-line-breaks: enable}")
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "a ryl-only rule in YAML config is a usage error: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert!(
+        output.contains("unicode-line-breaks"),
+        "error should name the rule: {output}"
+    );
+    assert!(
+        output.to_lowercase().contains("toml"),
+        "error should point to TOML config: {output}"
+    );
+}
+
+#[test]
+fn per_file_ignores_accept_the_rule_name() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ignored.yaml");
+    fs::write(&file, "a: \"x\u{2028}y\"\n").unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        format!(
+            "[rules]\nunicode-line-breaks = \"enable\"\n[per-file-ignores]\n'{}' = ['unicode-line-breaks']\n",
+            file.display()
+        ),
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "per-file-ignores should suppress the rule: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+}

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -299,6 +299,7 @@ fn normalize_toml_config_preserves_all_per_file_ignore_rule_names() {
     "quoted-strings",
     "trailing-spaces",
     "truthy",
+    "unicode-line-breaks",
 ]
 "#,
         false,
@@ -336,6 +337,7 @@ fn normalize_toml_config_preserves_all_per_file_ignore_rule_names() {
             "quoted-strings",
             "trailing-spaces",
             "truthy",
+            "unicode-line-breaks",
         ]
     );
 }

--- a/tests/directives_fix.rs
+++ b/tests/directives_fix.rs
@@ -25,10 +25,10 @@ fn replace_fixer_skips_block_disabled_lines() {
 
 #[test]
 fn replace_fixer_skips_inline_disabled_line() {
-    let input = "[1,2 ,3]  # ryl disable-line rule:commas\n[4,5 ,6]\n";
+    let input = "a: [1,2 ,3]  # ryl disable-line rule:commas\nb: [4,5 ,6]\n";
     assert_eq!(
         fix(input, "rules:\n  commas: enable\n"),
-        "[1,2 ,3]  # ryl disable-line rule:commas\n[4, 5, 6]\n",
+        "a: [1,2 ,3]  # ryl disable-line rule:commas\nb: [4, 5, 6]\n",
         "inline-disabled line is untouched; the next line is fixed"
     );
 }
@@ -92,7 +92,7 @@ fn fixer_runs_normally_when_a_different_rule_is_disabled() {
 
 #[test]
 fn disable_file_makes_fix_a_noop() {
-    let body = "a: 1   \n[1,2 ,3]\n";
+    let body = "a: 1   \nb: [1,2 ,3]\n";
     let config = "rules:\n  trailing-spaces: enable\n  commas: enable\n";
     assert_ne!(
         fix(body, config),

--- a/tests/fix_engine.rs
+++ b/tests/fix_engine.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use ryl::config::{Overrides, SourceKind, YamlLintConfig, discover_config};
 use ryl::fix::{
-    apply_safe_fixes, apply_safe_fixes_in_place, apply_safe_fixes_to_files,
+    FixOutcome, apply_safe_fixes, apply_safe_fixes_in_place, apply_safe_fixes_to_files,
 };
 use tempfile::tempdir;
 
@@ -19,10 +19,10 @@ fn apply_safe_fixes_in_place_reports_no_change() {
         "rules:\n  comments: enable\n  new-lines: enable\n  new-line-at-end-of-file: enable\n",
     );
 
-    let changed =
+    let outcome =
         apply_safe_fixes_in_place(&file, &cfg, dir.path()).expect("fix succeeds");
 
-    assert!(!changed);
+    assert_eq!(outcome, FixOutcome::Unchanged);
     assert_eq!(fs::read_to_string(&file).unwrap(), "key: value\n");
 }
 
@@ -33,13 +33,38 @@ fn apply_safe_fixes_in_place_writes_changes() {
     fs::write(&file, "key: value #comment").unwrap();
     let cfg = config("rules:\n  comments: enable\n  new-line-at-end-of-file: enable\n");
 
-    let changed =
+    let outcome =
         apply_safe_fixes_in_place(&file, &cfg, dir.path()).expect("fix succeeds");
 
-    assert!(changed);
+    assert_eq!(outcome, FixOutcome::Changed);
     assert_eq!(
         fs::read_to_string(&file).unwrap(),
         "key: value  # comment\n"
+    );
+}
+
+#[test]
+fn apply_safe_fixes_in_place_skips_and_reports_unparsable_file() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(&file, "a: *missing\n").unwrap();
+    let cfg = config("rules:\n  trailing-spaces: enable\n");
+
+    let outcome =
+        apply_safe_fixes_in_place(&file, &cfg, dir.path()).expect("fix succeeds");
+
+    match outcome {
+        FixOutcome::Skipped(problem) => assert!(
+            problem.message.contains("unknown anchor"),
+            "skip carries the parse error: {}",
+            problem.message
+        ),
+        other => panic!("expected Skipped for an unparsable file, got {other:?}"),
+    }
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "a: *missing\n",
+        "a skipped file is left byte-for-byte unchanged"
     );
 }
 
@@ -186,13 +211,34 @@ fn apply_safe_fixes_runs_comments_indentation_and_commas() {
     );
 
     let fixed = apply_safe_fixes(
-        "items: [1 ,2]\n # wrong\n  next: value\n",
+        "items: [1 ,2]\n # wrong\nnext: value\n",
         &cfg,
         std::path::Path::new("input.yaml"),
         std::path::Path::new("."),
     );
 
-    assert_eq!(fixed, "items: [1, 2]\n  # wrong\n  next: value\n");
+    assert_eq!(fixed, "items: [1, 2]\n# wrong\nnext: value\n");
+}
+
+#[test]
+fn whitespace_fixers_bail_on_unparsable_input() {
+    // The pipeline parse-gate normally keeps these fixers from seeing unparsable
+    // input; called directly they must still bail, because `protected_scalar_lines`
+    // cannot resolve scalar spans without a successful parse.
+    let unparsable = "items: [1 ,2]\n # wrong\n  next: value\n";
+    let empty_lines_cfg = ryl::rules::empty_lines::Config::resolve(&config(
+        "rules:\n  empty-lines: enable\n",
+    ));
+    assert_eq!(
+        ryl::rules::empty_lines::fix(unparsable, &empty_lines_cfg),
+        None,
+        "empty-lines fix bails when the buffer does not parse"
+    );
+    assert_eq!(
+        ryl::rules::trailing_spaces::fix(unparsable),
+        None,
+        "trailing-spaces fix bails when the buffer does not parse"
+    );
 }
 
 #[test]

--- a/tests/fix_engine.rs
+++ b/tests/fix_engine.rs
@@ -22,7 +22,7 @@ fn apply_safe_fixes_in_place_reports_no_change() {
     let outcome =
         apply_safe_fixes_in_place(&file, &cfg, dir.path()).expect("fix succeeds");
 
-    assert_eq!(outcome, FixOutcome::Unchanged);
+    assert_eq!(outcome, FixOutcome::default());
     assert_eq!(fs::read_to_string(&file).unwrap(), "key: value\n");
 }
 
@@ -36,7 +36,7 @@ fn apply_safe_fixes_in_place_writes_changes() {
     let outcome =
         apply_safe_fixes_in_place(&file, &cfg, dir.path()).expect("fix succeeds");
 
-    assert_eq!(outcome, FixOutcome::Changed);
+    assert!(outcome.changed && outcome.skipped.is_empty());
     assert_eq!(
         fs::read_to_string(&file).unwrap(),
         "key: value  # comment\n"
@@ -53,14 +53,13 @@ fn apply_safe_fixes_in_place_skips_and_reports_unparsable_file() {
     let outcome =
         apply_safe_fixes_in_place(&file, &cfg, dir.path()).expect("fix succeeds");
 
-    match outcome {
-        FixOutcome::Skipped(problem) => assert!(
-            problem.message.contains("unknown anchor"),
-            "skip carries the parse error: {}",
-            problem.message
-        ),
-        other => panic!("expected Skipped for an unparsable file, got {other:?}"),
-    }
+    assert!(!outcome.changed, "an unparsable file is not changed");
+    assert_eq!(outcome.skipped.len(), 1, "one whole-file parse error");
+    assert!(
+        outcome.skipped[0].message.contains("unknown anchor"),
+        "skip carries the parse error: {}",
+        outcome.skipped[0].message
+    );
     assert_eq!(
         fs::read_to_string(&file).unwrap(),
         "a: *missing\n",

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -97,6 +97,7 @@ const RULE_TRIGGERS: &[(&str, &str)] = &[
     ("tags", "a: !!omap []\n"),
     ("trailing-spaces", "a: 1   \n"),
     ("truthy", "a: Yes\n"),
+    ("unicode-line-breaks", "a: \"x\u{2028}y\"\n"),
 ];
 
 /// Guards the hand-maintained `rules::ALL_RULE_IDS` (which a bare `# ryl disable`

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -1,7 +1,9 @@
 use std::sync::LazyLock;
 
 use ryl::config::YamlLintConfig;
-use ryl::rules::{new_line_at_end_of_file, new_lines, trailing_spaces};
+use ryl::rules::{
+    new_line_at_end_of_file, new_lines, trailing_spaces, unicode_line_breaks,
+};
 
 #[derive(Debug, Clone)]
 pub struct Span {
@@ -159,6 +161,13 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     for violation in trailing_spaces::check(content) {
         spans.push(Span {
             rule: trailing_spaces::ID,
+            line: violation.line,
+            column: violation.column,
+        });
+    }
+    for violation in unicode_line_breaks::check(content) {
+        spans.push(Span {
+            rule: unicode_line_breaks::ID,
             line: violation.line,
             column: violation.column,
         });

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -126,7 +126,19 @@ impl Document {
 }
 
 fn arb_multibyte() -> impl Strategy<Value = char> {
-    prop_oneof![Just('é'), Just('—'), Just('世'), Just('🦀'), Just('å')]
+    prop_oneof![
+        Just('é'),
+        Just('—'),
+        Just('世'),
+        Just('🦀'),
+        Just('å'),
+        // Raw NEL / LS / PS: content in YAML 1.2 (not line breaks), so they
+        // interleave into keys/values/comments without splitting lines and
+        // exercise `unicode-line-breaks` across contexts.
+        Just('\u{85}'),
+        Just('\u{2028}'),
+        Just('\u{2029}'),
+    ]
 }
 
 fn arb_key() -> impl Strategy<Value = String> {

--- a/tests/property_safe_fix.rs
+++ b/tests/property_safe_fix.rs
@@ -4,15 +4,19 @@
 //!  * `config` — the named-config matrix that the suite runs each invariant
 //!    against, plus shared parse/lint helpers.
 //!  * `ast` — the synthetic YAML AST (`Document`, `Node`, `Scalar`, …) used
-//!    by the generator, together with rendering and the
-//!    "is this input expected to leave residue under a partial safe fix?"
-//!    predicate.
+//!    by the generator, together with rendering.
 //!  * `strategy` — proptest strategies that build random `Document` values.
 //!
-//! This file holds the `proptest!` invariants (idempotence, residual
-//! diagnostics, parse preservation) and a handful of deterministic
-//! regressions that pin known-dirty inputs and production-bug patterns
-//! (issues #184, #206, BOM preservation) through the same machinery.
+//! These invariants assert that `apply_safe_fixes` is *sound*, not *complete*:
+//! a safe fix must never change a document's meaning, but it may leave some
+//! reported violations unfixed (e.g. an occurrence in a context the fixer must
+//! not rewrite). This file holds four `proptest!` soundness invariants
+//! (idempotence, parse preservation, the leading-`# ryl disable` no-op, and that
+//! any reported progress — a drop in diagnostic count — corresponds to a real
+//! change to the file) plus deterministic regressions that pin known-dirty inputs
+//! and production-bug patterns (issues #184, #206, BOM preservation) — including
+//! effectiveness (`safe_fix_rule_diagnostics` clears on concrete inputs the fixer
+//! fully cleans).
 
 #[path = "property_safe_fix/ast.rs"]
 mod ast;
@@ -63,32 +67,6 @@ proptest! {
         }
     }
 
-    #[test]
-    fn safe_fix_leaves_no_safe_fix_rule_diagnostics(document in arb_document()) {
-        if document.has_partial_safe_fix_residue() {
-            return Ok(());
-        }
-        let input = document.render();
-        for prepared in safe_fix_configs() {
-            let cfg_name = prepared.name;
-            let cfg = &prepared.cfg;
-            let fixed =
-                apply_safe_fixes(&input, cfg, synthetic_path(), synthetic_base_dir());
-            if parse_for_compare(&fixed).is_none() {
-                continue;
-            }
-            let remaining = safe_fix_rule_diagnostics(&fixed, cfg);
-            prop_assert!(
-                remaining.is_empty(),
-                "safe-fix-rule diagnostics survived fix under config '{}' for input {:?}; fixed {:?}; diagnostics {:?}",
-                cfg_name,
-                input,
-                fixed,
-                remaining
-            );
-        }
-    }
-
     /// A leading `# ryl disable` mutes every rule, so `apply_safe_fixes` must not
     /// touch a single line: the output equals the input byte-for-byte under every
     /// config. This is the strongest form of "--fix never rewrites a disabled line".
@@ -135,6 +113,35 @@ proptest! {
                 input,
                 fixed
             );
+        }
+    }
+
+    /// Soundness of progress reporting: `ryl --fix` reports "N fixed" as the drop
+    /// in diagnostic count (problems before minus after), so any reported fix must
+    /// correspond to a real change to the file. If fixing reduces the safe-fix
+    /// diagnostic count, the output must differ from the input — a no-op that
+    /// reports progress would be a bug.
+    #[test]
+    fn safe_fix_reporting_progress_implies_mutation(document in arb_document()) {
+        let input = document.render();
+        for prepared in safe_fix_configs() {
+            let cfg_name = prepared.name;
+            let cfg = &prepared.cfg;
+            let before = safe_fix_rule_diagnostics(&input, cfg).len();
+            let fixed =
+                apply_safe_fixes(&input, cfg, synthetic_path(), synthetic_base_dir());
+            let after = safe_fix_rule_diagnostics(&fixed, cfg).len();
+            if after < before {
+                prop_assert_ne!(
+                    &fixed,
+                    &input,
+                    "fix reported progress ({} -> {} safe-fix diagnostics) but left the file byte-for-byte unchanged under config '{}'; input {:?}",
+                    before,
+                    after,
+                    cfg_name,
+                    input
+                );
+            }
         }
     }
 }

--- a/tests/property_safe_fix/ast.rs
+++ b/tests/property_safe_fix/ast.rs
@@ -246,12 +246,6 @@ impl MultilinePlainSpec {
 }
 
 impl Document {
-    pub fn has_partial_safe_fix_residue(&self) -> bool {
-        self.entries
-            .iter()
-            .any(BlockEntry::has_partial_safe_fix_residue)
-    }
-
     pub fn render(&self) -> String {
         let mut buffer = String::new();
         let line_terminator = match self.newline {
@@ -272,24 +266,6 @@ impl Document {
 }
 
 impl BlockEntry {
-    fn has_partial_safe_fix_residue(&self) -> bool {
-        match &self.value {
-            Node::BlockScalar(spec) => spec.body.iter().any(|line| match line {
-                BlockBodyLine::Content { trailing_ws, .. } => *trailing_ws > 0,
-                BlockBodyLine::Blank => true,
-            }),
-            Node::MultilineQuoted(spec) => spec
-                .lines
-                .iter()
-                .any(|line| matches!(line, MultilineLine::Blank)),
-            Node::MultilinePlain(spec) => spec
-                .continuations
-                .iter()
-                .any(|line| matches!(line, MultilineLine::Blank)),
-            _ => false,
-        }
-    }
-
     fn render(&self, buffer: &mut String, line_term: &str) {
         buffer.push_str(&self.key);
         buffer.push_str(": ");


### PR DESCRIPTION
## Summary

Adds the opt-in `unicode-line-breaks` rule (closes #253) and — per the [scope decision recorded on #253](https://github.com/owenlamont/ryl/issues/253#issuecomment-4639238361) — folds in two related `--fix` safety changes that share the fix-path code and property suites.

### New rule: `unicode-line-breaks` (detection-only)

Flags raw NEL (U+0085), LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) anywhere in the source. YAML 1.1 treated these as line breaks; YAML 1.2 does not, so a raw occurrence is a portability trap (a 1.1 vs 1.2 parser disagree on structure) and is invisible in most editors. The diagnostic suggests the dedicated escape (`\N`/`\L`/`\P`, valid in a double-quoted scalar).

- **Off by default**, **ryl-only** (no yamllint equivalent) so it is configurable only in TOML (`[rules.unicode-line-breaks]`); rejected in YAML config.
- No safe `--fix` (the escape is only valid in double-quoted scalars) — documented in the unfixable list.
- Multi-source citations in the module doc (YAML 1.2.2 changes page; spec §5.1/§5.4/§5.7).

### `--fix` never mutates a file that does not fully parse

`apply_safe_fixes` now gates on a strict parse check (`lint::parse_error`) and, when it refuses a file, prints `<path>:L:C skipped by --fix: <error>` so the user always learns why. This also closes a hole where an undefined alias masked a later syntax error and `--fix` rewrote invalid YAML. **Lint behavior is unchanged** — an undefined alias is still not a lint syntax error (the `anchors` rule reports it, matching yamllint); only `--fix` applies the stricter gate.

### Safe-fix property invariants: soundness, not completeness

A safe fix must be *sound* (never change a document's meaning), not *complete* (it may leave some reported violations unfixed). Removed the "no remaining diagnostics after fix" invariant and the hand-maintained residue allowlist; added `safe_fix_reporting_progress_implies_mutation` (if `--fix` reports progress, the file must actually have changed). Effectiveness stays pinned by deterministic tests.

### Notes

- Bare-CR (classic Mac OS, pre-2001) line endings are documented as unsupported (ryl counts lines by `\n` only).
- A follow-up for a `--fix` convergence property test is tracked in #268.

## Verification

- `prek run --all-files` green; full test suite passes; coverage reports **zero missed lines/regions**.
- All property suites pass at 512k cases (`property_check`, `property_safe_fix`, `property_markdown_fix`).
- Reviewed with `/code-review` and two local Codex passes (final pass clean).
