### PR TITLE
Fix `colons` false positive on alias mapping keys (closes #254)

### DIFF
--- a/docs/rules/colons.md
+++ b/docs/rules/colons.md
@@ -52,6 +52,21 @@ second: 2
 third:  3
 ```
 
+### Alias mapping keys
+
+A YAML anchor/alias name may legally contain `:`, so `*anchor:` is read as the alias to
+an anchor named `anchor:`. Using an alias as a mapping key therefore *requires* one space
+before the colon &mdash; `*anchor : value`. When that required space is present the
+colon's spacing is not reported (matching the parser's view of the alias); any other
+spacing is checked as usual.
+
+```yaml
+anchor: &a 42
+*a : value     # allowed: the required space is not reported
+*a  : value    # reported: an extra space before the colon
+*a:  value     # reported: too many spaces after the colon
+```
+
 ## Automatic fixing
 
 This rule does not auto-fix; correct spacing manually.

--- a/src/rules/colons.rs
+++ b/src/rules/colons.rs
@@ -1,6 +1,19 @@
+//! `colons` rule: limit spaces around `:` (and explicit `?`) in mappings.
+//!
+//! Alias-key special case: a YAML anchor/alias name may legally contain `:` (only the
+//! flow indicators `,[]{}` are excluded — YAML 1.2.2 §6.9.2 "Node Anchors", §7.1 "Alias
+//! Nodes"), so `*foo:` is the alias to an anchor named `foo:`. Using an alias as a
+//! mapping key therefore *requires* one separating space — `*foo : bar` — which must not
+//! be reported. We take alias extents from the parser (`collect_alias_ends`) rather than
+//! guessing from raw text, so the exemption fires exactly when an alias node ends one
+//! space before the colon — matching yamllint's `colons.py` `AliasToken` rule (see
+//! adrienverge/yamllint#226).
+use std::collections::HashSet;
+
 use crate::config::YamlLintConfig;
 use crate::rules::support::punctuation::{
-    build_line_starts, collect_scalar_ranges, line_and_column, skip_comment,
+    build_line_starts, collect_alias_ends, collect_scalar_ranges, line_and_column,
+    skip_comment,
 };
 use crate::rules::support::span_utils::{CharPos, containing_scalar_range};
 
@@ -62,10 +75,7 @@ pub struct Violation {
 }
 
 enum BeforeResult {
-    SameLine {
-        spaces: usize,
-        preceding_char: Option<usize>,
-    },
+    SameLine { spaces: usize },
     Ignored,
 }
 
@@ -81,6 +91,10 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     }
 
     let scalar_ranges = collect_scalar_ranges(buffer);
+    let alias_ends: HashSet<usize> = collect_alias_ends(buffer)
+        .iter()
+        .map(|pos| pos.get())
+        .collect();
     let chars: Vec<(usize, char)> = buffer.char_indices().collect();
     let line_starts = build_line_starts(&chars);
 
@@ -102,7 +116,14 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
                 continue;
             }
             ':' => {
-                evaluate_colon(cfg, &mut violations, &chars, idx, &line_starts);
+                evaluate_colon(
+                    cfg,
+                    &mut violations,
+                    &chars,
+                    idx,
+                    &line_starts,
+                    &alias_ends,
+                );
             }
             '?' => {
                 evaluate_question_mark(cfg, &mut violations, &chars, idx, &line_starts);
@@ -122,38 +143,34 @@ fn evaluate_colon(
     chars: &[(usize, char)],
     colon_idx: usize,
     line_starts: &[CharPos],
+    alias_ends: &HashSet<usize>,
 ) {
-    let mut skip_after_check = false;
-
-    if let BeforeResult::SameLine {
-        spaces,
-        preceding_char,
-    } = compute_spaces_before(chars, colon_idx)
+    // An alias used as a mapping key needs exactly one separating space (`*foo : bar`);
+    // skip both checks when an alias node ends one char before this colon.
+    if colon_idx
+        .checked_sub(1)
+        .is_some_and(|prev| alias_ends.contains(&prev))
     {
-        if let Some(preceding_idx) = preceding_char
-            && spaces == 0
-            && alias_immediately_before(chars, preceding_idx)
-        {
-            skip_after_check = true;
-        }
+        return;
+    }
 
-        if !skip_after_check && cfg.max_spaces_before >= 0 {
-            let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
-            if spaces_i64 > cfg.max_spaces_before {
-                let (line, column) =
-                    line_and_column(line_starts, CharPos::new(colon_idx));
-                let highlight_column = column.saturating_sub(1).max(1);
-                violations.push(Violation {
-                    line,
-                    column: highlight_column,
-                    message: TOO_MANY_BEFORE.to_string(),
-                });
-            }
+    if cfg.max_spaces_before >= 0
+        && let BeforeResult::SameLine { spaces } =
+            compute_spaces_before(chars, colon_idx)
+    {
+        let spaces_i64 = i64::try_from(spaces).unwrap_or(i64::MAX);
+        if spaces_i64 > cfg.max_spaces_before {
+            let (line, column) = line_and_column(line_starts, CharPos::new(colon_idx));
+            let highlight_column = column.saturating_sub(1).max(1);
+            violations.push(Violation {
+                line,
+                column: highlight_column,
+                message: TOO_MANY_BEFORE.to_string(),
+            });
         }
     }
 
-    if !skip_after_check
-        && cfg.max_spaces_after >= 0
+    if cfg.max_spaces_after >= 0
         && let AfterResult::SameLine { spaces, next_char } =
             compute_spaces_after(chars, colon_idx)
     {
@@ -202,28 +219,17 @@ fn compute_spaces_before(chars: &[(usize, char)], colon_idx: usize) -> BeforeRes
     let mut spaces = 0usize;
     let mut idx = colon_idx;
 
-    loop {
-        let Some(prev) = idx.checked_sub(1) else {
-            return BeforeResult::SameLine {
-                spaces,
-                preceding_char: None,
-            };
-        };
-
-        let ch = chars[prev].1;
-        if matches!(ch, ' ' | '\t') {
-            spaces += 1;
-            idx = prev;
-            continue;
+    while let Some(prev) = idx.checked_sub(1) {
+        match chars[prev].1 {
+            ' ' | '\t' => {
+                spaces += 1;
+                idx = prev;
+            }
+            '\n' | '\r' => return BeforeResult::Ignored,
+            _ => return BeforeResult::SameLine { spaces },
         }
-        if matches!(ch, '\n' | '\r') {
-            return BeforeResult::Ignored;
-        }
-        return BeforeResult::SameLine {
-            spaces,
-            preceding_char: Some(prev),
-        };
     }
+    BeforeResult::SameLine { spaces }
 }
 
 fn compute_spaces_after(chars: &[(usize, char)], start_idx: usize) -> AfterResult {
@@ -254,28 +260,6 @@ fn compute_spaces_after(chars: &[(usize, char)], start_idx: usize) -> AfterResul
     }
 
     AfterResult::Ignored
-}
-
-fn alias_immediately_before(chars: &[(usize, char)], preceding_idx: usize) -> bool {
-    let mut idx = preceding_idx;
-    loop {
-        let ch = chars[idx].1;
-        if ch == '*' {
-            return true;
-        }
-        if is_alias_identifier_char(ch) {
-            if idx == 0 {
-                return false;
-            }
-            idx -= 1;
-            continue;
-        }
-        return false;
-    }
-}
-
-const fn is_alias_identifier_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')
 }
 
 fn is_explicit_question_mark(chars: &[(usize, char)], idx: usize) -> bool {

--- a/src/rules/support/punctuation.rs
+++ b/src/rules/support/punctuation.rs
@@ -1,6 +1,8 @@
 use std::ops::Range;
 
-use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
+use granit_parser::{
+    Event, Parser, Scanner, Span, SpannedEventReceiver, StrInput, TokenType,
+};
 
 use crate::rules::support::span_utils::CharPos;
 
@@ -9,6 +11,18 @@ pub(crate) fn collect_scalar_ranges(buffer: &str) -> Vec<Range<CharPos>> {
     let mut collector = ScalarRangeCollector::new();
     let _ = parser.load(&mut collector, true);
     collector.into_sorted()
+}
+
+/// `CharPos` just past each alias token (`*name`), taken from the scanner so it is
+/// independent of anchor resolution — an undefined or forward alias is still an alias
+/// token (whereas the parser errors on it). `colons` uses these to exempt the required
+/// space before an alias mapping key (`*foo : bar`) instead of guessing alias extents
+/// from raw characters.
+pub(crate) fn collect_alias_ends(buffer: &str) -> Vec<CharPos> {
+    Scanner::new(StrInput::new(buffer))
+        .filter(|token| matches!(token.1, TokenType::Alias(_)))
+        .map(|token| CharPos::new(token.0.end.index()))
+        .collect()
 }
 
 pub(crate) fn skip_comment(chars: &[(usize, char)], mut idx: usize) -> usize {

--- a/tests/cli_colons_rule.rs
+++ b/tests/cli_colons_rule.rs
@@ -41,6 +41,44 @@ fn colons_reports_spacing_errors() {
 }
 
 #[test]
+fn colons_allows_required_space_for_alias_mapping_key() {
+    // Regression for #254: `*foo : bar` needs the space (without it `:` joins the alias
+    // name), so it must not be flagged; an extra space still is.
+    let dir = tempdir().unwrap();
+    let config = dir.path().join("config.yaml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  colons: enable\n",
+    )
+    .unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+
+    let ok = dir.path().join("alias-ok.yaml");
+    fs::write(&ok, "---\na: &foo 42\nm:\n  *foo : bar\n").unwrap();
+    let (code, stdout, stderr) = run(Command::new(exe).arg("-c").arg(&config).arg(&ok));
+    assert_eq!(
+        code, 0,
+        "alias key with the required space must be clean: stdout={stdout} stderr={stderr}"
+    );
+
+    let bad = dir.path().join("alias-bad.yaml");
+    fs::write(&bad, "---\na: &foo 42\nm:\n  *foo  : bar\n").unwrap();
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&bad));
+    assert_eq!(
+        code, 1,
+        "an extra space before the alias-key colon must fail: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(output.contains("4:8"), "expected line:col 4:8: {output}");
+    assert!(
+        output.contains("too many spaces before colon"),
+        "missing before-colon message: {output}"
+    );
+    assert!(output.contains("colons"), "rule id missing: {output}");
+}
+
+#[test]
 fn colons_reports_explicit_key_spacing() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("explicit.yaml");

--- a/tests/colons_rule.rs
+++ b/tests/colons_rule.rs
@@ -71,19 +71,73 @@ fn detects_excess_spaces_after_question_mark() {
 }
 
 #[test]
-fn ignores_alias_immediately_before_colon() {
+fn exempts_required_space_before_alias_key_colon() {
+    // `*a :` needs the space: without it `:` joins the alias name (`a:`), so the single
+    // required space must not be flagged (adrienverge/yamllint#226).
     let cfg = Config::new_for_tests(0, 1);
-    let points = violation_points("- anchor: &a key\n- *a: 42\n", cfg);
-    assert!(points.is_empty());
+    let points = violation_points("- anchor: &a key\n- *a : 42\n", cfg);
+    assert!(
+        points.is_empty(),
+        "required space before an alias-key colon must be allowed: {points:?}"
+    );
 }
 
 #[test]
-fn flags_alias_with_extra_spaces() {
+fn flags_extra_space_before_alias_key_colon() {
     let cfg = Config::new_for_tests(0, 1);
     let points = violation_points("- anchor: &a key\n- *a  : 42\n", cfg);
     assert_eq!(
         points,
         vec![(2, 6, "too many spaces before colon".to_string())]
+    );
+}
+
+#[test]
+fn still_flags_spaces_after_alias_key_colon() {
+    // The exemption covers only the required space *before* the colon; spacing after it
+    // is still checked (a latent false negative before the #254 fix).
+    let cfg = Config::new_for_tests(0, 1);
+    let points = violation_points("- anchor: &a key\n- *a:  42\n", cfg);
+    assert_eq!(
+        points,
+        vec![(2, 7, "too many spaces after colon".to_string())]
+    );
+}
+
+#[test]
+fn flags_plain_scalar_key_containing_alias_marker() {
+    // `foo *bar` is a plain scalar key, not an alias node, so the space before `:` is
+    // still flagged — the exemption only applies where the parser resolved an alias.
+    let cfg = Config::new_for_tests(0, 1);
+    let points = violation_points("foo *bar : baz\n", cfg);
+    assert_eq!(
+        points,
+        vec![(1, 9, "too many spaces before colon".to_string())]
+    );
+}
+
+#[test]
+fn allows_document_initial_colon_with_null_key() {
+    // Colon at the buffer start (a null mapping key): no key text precedes it, so there
+    // are no excess spaces before the colon to report.
+    let cfg = Config::new_for_tests(0, 1);
+    let points = violation_points(": value\n", cfg);
+    assert!(
+        points.is_empty(),
+        "a document-initial null-key colon has no spacing violation: {points:?}"
+    );
+}
+
+#[test]
+fn exempts_required_space_for_undefined_alias_key() {
+    // The exemption reads scanner tokens, so it fires for an alias key even when the
+    // anchor is undefined or forward-referenced (the parser errors, but the token is
+    // still an alias) — matching yamllint, which exempts regardless of resolution.
+    let cfg = Config::new_for_tests(0, 1);
+    let points = violation_points("*missing : 42\n", cfg);
+    assert!(
+        points.is_empty(),
+        "an alias key is exempt even when its anchor is undefined: {points:?}"
     );
 }
 

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -159,6 +159,11 @@ fn arb_key() -> impl Strategy<Value = String> {
         Just("0xB".to_string()),
         Just("11".to_string()),
         Just("~".to_string()),
+        // An alias as a mapping key: paired with the entry generator's
+        // `spaces_before_colon` range it produces `*anchor : v` (the required-space
+        // `colons` exemption) plus the non-exempt 0/2-space forms, and exercises an
+        // alias in key position through the shared mapping-key walker.
+        Just("*anchor".to_string()),
         arb_multibyte().prop_map(|ch| format!("k{ch}")),
     ]
 }

--- a/tests/yamllint_compat_colons.rs
+++ b/tests/yamllint_compat_colons.rs
@@ -257,6 +257,49 @@ fn colons_rule_matches_yamllint() {
 }
 
 #[test]
+fn alias_mapping_key_matches_yamllint() {
+    ensure_yamllint_installed();
+
+    let dir = tempdir().unwrap();
+
+    let cfg_path = dir.path().join("colons-alias.yaml");
+    fs::write(
+        &cfg_path,
+        "rules:\n  document-start: disable\n  colons: enable\n",
+    )
+    .unwrap();
+
+    // Alias used as a mapping key: the required single space before `:` must be allowed
+    // (#254), an extra space before is flagged, and spacing after `:` is still checked.
+    let yaml_path = dir.path().join("alias.yaml");
+    fs::write(
+        &yaml_path,
+        "---\na: &foo 42\nok:\n  *foo : 1\nextra:\n  *foo  : 2\nafter:\n  *foo:  3\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+
+    for scenario in SCENARIOS {
+        let mut ryl_cmd = build_ryl_command(exe, scenario.ryl_format);
+        ryl_cmd.arg("-c").arg(&cfg_path).arg(&yaml_path);
+        let (ryl_code, ryl_output) = capture_with_env(ryl_cmd, scenario.envs);
+
+        let mut yam_cmd = build_yamllint_command(scenario.yam_format);
+        yam_cmd.arg("-c").arg(&cfg_path).arg(&yaml_path);
+        let (yam_code, yam_output) = capture_with_env(yam_cmd, scenario.envs);
+
+        assert_eq!(ryl_code, 1, "ryl alias exit ({})", scenario.label);
+        assert_eq!(yam_code, 1, "yamllint alias exit ({})", scenario.label);
+        assert_eq!(
+            ryl_output, yam_output,
+            "alias diagnostics mismatch ({})",
+            scenario.label
+        );
+    }
+}
+
+#[test]
 fn inline_comment_after_value_matches_yamllint() {
     ensure_yamllint_installed();
 


### PR DESCRIPTION
Closes #254.

## Problem

An alias used as a mapping key requires a separating space — `*foo : bar`. Without it, `:` is lexed into the alias name (`foo:`), so the space is **required**, not stylistic. The `colons` rule wrongly reported it as "too many spaces before colon".

Confirmed against three authorities:
- **play.yaml.com reference parser**: `*foo: bar` → parse error ("Parser finished before end of input"); `*foo : bar` → `+MAP =ALI *foo =VAL :bar -MAP`.
- **ruamel (YAML 1.2)**: `*foo: bar` → `ComposerError: undefined alias 'foo:'`; `*foo : bar` → `{42: 'bar'}`.
- **yamllint**: does not flag `*foo : bar`.

## Fix

Derive alias extents from the parser's **scanner tokens** (new `collect_alias_ends`) and exempt a colon iff an alias token ends exactly one space before it — the same rule as yamllint's `colons.py` (`prev is AliasToken && gap == 1`), but taken from the parser's real lexing instead of a backward char-scan heuristic.

Using scanner tokens (resolution-independent) rather than parser events also fixes cases the old heuristic got wrong:
- `foo *bar : baz` / `a-*b : c` — plain scalars that merely *contain* `*`; correctly **flagged** (they are not aliases).
- `*foo.bar : v` — alias names with `.`/`/`/etc.; correctly **exempt** (granit and the spec accept the broad anchor charset).
- `*missing : 42` (undefined / forward-referenced anchor) — correctly **exempt** (still an alias token), matching yamllint.

The old heuristic (`alias_immediately_before` and friends) is removed — net source shrink.

## Verification

- New yamllint differential test (`alias_mapping_key_matches_yamllint`) + CLI and unit regressions.
- `property_check` generator extended with alias keys; 512k-case sweep green.
- `prek` clean; zero-missed coverage.

---

A related parser-level question (granit accepts dotted anchor names that PyYAML rejects) is raised upstream at bourumir-wyngs/granit-parser#14; it is out of scope here.
