### PR TITLE
Use granit tag metadata in tags rule (closes #271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+checksum = "599a28c6c3171864dbf7fdb3a666f7ac301fab54c2b6e71534f413959cd37b49"
 dependencies = [
  "arraydeque",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ globset = "0.4.18"
 ignore = "0.4.25"
 rayon = "1.11.0"
 schemars = { version = "1.2.1", features = ["derive"] }
-granit-parser = "0.0.3"
+granit-parser = "0.0.5"
 hashlink = "0.11.0"
 ordered-float = "5"
 dirs-next = "2.0.0"

--- a/docs/rules/tags.md
+++ b/docs/rules/tags.md
@@ -47,19 +47,16 @@ allowed-tags = []
 | `forbid-removed-types` | `false` | Forbid the YAML 1.1 types removed in 1.2: `!!omap`, `!!pairs`, `!!set`, `!!timestamp`, `!!binary`. |
 | `allowed-tags` | `[]` | When non-empty, report any other local / non-core tag (e.g. `!env`) that is not listed. Core-schema tags (`!!str`, `!!omap`, …) are governed by the other two options, not by this allowlist. |
 
-List `allowed-tags` entries in shorthand form (e.g. `!env`). Tag spelling is
-normalised before matching, so shorthand, local, and verbatim (`!<…>`) forms
-are treated alike and core-schema tags always compare as their `!!type` form.
-A tag written with a custom `%TAG` handle is matched by its resolved URI (e.g.
-`tag:example.com,2002:env`), not the `!handle!suffix` shorthand. The
-non-specific `!` tag is never reported.
+List `allowed-tags` entries as the author-facing tag spelling (e.g. `!env`).
+Custom `%TAG` handles are matched as written, so `!e!keep` is allowlisted with
+`"!e!keep"` rather than its resolved URI. Verbatim tags use their normalised
+verbatim spelling (`!<…>`). The non-specific `!` tag is never reported.
 
 When more than one check matches the same node, a single diagnostic is
 reported in the order: unsafe, removed type, not allowed.
 
-A tag heading a block collection is reported at the collection, which may begin
-on the next line, so a `# ryl disable-line` for it must sit on that line, not the
-tag's line.
+Diagnostics point at the explicit tag token, including when a tagged block
+collection begins on the next line.
 
 ## Examples
 

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -29,7 +29,6 @@
 use granit_parser::{Event, Parser, Span, SpannedEventReceiver, Tag};
 
 use crate::config::YamlLintConfig;
-use crate::rules::support::span_utils;
 use crate::yaml_dom::YamlOwned;
 
 pub const ID: &str = "tags";
@@ -126,21 +125,7 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
         diagnostics: Vec::new(),
     };
     let _ = parser.load(&mut receiver, true);
-    let mut diagnostics = receiver.diagnostics;
-    clamp_overshoot(buffer, &mut diagnostics);
-    diagnostics
-}
-
-/// A tag on an implicit/empty scalar that ends the document is positioned by
-/// granit at a virtual location that can fall outside the document (see
-/// [`span_utils::clamp_position`]); clamp it back onto a real position.
-fn clamp_overshoot(buffer: &str, diagnostics: &mut [Violation]) {
-    for violation in diagnostics {
-        let (line, column) =
-            span_utils::clamp_position(buffer, violation.line, violation.column);
-        violation.line = line;
-        violation.column = column;
-    }
+    receiver.diagnostics
 }
 
 struct TagsReceiver<'cfg> {
@@ -153,9 +138,12 @@ impl<'input> SpannedEventReceiver<'input> for TagsReceiver<'_> {
         if let Some(tag) = event.tag()
             && let Some(message) = self.cfg.diagnose(tag)
         {
+            let tag_start = span
+                .tag_start()
+                .expect("granit provides tag_start for tagged node events");
             self.diagnostics.push(Violation {
-                line: span.start.line(),
-                column: span.start.col() + 1,
+                line: tag_start.line(),
+                column: tag_start.col() + 1,
                 message,
             });
         }
@@ -196,12 +184,12 @@ fn unsafe_namespace<'a>(tag: &'a Tag, core: Option<&'a str>) -> Option<&'a str> 
     }
 }
 
-/// Render a tag in shorthand for diagnostics: `!!type` for core-schema tags
-/// however they were spelled, otherwise the parser's resolved `!handle`/prefix
-/// form (a custom `%TAG` handle renders as its resolved prefix).
+/// Render a tag for diagnostics and allowlist matching: `!!type` for
+/// core-schema tags however they were spelled, otherwise its author-facing
+/// spelling.
 fn shorthand(tag: &Tag) -> String {
     match core_suffix(tag) {
         Some(suffix) => format!("!!{suffix}"),
-        None => tag.to_string(),
+        None => tag.original(),
     }
 }

--- a/tests/cli_tags_rule.rs
+++ b/tests/cli_tags_rule.rs
@@ -40,12 +40,12 @@ fn unsafe_tags_flagged_for_core_and_local_namespaces() {
         output.contains("forbidden unsafe tag \"!!python/object/apply:os.system\""),
         "core-schema python tag message missing: {output}"
     );
-    assert!(output.contains("1:39"), "python tag position: {output}");
+    assert!(output.contains("1:7"), "python tag position: {output}");
     assert!(
         output.contains("forbidden unsafe tag \"!ruby/object:Foo\""),
         "local ruby tag message missing: {output}"
     );
-    assert!(output.contains("2:23"), "ruby tag position: {output}");
+    assert!(output.contains("2:6"), "ruby tag position: {output}");
     assert!(output.contains("tags"), "rule id missing: {output}");
     assert!(
         !output.contains("!!str"),
@@ -64,12 +64,12 @@ fn removed_yaml_1_1_types_flagged_for_core_schema_only() {
         output.contains("forbidden removed YAML 1.1 type \"!!omap\""),
         "omap message missing: {output}"
     );
-    assert!(output.contains("1:11"), "omap position: {output}");
+    assert!(output.contains("1:4"), "omap position: {output}");
     assert!(
         output.contains("forbidden removed YAML 1.1 type \"!!set\""),
         "set message missing: {output}"
     );
-    assert!(output.contains("2:10"), "set position: {output}");
+    assert!(output.contains("2:4"), "set position: {output}");
     assert!(
         !output.contains("!env"),
         "local tag is not a removed core type: {output}"
@@ -91,7 +91,7 @@ fn allowed_tags_flags_only_unlisted_custom_tags() {
         output.contains("tag \"!env\" is not in allowed-tags"),
         "unlisted tag message missing: {output}"
     );
-    assert!(output.contains("1:9"), "!env position: {output}");
+    assert!(output.contains("1:4"), "!env position: {output}");
     assert!(
         !output.contains("!keep"),
         "allowlisted tag must not be flagged: {output}"
@@ -120,7 +120,7 @@ fn multibyte_key_column_is_char_based() {
     );
     assert_eq!(code, 1, "removed type should fail: {output}");
     assert!(
-        output.contains("1:14"),
+        output.contains("1:7"),
         "char-based column past the multibyte key: {output}"
     );
 }
@@ -150,8 +150,8 @@ fn verbatim_and_javax_tag_spellings_are_normalised_and_detected() {
         "verbatim core tag should normalise to !!omap: {output}"
     );
     assert!(
-        output.contains("forbidden unsafe tag \"!python/object\""),
-        "verbatim local construction tag should be flagged: {output}"
+        output.contains("forbidden unsafe tag \"!<!python/object>\""),
+        "verbatim local construction tag should preserve its spelling: {output}"
     );
     assert!(
         output.contains("forbidden unsafe tag \"!!javax.script.ScriptEngineManager\""),
@@ -172,6 +172,40 @@ fn custom_tag_directive_handle_is_not_namespace_matched() {
     assert!(
         output.trim().is_empty(),
         "expected no diagnostics: {output}"
+    );
+}
+
+#[test]
+fn custom_tag_directive_handle_is_allowlisted_as_written() {
+    let (code, output) = lint_with_toml_config(
+        "%TAG !e! tag:example.com,2000:\n---\na: !e!keep value\nb: !e!other value\n",
+        "[rules.tags]\nallowed-tags = [\"!e!keep\"]\n",
+    );
+    assert_eq!(code, 1, "unlisted custom handle tag should fail: {output}");
+    assert!(
+        !output.contains("!e!keep"),
+        "author-spelled allowlisted tag must not be flagged: {output}"
+    );
+    assert!(
+        output.contains("tag \"!e!other\" is not in allowed-tags"),
+        "diagnostic should preserve the author's custom handle: {output}"
+    );
+    assert!(
+        !output.contains("tag:example.com,2000:"),
+        "resolved URI should not replace the author's spelling: {output}"
+    );
+
+    let (code, output) = lint_with_toml_config(
+        "%TAG !e! tag:example.com,2000:\n---\na: !e!keep value\n",
+        "[rules.tags]\nallowed-tags = [\"tag:example.com,2000:keep\"]\n",
+    );
+    assert_eq!(
+        code, 1,
+        "resolved URI must not allow a differently-spelled tag: {output}"
+    );
+    assert!(
+        output.contains("tag \"!e!keep\" is not in allowed-tags"),
+        "allowlist matching should use the author's spelling: {output}"
     );
 }
 
@@ -211,9 +245,6 @@ fn non_specific_bare_tag_stays_exempt_under_tag_directive() {
 
 #[test]
 fn tag_on_trailing_empty_scalar_points_at_its_content_line() {
-    // granit positions the empty scalar on the blank segment after the final
-    // newline; the diagnostic must clamp back to the tag's content line so it
-    // is suppressible with a `disable-line` on that line.
     let (code, output) = lint_with_toml_config(
         "x: 1\nb: !!omap\n",
         "[rules.tags]\nforbid-removed-types = true\n",
@@ -223,13 +254,39 @@ fn tag_on_trailing_empty_scalar_points_at_its_content_line() {
         "trailing empty tagged scalar should fail: {output}"
     );
     assert!(
-        output.contains("2:1"),
-        "must point at the content line (2), not the phantom trailing line 3: {output}"
+        output.contains("2:4"),
+        "must point at the tag token: {output}"
     );
     assert!(
         !output.contains("3:1"),
         "must not overshoot onto the trailing empty segment: {output}"
     );
+}
+
+#[test]
+fn block_collection_tag_points_at_tag_and_disable_line_suppresses_it() {
+    let config = "[rules.tags]\nallowed-tags = [\"!keep\"]\n";
+    let (code, output) = lint_with_toml_config("a: !env\n  - x\n", config);
+    assert_eq!(
+        code, 1,
+        "unlisted block collection tag should fail: {output}"
+    );
+    assert!(
+        output.contains("1:4"),
+        "diagnostic should point at the tag rather than the collection: {output}"
+    );
+    assert!(
+        !output.contains("2:3"),
+        "diagnostic must not point at the collection: {output}"
+    );
+
+    let (code, output) =
+        lint_with_toml_config("a: !env # ryl disable-line rule:tags\n  - x\n", config);
+    assert_eq!(
+        code, 0,
+        "disable-line on the explicit tag line should suppress it: {output}"
+    );
+    assert!(output.trim().is_empty(), "expected no output: {output}");
 }
 
 #[test]

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -37,6 +37,7 @@ pub enum Line {
         spaces_after_hash: u8,
         text: String,
     },
+    TagDirective,
     DocumentStart,
     DocumentEnd,
     Blank {
@@ -103,6 +104,7 @@ impl Line {
                 push_spaces(out, *spaces_after_hash);
                 out.push_str(text);
             }
+            Self::TagDirective => out.push_str("%TAG !e! tag:example.com,2000:"),
             Self::DocumentStart => out.push_str("---"),
             Self::DocumentEnd => out.push_str("..."),
             Self::Blank { spaces } => push_spaces(out, *spaces),
@@ -192,9 +194,9 @@ fn arb_bare_value() -> impl Strategy<Value = String> {
 
 // Tag tokens spanning shorthand, local, verbatim, and non-specific forms. They
 // are synthesized onto values so the no-panic / in-bounds-span invariants run
-// over tagged nodes — exercising `tags::check`, the spelling normalisation, and
-// `clamp_overshoot` across positions, multibyte chars, and LF/CRLF. This suite
-// only asserts those invariants; tag-handling correctness lives in the
+// over tagged nodes — exercising `tags::check`, tag-token positions, and
+// author-facing spellings across positions, multibyte chars, and LF/CRLF. This
+// suite only asserts those invariants; tag-handling correctness lives in the
 // deterministic CLI tests.
 fn arb_tag() -> impl Strategy<Value = &'static str> {
     prop_oneof![
@@ -216,8 +218,6 @@ fn arb_value() -> impl Strategy<Value = String> {
     (prop::option::weighted(0.35, arb_tag()), arb_bare_value()).prop_map(
         |(tag, base)| match tag {
             None => base,
-            // An empty base leaves the tag on an implicit scalar — the
-            // `clamp_overshoot` hot path when it ends the document.
             Some(tag) if base.is_empty() => tag.to_string(),
             Some(tag) => format!("{tag} {base}"),
         },
@@ -343,10 +343,23 @@ fn arb_merge_block() -> impl Strategy<Value = Vec<Line>> {
         })
 }
 
+fn arb_custom_tag_block() -> impl Strategy<Value = Vec<Line>> {
+    prop_oneof![Just("!e!keep"), Just("!e!other")].prop_map(|tag| {
+        vec![
+            Line::TagDirective,
+            Line::DocumentStart,
+            merge_entry(0, "tagged", format!("{tag} value")),
+        ]
+    })
+}
+
 fn arb_fragment() -> impl Strategy<Value = Vec<(Line, Newline)>> {
     prop_oneof![
         10 => (arb_line(), arb_newline()).prop_map(|pair| vec![pair]),
         1 => (arb_merge_block(), arb_newline()).prop_map(|(lines, newline)| {
+            lines.into_iter().map(|line| (line, newline)).collect()
+        }),
+        1 => (arb_custom_tag_block(), arb_newline()).prop_map(|(lines, newline)| {
             lines.into_iter().map(|line| (line, newline)).collect()
         }),
     ]


### PR DESCRIPTION
## Summary

Resolves the two `tags` rule limitations retained in #262 now that granit-parser 0.0.5 exposes the required metadata.

- Upgrade `granit-parser` from 0.0.3 to 0.0.5.
- Point tag diagnostics at the explicit tag token via `Span::tag_start`, including tags attached to block collections and empty scalars.
- Match non-core `allowed-tags` entries and diagnostic text against the author's tag spelling via `Tag::original`, including custom `%TAG` handles.
- Keep resolved tag identity for unsafe-tag and removed-type classification so alternate spellings cannot evade those checks.
- Remove the obsolete position-clamping workaround and documentation caveats.

## Impact

A custom handle such as `!e!keep` can now be allowlisted directly as `"!e!keep"`; its resolved URI no longer matches. `# ryl disable-line rule:tags` on a block collection's explicit tag line now suppresses the diagnostic as expected.

## Verification

- `prek run --all-files`
- `./scripts/coverage-missing.sh` — zero uncovered regions
- `PROPTEST_CASES=512000 cargo test --release --test property_check`
- `uv run scripts/source_size.py --compare-to main` — production source decreased by 12 lines

Closes #271.