### PR TITLE
Add `merge-keys` rule flagging `<<` merge keys (closes #256)

### DIFF
--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -116,6 +116,9 @@ max = 100
 allow-non-breakable-words = true
 allow-non-breakable-inline-mappings = true
 
+[rules.merge-keys]
+level = "warning"
+
 [rules.new-line-at-end-of-file]
 level = "warning"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,10 @@ the unsafe-trigger subset in that rule's module-level doc comment instead.
   that depend on whether the scalar is plain, quoted, or block-styled, and on
   whether folding is semantically allowed; no single rewrite is universally
   safe.
+- `merge-keys` — Removing a `<<` merge requires inlining the merged mapping's
+  resolved keys/values (which the source text alone does not carry) and would
+  change the document's structure; quoting the `<<` silently drops the merge, so
+  no rewrite is universally safe.
 - `octal-values` — Resolving `010` requires knowing whether the user meant
   the integer `8`, the integer `10`, or the string `"010"`; the YAML source
   alone cannot disambiguate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,14 @@ ryl is a CLI tool for linting yaml files
   will likely require a new test to be added and maintained. We want to keep code bloat
   to a minimum and the best refactors generally are those that remove lines of code
   while maintaining functionality.
-- Comments should only be used to explain unavoidable code smells (arising from third
-  party crate use), or the reason for temporary dependency version pinning (e.g.
-  linking an unresolved GitHub issues) or lastly explaining opaque code or non-obvious
-  trade-offs or workarounds.
+- Comment the *why*, not the *what*. Capture non-obvious invariants, spec/standard
+  rationale, verified-behaviour notes (e.g. "verified against ruamel/PyYAML"), deliberate
+  trade-offs/workarounds, third-party code smells, and version-pin reasons (link the
+  issue) &mdash; and "looks-wrong-but-isn't" reasoning that stops a later reader
+  "fixing" subtle logic. Because this codebase is maintained largely by AI agents across
+  many models and sessions, that durable *why*-context is usually worth more than the
+  tokens it costs, so lean toward including it. Still don't narrate self-evident *what*:
+  good names carry that, and *what*-comments are the ones that go stale fastest.
 - Leverage the provided linters and formatters to fix code, configuration, and
   documentation often - it's much cheaper to have the linters and formatters auto fix
   issues than correcting them yourself. Only correct what the linters and formatters
@@ -168,11 +172,12 @@ ryl is a CLI tool for linting yaml files
 ## Automated Tests
 
 - Convey a test's purpose with meaningful function and variable names, and convey
-  what each check verifies with assertion messages. Comments in tests follow the
-  same bar as the rest of the codebase (see Coding Standards): keep them minimal and
-  reserve them for genuinely non-obvious trade-offs, opaque mechanics, or
-  module/harness orientation (e.g. a `//!` header describing a property suite's
-  invariants and reuse) — never to narrate what a self-evident test already says.
+  what each check verifies with assertion messages. Comments in tests follow the same
+  *why*-not-*what* bar as the rest of the codebase (see Coding Standards): a one-line
+  note on the invariant a test pins, why an input is crafted a certain way (e.g. the
+  `café` char-vs-byte column rationale), a regression's issue link, or a `//!` header
+  describing a property suite's invariants and reuse is welcome where it adds durable
+  context &mdash; just don't restate what a self-evident assertion already says.
 - Every line of code has a maintenance cost, so don't add tests that don't meaningfully
   increase code coverage. Aim for full branch coverage but also minimise the tests code
   lines to src code lines ratio.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -114,8 +114,10 @@ regions, because a region is not a standalone file:
 - `new-line-at-end-of-file` and `new-lines` — these are governed by the host
   Markdown file, not the embedded snippet.
 
-All other rules (indentation, `key-duplicates`, `colons`, `truthy`,
-`line-length`, `trailing-spaces`, …) run normally.
+Those four are the **only** rules suppressed; every other rule runs normally inside an
+embedded region &mdash; layout (`indentation`, `colons`, `line-length`,
+`trailing-spaces`), keys and values (`key-duplicates`, `truthy`), and the ryl-only
+`tags`, `unicode-line-breaks`, and `merge-keys` rules alike.
 
 [Inline directives](directives.md) (`# ryl disable` / `# yamllint disable`) also
 work inside an embedded region; a directive applies within the region that

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-ryl implements 25 rules for checking YAML files. This page is a categorised
+ryl implements 26 rules for checking YAML files. This page is a categorised
 index of every rule with a brief description and a link to its detailed
 documentation. Each rule page covers what the rule does, why it matters,
 configuration options, and (where applicable) automatic fix behaviour.
@@ -51,6 +51,7 @@ Rules that auto-fix are marked with :wrench: in the **Fix** column.
 | [`empty-values`](rules/empty-values.md) | Empty values in mappings and sequences. |  |
 | [`key-duplicates`](rules/key-duplicates.md) | Duplicate keys in mappings. |  |
 | [`key-ordering`](rules/key-ordering.md) | Alphabetical ordering of mapping keys. |  |
+| [`merge-keys`](rules/merge-keys.md) | The `<<` merge key (a YAML 1.1 feature removed in 1.2). |  |
 | [`tags`](rules/tags.md) | Unsafe and non-portable YAML tags. |  |
 
 ## Comments

--- a/docs/rules/colons.md
+++ b/docs/rules/colons.md
@@ -54,17 +54,21 @@ third:  3
 
 ### Alias mapping keys
 
-A YAML anchor/alias name may legally contain `:`, so `*anchor:` is read as the alias to
-an anchor named `anchor:`. Using an alias as a mapping key therefore *requires* one space
-before the colon &mdash; `*anchor : value`. When that required space is present the
-colon's spacing is not reported (matching the parser's view of the alias); any other
-spacing is checked as usual.
+A YAML anchor/alias name may legally contain `:`, so `*anchor:` welds into an alias to an
+anchor named `anchor:` (a parse error here, since no mapping colon remains). Using an
+alias as a mapping key therefore *requires* one separating space before the colon
+&mdash; `*anchor : value`. When exactly that one space is present the colon's spacing is
+not reported (the rule defers to the parser's view of the alias); more than one space
+before the colon is reported as usual.
 
 ```yaml
-anchor: &a 42
-*a : value     # allowed: the required space is not reported
-*a  : value    # reported: an extra space before the colon
-*a:  value     # reported: too many spaces after the colon
+base: &a name
+*a : value     # allowed: the one required separating space is not reported
+```
+
+```yaml
+base: &a name
+*a  : value    # reported (2:4): too many spaces before colon
 ```
 
 ## Automatic fixing

--- a/docs/rules/key-duplicates.md
+++ b/docs/rules/key-duplicates.md
@@ -110,3 +110,5 @@ which value is canonical.
   order, which makes duplicates harder to introduce accidentally.
 - [`anchors`](anchors.md) &mdash; covers a related class of ambiguity
   for anchor/alias declarations.
+- [`merge-keys`](merge-keys.md) &mdash; forbids the `<<` merge key outright;
+  this rule's merge options instead detect *duplicate* or value-changing merges.

--- a/docs/rules/merge-keys.md
+++ b/docs/rules/merge-keys.md
@@ -1,0 +1,100 @@
+# merge-keys
+
+## What this rule does
+
+Reports the `<<` merge key. A merge key splices the keys of another mapping into
+the current one:
+
+```yaml
+defaults: &defaults
+  retries: 3
+  timeout: 30
+prod:
+  <<: *defaults       # prod gains retries: 3 and timeout: 30
+  host: prod.example.com
+```
+
+When enabled the rule flags every `<<` key, whether its value is an alias
+(`<<: *defaults`), an inline mapping (`<<: {a: 1}`), or a list of either
+(`<<: [*a, *b]`). A key explicitly tagged `!!merge` is also flagged regardless of
+its text (`!!merge foo:` merges in the same loaders that honour `<<`). It is
+**off by default**.
+
+## Why this matters
+
+The merge key is a YAML **1.1** type (`yaml.org/type/merge.html`). YAML **1.2**
+removed it: "The merge `<<` and value `=` special mapping keys have been removed"
+(YAML 1.2.2 changes page). ryl resolves scalars under the YAML 1.2 core schema,
+where `<<` is an ordinary string key with no special meaning.
+
+That makes `<<` a portability trap. Whether `<<: *defaults` actually merges
+anything depends entirely on the parsing library: some still honour the 1.1 merge,
+others treat `<<` as a literal key, so the same document can produce a different
+mapping depending on the tool. A portability-sensitive repository can enable this
+rule to forbid the construct outright.
+
+A quoted `"<<"` is **not** flagged: quoting turns it into a plain string key that
+never merges in any parser (verified against PyYAML and ruamel.yaml), so it is not
+a portability hazard. Note that quoting is therefore not a way to *keep* a merge —
+it removes the merge behaviour entirely.
+
+Sources: YAML 1.2.2 changes page; YAML merge type (`yaml.org/type/merge.html`).
+
+## Configuration
+
+`merge-keys` is a ryl-only rule (yamllint has no equivalent), so it is configured
+**only in TOML** &mdash; `[rules.merge-keys]` in `.ryl.toml`/`ryl.toml` or
+`[tool.ryl.rules.merge-keys]` in `pyproject.toml`. It is rejected in
+yamllint-compatible YAML config (including `-d` data) so the YAML namespace stays
+reserved for any future yamllint rule.
+
+```toml
+[rules.merge-keys]
+level = "error"
+```
+
+The rule has no options: when enabled it flags every `<<` merge key.
+
+## Examples
+
+### :x: Reported
+
+```yaml
+defaults: &defaults
+  retries: 3
+prod:
+  <<: *defaults
+  host: prod.example.com
+```
+
+```text
+4:3  error  forbidden merge key "<<"  (merge-keys)
+```
+
+### :white_check_mark: Allowed
+
+Write the keys explicitly instead of merging:
+
+```yaml
+defaults: &defaults
+  retries: 3
+prod:
+  retries: 3
+  host: prod.example.com
+```
+
+## Automatic fixing
+
+This rule does not auto-fix. Removing a merge requires inlining the merged
+mapping's resolved keys and values (which the source text alone does not carry),
+and quoting the `<<` would silently drop the merge; no single rewrite is
+universally safe.
+
+## Related rules
+
+- [`key-duplicates`](key-duplicates.md) &mdash; its `forbid-duplicated-merge-keys`
+  option targets a *repeated* `<<` in one mapping, and its `check-canonical` /
+  `forbid-merge-key-shadowing` options flag merges that silently change a key's
+  value. `merge-keys` instead forbids *any* use of `<<`.
+- [`anchors`](anchors.md) &mdash; governs the anchors and aliases (`&`/`*`) a
+  merge typically relies on.

--- a/docs/rules/unicode-line-breaks.md
+++ b/docs/rules/unicode-line-breaks.md
@@ -62,7 +62,7 @@ title: "first line<LS>second line"
 ```
 
 ```text
-1:20  error  forbidden raw line separator U+2028; escape as "\L" in a double-quoted scalar  (unicode-line-breaks)
+1:19  error  forbidden raw line separator U+2028; escape as "\L" in a double-quoted scalar  (unicode-line-breaks)
 ```
 
 The rule also fires on a raw `U+0085`/`U+2029` in a plain scalar or a comment.

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -484,6 +484,7 @@
         "key-duplicates",
         "key-ordering",
         "line-length",
+        "merge-keys",
         "new-line-at-end-of-file",
         "new-lines",
         "octal-values",
@@ -1788,6 +1789,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RuleEntryForLineLengthOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "merge-keys": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleEntryForNoOptions"
             },
             {
               "type": "null"

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -262,6 +262,8 @@ pub enum RuleName {
     KeyOrdering,
     #[serde(rename = "line-length")]
     LineLength,
+    #[serde(rename = "merge-keys")]
+    MergeKeys,
     #[serde(rename = "new-line-at-end-of-file")]
     NewLineAtEndOfFile,
     #[serde(rename = "new-lines")]
@@ -301,6 +303,7 @@ impl RuleName {
             Self::KeyDuplicates => "key-duplicates",
             Self::KeyOrdering => "key-ordering",
             Self::LineLength => "line-length",
+            Self::MergeKeys => "merge-keys",
             Self::NewLineAtEndOfFile => "new-line-at-end-of-file",
             Self::NewLines => "new-lines",
             Self::OctalValues => "octal-values",
@@ -346,6 +349,8 @@ pub struct RulesTable<
     pub key_ordering: Option<RuleEntry<KeyOrderingOptions>>,
     #[serde(rename = "line-length")]
     pub line_length: Option<RuleEntry<LineLengthOptions>>,
+    #[serde(rename = "merge-keys")]
+    pub merge_keys: Option<RuleEntry<NoOptions>>,
     #[serde(rename = "new-line-at-end-of-file")]
     pub new_line_at_end_of_file: Option<RuleEntry<NoOptions>>,
     #[serde(rename = "new-lines")]

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -222,6 +222,7 @@ fn rules_table_to_value<Q: Serialize, K: Serialize, A: Serialize>(
     insert_serialized(&mut table, "key-duplicates", rules.key_duplicates.as_ref());
     insert_serialized(&mut table, "key-ordering", rules.key_ordering.as_ref());
     insert_serialized(&mut table, "line-length", rules.line_length.as_ref());
+    insert_serialized(&mut table, "merge-keys", rules.merge_keys.as_ref());
     insert_serialized(
         &mut table,
         "new-line-at-end-of-file",

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -5,9 +5,9 @@ use crate::decoder;
 use crate::rules::{
     anchors, braces, brackets, colons, commas, comments, comments_indentation,
     document_end, document_start, empty_lines, empty_values, float_values, hyphens,
-    indentation, key_duplicates, key_ordering, line_length, new_line_at_end_of_file,
-    new_lines, octal_values, quoted_strings, tags, trailing_spaces, truthy,
-    unicode_line_breaks,
+    indentation, key_duplicates, key_ordering, line_length, merge_keys,
+    new_line_at_end_of_file, new_lines, octal_values, quoted_strings, tags,
+    trailing_spaces, truthy, unicode_line_breaks,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -294,6 +294,8 @@ pub fn lint_str(
         base_dir,
     );
 
+    collect_merge_keys_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
+
     let directives = crate::directives::Directives::parse(content);
     diagnostics.retain(|problem| {
         !problem
@@ -556,6 +558,28 @@ fn collect_unicode_line_breaks_diagnostics(
                 level: level.into(),
                 message: hit.message,
                 rule: Some(unicode_line_breaks::ID),
+            });
+        }
+    }
+}
+
+fn collect_merge_keys_diagnostics(
+    diagnostics: &mut Vec<LintProblem>,
+    content: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+) {
+    if let Some(level) = cfg.rule_level(merge_keys::ID)
+        && !cfg.is_rule_ignored(merge_keys::ID, path, base_dir)
+    {
+        for hit in merge_keys::check(content) {
+            diagnostics.push(LintProblem {
+                line: hit.line,
+                column: hit.column,
+                level: level.into(),
+                message: hit.message,
+                rule: Some(merge_keys::ID),
             });
         }
     }

--- a/src/rules/key_duplicates.rs
+++ b/src/rules/key_duplicates.rs
@@ -579,15 +579,8 @@ impl<'cfg> KeyDuplicatesState<'cfg> {
         }
 
         let id = key_id(value, style, tag, self.config.check_canonical);
-        // A `<<` key is a merge directive when YAML resolves it to the merge
-        // type: a plain untagged `<<` (implicit), or any `<<` carrying an
-        // explicit `!!merge` tag. A quoted/otherwise-tagged `<<` is a plain
-        // string key.
-        let is_merge_directive = value == "<<"
-            && (tag.is_none() && matches!(style, ScalarStyle::Plain)
-                || tag.is_some_and(|tag| {
-                    tag.is_yaml_core_schema() && tag.suffix == "merge"
-                }));
+        let is_merge_directive =
+            crate::rules::support::merge_key::is_merge_directive(value, style, tag);
         let pos = (span.start.line(), span.start.col() + 1);
         let map = self
             .walker

--- a/src/rules/merge_keys.rs
+++ b/src/rules/merge_keys.rs
@@ -17,6 +17,11 @@
 //! (verified against `PyYAML` and ruamel.yaml) and is the portable way to use the
 //! literal text, so it is not flagged.
 //!
+//! Detection covers merge keys whose key node is a *scalar* (every merge key in
+//! practice). A merge tag on a non-scalar key — the pathological
+//! `!!merge {k: 1}: *base` — is not detected, since the key arrives as a
+//! mapping/sequence event rather than a scalar.
+//!
 //! Sources: YAML 1.2.2 changes page; YAML merge type (yaml.org/type/merge.html).
 //! There is no safe `--fix`: removing a merge requires inlining the merged
 //! mapping's resolved values (see AGENTS.md "Rules Without A Safe `--fix`").

--- a/src/rules/merge_keys.rs
+++ b/src/rules/merge_keys.rs
@@ -1,0 +1,80 @@
+//! `merge-keys` rule &mdash; flags the `<<` merge key (issue #256).
+//!
+//! The merge key is a YAML 1.1 type (yaml.org/type/merge.html): `<<: *base`
+//! splices the keys of the mapping `*base` resolves to into the current mapping.
+//! YAML 1.2 removed it &mdash; "The merge `<<` and value `=` special mapping keys
+//! have been removed" (YAML 1.2.2 changes page) &mdash; and ryl resolves scalars
+//! under the YAML 1.2 core schema, where `<<` is an ordinary string key. Whether a
+//! `<<` key performs a merge therefore depends entirely on the parsing library, so
+//! it is a portability trap; this off-by-default rule lets portability-sensitive
+//! repositories forbid it.
+//!
+//! A key is flagged only when YAML would actually merge on it: an untagged plain
+//! `<<`, or ANY scalar explicitly tagged `!!merge` regardless of its text
+//! (`!!merge foo` merges just like `<<`). This is the shared
+//! [`crate::rules::support::merge_key::is_merge_directive`] definition, also used
+//! by `key-duplicates`. A quoted `"<<"` is a plain string key that never merges
+//! (verified against `PyYAML` and ruamel.yaml) and is the portable way to use the
+//! literal text, so it is not flagged.
+//!
+//! Sources: YAML 1.2.2 changes page; YAML merge type (yaml.org/type/merge.html).
+//! There is no safe `--fix`: removing a merge requires inlining the merged
+//! mapping's resolved values (see AGENTS.md "Rules Without A Safe `--fix`").
+
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
+
+use crate::rules::support::mapping_key_walker::Walker;
+use crate::rules::support::merge_key::is_merge_directive;
+
+pub const ID: &str = "merge-keys";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+#[must_use]
+pub fn check(buffer: &str) -> Vec<Violation> {
+    let mut parser = Parser::new_from_str(buffer);
+    let mut receiver = MergeKeysReceiver {
+        walker: Walker::new(),
+        violations: Vec::new(),
+    };
+    let _ = parser.load(&mut receiver, true);
+    receiver.violations
+}
+
+struct MergeKeysReceiver {
+    walker: Walker<()>,
+    violations: Vec<Violation>,
+}
+
+impl SpannedEventReceiver<'_> for MergeKeysReceiver {
+    fn on_event(&mut self, event: Event<'_>, span: Span) {
+        match event {
+            Event::StreamStart | Event::DocumentStart(_) | Event::DocumentEnd => {
+                self.walker.reset();
+            }
+            Event::MappingStart(..) => self.walker.enter_mapping((), ()),
+            Event::SequenceStart(..) => self.walker.enter_sequence(()),
+            Event::MappingEnd | Event::SequenceEnd => self.walker.exit_container(),
+            Event::Scalar(value, style, _anchor, tag) => {
+                let context = self.walker.begin_node();
+                if context.key_root()
+                    && is_merge_directive(value.as_ref(), style, tag.as_ref())
+                {
+                    self.violations.push(Violation {
+                        line: span.start.line(),
+                        column: span.start.col() + 1,
+                        message: format!("forbidden merge key \"{value}\""),
+                    });
+                }
+                self.walker.finish_node(context);
+            }
+            Event::Alias(_) => self.walker.skip_node(),
+            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
+        }
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -15,6 +15,7 @@ pub mod indentation;
 pub mod key_duplicates;
 pub mod key_ordering;
 pub mod line_length;
+pub mod merge_keys;
 pub mod new_line_at_end_of_file;
 pub mod new_lines;
 pub mod octal_values;
@@ -27,7 +28,7 @@ pub mod unicode_line_breaks;
 
 /// Every rule id, used by the directive engine to expand a bare `disable`/`enable`
 /// (no `rule:` token) to "all rules". Extend this when adding a rule.
-pub const ALL_RULE_IDS: [&str; 25] = [
+pub const ALL_RULE_IDS: [&str; 26] = [
     anchors::ID,
     braces::ID,
     brackets::ID,
@@ -45,6 +46,7 @@ pub const ALL_RULE_IDS: [&str; 25] = [
     key_duplicates::ID,
     key_ordering::ID,
     line_length::ID,
+    merge_keys::ID,
     new_line_at_end_of_file::ID,
     new_lines::ID,
     octal_values::ID,
@@ -60,4 +62,5 @@ pub const ALL_RULE_IDS: [&str; 25] = [
 /// out of the YAML schema so the YAML `rules` namespace stays reserved for
 /// yamllint's own definitions (see `AGENTS.md`). Extend this when adding a rule
 /// that yamllint does not have.
-pub const RYL_ONLY_RULE_IDS: [&str; 2] = [tags::ID, unicode_line_breaks::ID];
+pub const RYL_ONLY_RULE_IDS: [&str; 3] =
+    [merge_keys::ID, tags::ID, unicode_line_breaks::ID];

--- a/src/rules/support/merge_key.rs
+++ b/src/rules/support/merge_key.rs
@@ -5,13 +5,16 @@ use std::borrow::Cow;
 
 use granit_parser::{ScalarStyle, Tag};
 
+/// The fully-resolved YAML core-schema merge tag.
+const MERGE_TAG: &str = "tag:yaml.org,2002:merge";
+
 /// Whether a mapping key resolves to the YAML merge type (`tag:yaml.org,2002:merge`).
 ///
 /// Two forms merge: an untagged plain `<<` (implicit resolution), or ANY scalar
-/// explicitly tagged `!!merge` regardless of its text — `!!merge foo` merges in
-/// `PyYAML` and ruamel.yaml exactly like `!!merge "<<"` (both verified). A quoted
-/// `"<<"`, or a `<<` carrying any other tag, is an ordinary string key that never
-/// merges.
+/// explicitly tagged as the merge type regardless of its text — `!!merge foo`
+/// merges in `PyYAML` and ruamel.yaml exactly like `!!merge "<<"` (both verified).
+/// A quoted `"<<"`, or a `<<` carrying any other tag, is an ordinary string key
+/// that never merges.
 #[must_use]
 pub(crate) fn is_merge_directive(
     value: &str,
@@ -19,7 +22,13 @@ pub(crate) fn is_merge_directive(
     tag: Option<&Cow<'_, Tag>>,
 ) -> bool {
     match tag {
-        Some(tag) => tag.is_yaml_core_schema_tag("merge"),
+        // Match by resolved URI (`handle + suffix`) so shorthand (`!!merge`) and
+        // verbatim (`!<tag:yaml.org,2002:merge>`, which granit scans to an empty
+        // handle) are both recognised; `Tag::is_yaml_core_schema` inspects only
+        // the handle and so misses the verbatim spelling.
+        Some(tag) => MERGE_TAG
+            .strip_prefix(tag.handle.as_str())
+            .is_some_and(|suffix| suffix == tag.suffix.as_str()),
         None => value == "<<" && matches!(style, ScalarStyle::Plain),
     }
 }

--- a/src/rules/support/merge_key.rs
+++ b/src/rules/support/merge_key.rs
@@ -1,0 +1,25 @@
+//! Shared definition of a YAML merge key (`<<`), used by `key-duplicates`
+//! (merge-collision detection) and `merge-keys` (portability).
+
+use std::borrow::Cow;
+
+use granit_parser::{ScalarStyle, Tag};
+
+/// Whether a mapping key resolves to the YAML merge type (`tag:yaml.org,2002:merge`).
+///
+/// Two forms merge: an untagged plain `<<` (implicit resolution), or ANY scalar
+/// explicitly tagged `!!merge` regardless of its text — `!!merge foo` merges in
+/// `PyYAML` and ruamel.yaml exactly like `!!merge "<<"` (both verified). A quoted
+/// `"<<"`, or a `<<` carrying any other tag, is an ordinary string key that never
+/// merges.
+#[must_use]
+pub(crate) fn is_merge_directive(
+    value: &str,
+    style: ScalarStyle,
+    tag: Option<&Cow<'_, Tag>>,
+) -> bool {
+    match tag {
+        Some(tag) => tag.is_yaml_core_schema_tag("merge"),
+        None => value == "<<" && matches!(style, ScalarStyle::Plain),
+    }
+}

--- a/src/rules/support/mod.rs
+++ b/src/rules/support/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod comments_scan;
 pub(crate) mod flow_collection;
 pub(crate) mod line_syntax;
 pub(crate) mod mapping_key_walker;
+pub(crate) mod merge_key;
 pub(crate) mod punctuation;
 pub(crate) mod span_utils;

--- a/tests/cli_merge_keys_rule.rs
+++ b/tests/cli_merge_keys_rule.rs
@@ -1,0 +1,162 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
+    if stderr.is_empty() { stdout } else { stderr }
+}
+
+/// `merge-keys` is a ryl-only rule, so it is configured through TOML rather than
+/// the yamllint-compatible YAML config that `-d` carries.
+fn lint_with_toml_config(content: &str, config: &str) -> (i32, String) {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, content).unwrap();
+    let config_path = dir.path().join(".ryl.toml");
+    fs::write(&config_path, config).unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config_path).arg(&file));
+    (code, command_output(&stdout, &stderr).to_string())
+}
+
+const ENABLE: &str = "[rules]\nmerge-keys = \"enable\"\n";
+
+#[test]
+fn flags_merge_key_for_alias_inline_and_sequence_values() {
+    // A plain `<<` merges whether its value is an alias, an inline mapping, or a
+    // sequence of either — the key itself is flagged in every case.
+    let (code, output) = lint_with_toml_config(
+        "base: &b {x: 1}\nalias:\n  <<: *b\ninline:\n  <<: {y: 2}\nseq:\n  <<: [*b]\n",
+        ENABLE,
+    );
+    assert_eq!(code, 1, "merge keys should fail: {output}");
+    for pos in ["3:3", "5:3", "7:3"] {
+        assert!(
+            output.contains(pos),
+            "expected a merge-key diagnostic at {pos}: {output}"
+        );
+    }
+    assert!(
+        output.contains("forbidden merge key") && output.contains("merge-keys"),
+        "message text and bare rule id expected: {output}"
+    );
+}
+
+#[test]
+fn flags_flow_merge_key_with_char_based_column() {
+    // `<<` after a multibyte key in a flow mapping: column 17 counts characters,
+    // not bytes (`é` in `café` is two bytes, which would push the byte offset to
+    // 18).
+    let (code, output) =
+        lint_with_toml_config("base: &b {x: 1}\nflow: {café: 1, <<: *b}\n", ENABLE);
+    assert_eq!(code, 1, "flow merge key should fail: {output}");
+    assert!(
+        output.contains("2:17"),
+        "char-based column past the multibyte key café: {output}"
+    );
+}
+
+#[test]
+fn does_not_flag_quoted_merge_key() {
+    // A quoted `"<<"` is a plain string key that never merges (PyYAML/ruamel),
+    // so it is the portable form and must not be flagged.
+    let (code, output) =
+        lint_with_toml_config("base: &b {x: 1}\nchild:\n  \"<<\": *b\n", ENABLE);
+    assert_eq!(code, 0, "a quoted '<<' is not a merge key: {output}");
+    assert!(
+        !output.contains("merge-keys"),
+        "quoted '<<' must not be flagged: {output}"
+    );
+}
+
+#[test]
+fn flags_explicitly_tagged_merge_key_regardless_of_text() {
+    // An explicit `!!merge` tag performs a merge regardless of the scalar's text
+    // (verified in PyYAML and ruamel), so `!!merge foo` is a merge directive even
+    // though its text is not `<<`; the diagnostic names the actual key.
+    let (code, output) =
+        lint_with_toml_config("base: &b {x: 1}\nchild:\n  !!merge foo: *b\n", ENABLE);
+    assert_eq!(code, 1, "an explicit !!merge key should fail: {output}");
+    assert!(
+        output.contains("3:11")
+            && output.contains("forbidden merge key \"foo\"")
+            && output.contains("merge-keys"),
+        "tagged merge flagged with the actual key text: {output}"
+    );
+}
+
+#[test]
+fn rule_does_not_fire_when_not_enabled() {
+    let (code, output) = lint_with_toml_config(
+        "base: &b {x: 1}\nchild:\n  <<: *b\n",
+        "[rules]\ntruthy = \"enable\"\n",
+    );
+    assert_eq!(code, 0, "rule is off unless enabled: {output}");
+    assert!(
+        !output.contains("merge-keys"),
+        "rule must not run unless enabled: {output}"
+    );
+}
+
+#[test]
+fn rule_is_rejected_in_yaml_config() {
+    // ryl-only: yamllint-compatible YAML config (here via `-d`) must reject it
+    // rather than silently linting or clashing with a future yamllint rule.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "base: &b {x: 1}\nchild:\n  <<: *b\n").unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules: {merge-keys: enable}")
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "a ryl-only rule in YAML config is a usage error: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert!(
+        output.contains("merge-keys"),
+        "error should name the rule: {output}"
+    );
+    assert!(
+        output.to_lowercase().contains("toml"),
+        "error should point to TOML config: {output}"
+    );
+}
+
+#[test]
+fn per_file_ignores_accept_the_rule_name() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ignored.yaml");
+    fs::write(&file, "base: &b {x: 1}\nchild:\n  <<: *b\n").unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        format!(
+            "[rules]\nmerge-keys = \"enable\"\n[per-file-ignores]\n'{}' = ['merge-keys']\n",
+            file.display()
+        ),
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "per-file-ignores should suppress the rule: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+}

--- a/tests/cli_merge_keys_rule.rs
+++ b/tests/cli_merge_keys_rule.rs
@@ -96,6 +96,24 @@ fn flags_explicitly_tagged_merge_key_regardless_of_text() {
 }
 
 #[test]
+fn flags_verbatim_merge_tag() {
+    // A verbatim-spelled core merge tag merges identically (verified in PyYAML and
+    // ruamel) but resolves to an empty handle, so it is matched by the tag's full
+    // URI rather than granit's handle-only `is_yaml_core_schema`.
+    let (code, output) = lint_with_toml_config(
+        "base: &b {x: 1}\n!<tag:yaml.org,2002:merge> foo: *b\n",
+        ENABLE,
+    );
+    assert_eq!(code, 1, "a verbatim merge tag should fail: {output}");
+    assert!(
+        output.contains("2:28")
+            && output.contains("forbidden merge key \"foo\"")
+            && output.contains("merge-keys"),
+        "verbatim merge tag flagged with the actual key text: {output}"
+    );
+}
+
+#[test]
 fn rule_does_not_fire_when_not_enabled() {
     let (code, output) = lint_with_toml_config(
         "base: &b {x: 1}\nchild:\n  <<: *b\n",

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -94,6 +94,7 @@ const RULE_TRIGGERS: &[(&str, &str)] = &[
     ("key-duplicates", "a: 1\na: 2\n"),
     ("key-ordering", "b: 1\na: 2\n"),
     ("line-length", "a: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"),
+    ("merge-keys", "a: &a {x: 1}\nb:\n  <<: *a\n"),
     ("new-line-at-end-of-file", "a: 1"),
     ("new-lines", "a: 1\r\n"),
     ("octal-values", "a: 010\n"),

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -2,7 +2,8 @@ use std::sync::LazyLock;
 
 use ryl::config::YamlLintConfig;
 use ryl::rules::{
-    new_line_at_end_of_file, new_lines, trailing_spaces, unicode_line_breaks,
+    merge_keys, new_line_at_end_of_file, new_lines, trailing_spaces,
+    unicode_line_breaks,
 };
 
 #[derive(Debug, Clone)]
@@ -192,6 +193,13 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     for violation in unicode_line_breaks::check(content) {
         spans.push(Span {
             rule: unicode_line_breaks::ID,
+            line: violation.line,
+            column: violation.column,
+        });
+    }
+    for violation in merge_keys::check(content) {
+        spans.push(Span {
+            rule: merge_keys::ID,
             line: violation.line,
             column: violation.column,
         });


### PR DESCRIPTION
## Summary

Adds a new opt-in rule **`merge-keys`** that flags the YAML `<<` merge key as a
portability trap (issue #256 — the last Tier-1 item of epic #261).

The merge key is a YAML **1.1** type (yaml.org/type/merge.html). YAML **1.2**
removed it ("The merge `<<` and value `=` special mapping keys have been
removed", [YAML 1.2.2 changes page](https://yaml.org/spec/1.2.2/ext/changes/)),
and ryl resolves scalars under the YAML 1.2 core schema where `<<` is an ordinary
string key. Whether `<<: *base` actually merges therefore depends entirely on the
parsing library — a portability hazard. Off-by-default, opt-in for
portability-sensitive repositories.

## Design

- **Parser-backed detection** (not a char heuristic): a small `granit` event
  receiver over the shared `support::mapping_key_walker::Walker`, identical to the
  pattern `key-duplicates` uses to track key/value position.
- **Shared definition.** "What counts as a merge key" is extracted into
  `support::merge_key::is_merge_directive`, now the single source of truth shared
  by both `merge-keys` and `key-duplicates` (the latter's inline copy is removed —
  net cleaner there).
- **ryl-only, TOML-only, off by default**, consistent with `tags` /
  `unicode-line-breaks`: added to `RYL_ONLY_RULE_IDS` (rejected in YAML config,
  pruned from the YAML schema), configured only via `[rules.merge-keys]`.
- **No safe `--fix`** (added to the AGENTS.md catalog): removing a merge needs the
  merged mapping's resolved values and changes structure.

## What is flagged (verified against PyYAML and ruamel.yaml)

| Key | Merges? | Flagged |
| --- | --- | --- |
| plain `<<:` | yes | ✅ |
| `!!merge`-tagged scalar (e.g. `!!merge foo:`), any text | yes | ✅ |
| `<<: *a` / `<<: {…}` / `<<: [*a, *b]` | yes | ✅ |
| quoted `"<<":` | no (portable string key) | ❌ |
| `!!str <<:` (explicit non-merge tag) | no | ❌ |

An explicit `!!merge` tag triggers a merge **regardless of the scalar's text**
(confirmed in both PyYAML and ruamel, 1.1 and 1.2 modes), so the rule flags it
independent of text; the diagnostic names the actual key (`forbidden merge key
"foo"`).

## Sources

- [YAML 1.2.2 changes page](https://yaml.org/spec/1.2.2/ext/changes/)
- [YAML merge type (1.1)](https://yaml.org/type/merge.html)

## Testing

- New `tests/cli_merge_keys_rule.rs` (7 tests: alias/inline/seq, char-based
  columns, quoted-`<<` not flagged, explicit `!!merge` regardless of text,
  off-by-default, rejected-in-YAML-config, per-file-ignores).
- `property_check` trigger + harness dispatch (the generator already emits `<<`);
  ~1000× release sweep (512k cases) clean.
- `prek` green, coverage reports **zero** uncovered lines/regions.

After merge: this completes Tier-1 of #261 — a release bundling #251–#256 follows.