### PR TITLE
Recognise verbatim core-schema tags via shared core_schema_suffix helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,6 +437,18 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   everywhere (leading-zero decimal is an int, an empty plain scalar is null, `0x`/`0o`
   radixes, full bool/null spelling sets); keep that schema choice consistent across rules
   instead of switching to JSON/1.1 semantics in any single rule.
+- Matching a core-schema tag (`!!int`, `!!str`, …): use
+  `crate::yaml_dom::core_schema_suffix(tag)` / `is_core_schema(tag)`, **never**
+  granit's `Tag::is_yaml_core_schema`. The latter inspects only the *handle*, so a
+  verbatim core tag (`!<tag:yaml.org,2002:int>` — granit scans it to an empty handle
+  with the full URI in `suffix`) slips past it even though PyYAML/ruamel resolve it to
+  the same type. The shared helpers report the core suffix for both the canonical
+  `tag:yaml.org,2002:` handle (including a `%TAG` that resolves to it) and the verbatim
+  spelling. They do **not** decompose a `%TAG` directive that splits the URI mid-token
+  (`%TAG !m! tag:yaml.org,2002:m` + `!m!erge`, which the reference parser still resolves
+  to `tag:yaml.org,2002:merge`); to match one specific type regardless of the split
+  point, compare the complete resolved URI (`handle` ++ `suffix`) as
+  `rules::support::merge_key` does for the merge tag (#277).
 
 CI will fail the build on any missed line or region, so keep local runs green by
 sticking to the quick-status step above.

--- a/src/rules/key_duplicates.rs
+++ b/src/rules/key_duplicates.rs
@@ -47,7 +47,7 @@ use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver, Tag}
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::mapping_key_walker::Walker;
-use crate::yaml_dom::{Scalar, ScalarOwned};
+use crate::yaml_dom::{Scalar, ScalarOwned, core_schema_suffix, is_core_schema};
 
 pub const ID: &str = "key-duplicates";
 
@@ -117,7 +117,7 @@ fn key_id(
     canonical: bool,
 ) -> KeyId {
     if canonical
-        && tag.is_none_or(|tag| tag.is_yaml_core_schema())
+        && tag.is_none_or(|tag| is_core_schema(tag))
         && let Some(scalar) = Scalar::resolve_scalar(Cow::Borrowed(value), style, tag)
     {
         return KeyId::Resolved(scalar.into_owned());
@@ -159,9 +159,13 @@ const DEFAULT_TAG_SUFFIXES: [&str; 7] =
 /// the implicit default tags do not.
 fn tag_vid(tag: Option<&Cow<'_, Tag>>) -> Vid {
     match tag.map(Cow::as_ref) {
+        // `core_schema_suffix`, not granit's handle-only check, so a verbatim core
+        // default tag is recognised as non-distinguishing too (#277).
         Some(tag)
-            if !(tag.is_yaml_core_schema()
-                && DEFAULT_TAG_SUFFIXES.contains(&tag.suffix.as_str())) =>
+            if !matches!(
+                core_schema_suffix(tag),
+                Some(suffix) if DEFAULT_TAG_SUFFIXES.contains(&suffix)
+            ) =>
         {
             hash_of(tag)
         }

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -8,7 +8,7 @@ use crate::rules::support::mapping_key_walker::Walker;
 use crate::rules::support::span_utils::{
     BytePos, apply_replacements, marker_byte_offset,
 };
-use crate::yaml_dom::Scalar;
+use crate::yaml_dom::{Scalar, is_core_schema};
 
 pub const ID: &str = "quoted-strings";
 
@@ -468,10 +468,6 @@ fn build_violation(span: Span, message: String) -> Violation {
     }
 }
 
-fn is_core_tag(tag: &Tag) -> bool {
-    tag.handle == "tag:yaml.org,2002:"
-}
-
 fn value_resolves_to_string(value: &str) -> bool {
     matches!(
         Scalar::resolve_plain_scalar(value.into()),
@@ -495,7 +491,7 @@ fn should_skip_scalar(
     }
 
     if let Some(tag) = tag
-        && is_core_tag(tag)
+        && is_core_schema(tag)
     {
         return true;
     }

--- a/src/rules/support/merge_key.rs
+++ b/src/rules/support/merge_key.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 
 use granit_parser::{ScalarStyle, Tag};
 
-/// The fully-resolved YAML core-schema merge tag.
+/// The fully-resolved YAML core-schema merge tag URI.
 const MERGE_TAG: &str = "tag:yaml.org,2002:merge";
 
 /// Whether a mapping key resolves to the YAML merge type (`tag:yaml.org,2002:merge`).
@@ -22,10 +22,15 @@ pub(crate) fn is_merge_directive(
     tag: Option<&Cow<'_, Tag>>,
 ) -> bool {
     match tag {
-        // Match by resolved URI (`handle + suffix`) so shorthand (`!!merge`) and
-        // verbatim (`!<tag:yaml.org,2002:merge>`, which granit scans to an empty
-        // handle) are both recognised; `Tag::is_yaml_core_schema` inspects only
-        // the handle and so misses the verbatim spelling.
+        // Match the *complete* resolved URI (`handle` ++ `suffix`), not the
+        // canonical-split suffix that `yaml_dom::core_schema_suffix` reports. The
+        // spec resolves a tag by concatenating the `%TAG` prefix with the suffix
+        // (YAML 1.2.2 §6.8.2.2), so the merge URI can be split anywhere: the
+        // play.yaml.com reference parser resolves `%TAG !m! tag:yaml.org,2002:m`
+        // + `!m!erge`, verbatim `!<tag:yaml.org,2002:merge>`, and `!!merge` all to
+        // the same `tag:yaml.org,2002:merge`, and PyYAML/ruamel merge all three.
+        // `core_schema_suffix` only reports the canonical/verbatim splits, so the
+        // merge check matches the whole URI here instead.
         Some(tag) => MERGE_TAG
             .strip_prefix(tag.handle.as_str())
             .is_some_and(|suffix| suffix == tag.suffix.as_str()),

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -29,11 +29,10 @@
 use granit_parser::{Event, Parser, Span, SpannedEventReceiver, Tag};
 
 use crate::config::YamlLintConfig;
-use crate::yaml_dom::YamlOwned;
+use crate::yaml_dom::{YamlOwned, core_schema_suffix};
 
 pub const ID: &str = "tags";
 
-const CORE_SCHEMA_PREFIX: &str = "tag:yaml.org,2002:";
 const UNSAFE_TAG_PREFIXES: [&str; 7] = [
     "python/", "ruby/", "perl/", "php/", "java/", "java.", "javax.",
 ];
@@ -86,7 +85,7 @@ impl Config {
         if tag.suffix == "!" {
             return None;
         }
-        let core = core_suffix(tag);
+        let core = core_schema_suffix(tag);
         if self.forbid_unsafe_tags
             && unsafe_namespace(tag, core).is_some_and(is_unsafe_suffix)
         {
@@ -156,19 +155,6 @@ fn is_unsafe_suffix(suffix: &str) -> bool {
         .any(|prefix| suffix.starts_with(prefix))
 }
 
-/// The core-schema type suffix this tag resolves to regardless of spelling
-/// (`!!omap` and verbatim `!<tag:yaml.org,2002:omap>` both yield `omap`), or
-/// `None` for any non-core tag.
-fn core_suffix(tag: &Tag) -> Option<&str> {
-    if tag.handle == CORE_SCHEMA_PREFIX {
-        Some(tag.suffix.as_str())
-    } else if tag.handle.is_empty() {
-        tag.suffix.strip_prefix(CORE_SCHEMA_PREFIX)
-    } else {
-        None
-    }
-}
-
 /// The construction namespace this tag could match, or `None` when its handle
 /// is a custom `%TAG` prefix (whose suffix is a local name in an unrelated
 /// namespace, so it must not be namespace-matched). Only core-schema (`!!`) and
@@ -188,7 +174,7 @@ fn unsafe_namespace<'a>(tag: &'a Tag, core: Option<&'a str>) -> Option<&'a str> 
 /// core-schema tags however they were spelled, otherwise its author-facing
 /// spelling.
 fn shorthand(tag: &Tag) -> String {
-    match core_suffix(tag) {
+    match core_schema_suffix(tag) {
         Some(suffix) => format!("!!{suffix}"),
         None => tag.original(),
     }

--- a/src/yaml_dom/loader.rs
+++ b/src/yaml_dom/loader.rs
@@ -10,6 +10,7 @@ use granit_parser::{
     Event, Marker, Parser, ScanError, Span, SpannedEventReceiver, Tag,
 };
 
+use super::is_core_schema;
 use crate::yaml_dom::scalar::Scalar;
 use crate::yaml_dom::yaml_owned::{MappingOwned, YamlOwned};
 
@@ -113,7 +114,7 @@ impl<'input> SpannedEventReceiver<'input> for Loader {
             }
             Event::Scalar(value, style, aid, tag) => {
                 let node = match tag.as_ref() {
-                    Some(tag_ref) if !tag_ref.is_yaml_core_schema() => {
+                    Some(tag_ref) if !is_core_schema(tag_ref) => {
                         let inner = Scalar::resolve_scalar(value, style, None)
                             .map_or(YamlOwned::BadValue, |scalar| {
                                 YamlOwned::Value(scalar.into_owned())
@@ -167,7 +168,7 @@ impl Loader {
             Container::Mapping(map, _) => YamlOwned::Mapping(map),
         };
         let node = match tag {
-            Some(tag) if !tag.is_yaml_core_schema() => {
+            Some(tag) if !is_core_schema(&tag) => {
                 YamlOwned::Tagged(tag, Box::new(node))
             }
             _ => node,

--- a/src/yaml_dom/loader.rs
+++ b/src/yaml_dom/loader.rs
@@ -10,7 +10,7 @@ use granit_parser::{
     Event, Marker, Parser, ScanError, Span, SpannedEventReceiver, Tag,
 };
 
-use super::is_core_schema;
+use super::{core_schema_suffix, is_core_schema};
 use crate::yaml_dom::scalar::Scalar;
 use crate::yaml_dom::yaml_owned::{MappingOwned, YamlOwned};
 
@@ -163,15 +163,22 @@ impl Loader {
             size,
         } = frame;
         let self_size = size + 1;
-        let node = match container {
-            Container::Sequence(seq) => YamlOwned::Sequence(seq),
-            Container::Mapping(map, _) => YamlOwned::Mapping(map),
+        // `default_suffix` is the core-schema tag this collection resolves to
+        // implicitly, so an explicit tag equal to it is redundant and dropped.
+        let (node, default_suffix) = match container {
+            Container::Sequence(seq) => (YamlOwned::Sequence(seq), "seq"),
+            Container::Mapping(map, _) => (YamlOwned::Mapping(map), "map"),
         };
+        // Drop only the collection's own default core tag (`!!map` on a mapping,
+        // `!!seq` on a sequence). A mismatched core tag (`!!seq` on a mapping), an
+        // unknown core suffix (`!!custom`), or a local tag is preserved as `Tagged`
+        // so config validation rejects it instead of silently treating the node as
+        // untyped — mirroring the scalar path, which yields `BadValue` for a core
+        // tag that does not match the value.
         let node = match tag {
-            Some(tag) if !is_core_schema(&tag) => {
-                YamlOwned::Tagged(tag, Box::new(node))
-            }
-            _ => node,
+            Some(tag) if core_schema_suffix(&tag) == Some(default_suffix) => node,
+            Some(tag) => YamlOwned::Tagged(tag, Box::new(node)),
+            None => node,
         };
         if anchor_id > 0 {
             self.anchor_map.insert(anchor_id, node.clone());

--- a/src/yaml_dom/mod.rs
+++ b/src/yaml_dom/mod.rs
@@ -4,7 +4,9 @@
 
 mod loader;
 mod scalar;
+mod tag;
 mod yaml_owned;
 
 pub use scalar::{Scalar, ScalarOwned};
+pub use tag::{core_schema_suffix, is_core_schema};
 pub use yaml_owned::{MappingOwned, SequenceOwned, YamlOwned};

--- a/src/yaml_dom/scalar.rs
+++ b/src/yaml_dom/scalar.rs
@@ -13,6 +13,8 @@ use std::borrow::Cow;
 use granit_parser::{ScalarStyle, Tag};
 use ordered_float::OrderedFloat;
 
+use super::core_schema_suffix;
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum Scalar<'input> {
     Null,
@@ -50,23 +52,25 @@ impl<'input> Scalar<'input> {
     ) -> Option<Self> {
         // An explicit core-schema tag fixes the type regardless of quoting style
         // (`!!int "1"` is the integer 1, not the string "1"), so it is resolved
-        // before the non-plain-is-a-string fallback.
-        match tag.map(Cow::as_ref) {
-            Some(tag) if tag.is_yaml_core_schema() => match tag.suffix.as_str() {
-                "bool" => parse_core_schema_bool(&v).map(Self::Boolean),
-                "int" => parse_core_schema_int(&v).map(Self::Integer),
-                "float" => parse_core_schema_fp(&v)
-                    .map(OrderedFloat)
-                    .map(Self::FloatingPoint),
-                "null" => is_core_schema_null(&v).then_some(Self::Null),
-                // `merge` resolves `!!merge '<<'` to the same string identity as a
-                // plain `<<` so the two merge-key spellings are recognised as one
-                // key (e.g. for `forbid-duplicated-merge-keys`).
-                "str" | "merge" => Some(Self::String(v)),
-                _ => None,
-            },
-            _ if style != ScalarStyle::Plain => Some(Self::String(v)),
-            _ => Some(Self::resolve_plain_scalar(v)),
+        // before the non-plain-is-a-string fallback. Matching on the core-schema
+        // *suffix* (not the handle) means a verbatim `!<tag:yaml.org,2002:int>`
+        // resolves identically to the `!!int` shorthand (issue #277).
+        match tag.map(Cow::as_ref).and_then(core_schema_suffix) {
+            Some("bool") => parse_core_schema_bool(&v).map(Self::Boolean),
+            Some("int") => parse_core_schema_int(&v).map(Self::Integer),
+            Some("float") => parse_core_schema_fp(&v)
+                .map(OrderedFloat)
+                .map(Self::FloatingPoint),
+            Some("null") => is_core_schema_null(&v).then_some(Self::Null),
+            // `merge` resolves a `!!merge '<<'` to the same string identity as a
+            // plain `<<` so the two merge-key spellings are recognised as one key
+            // (e.g. for `forbid-duplicated-merge-keys`).
+            Some("str" | "merge") => Some(Self::String(v)),
+            // A core tag naming a non-scalar type (`!!seq`, `!!map`) cannot resolve
+            // a scalar value.
+            Some(_) => None,
+            None if style != ScalarStyle::Plain => Some(Self::String(v)),
+            None => Some(Self::resolve_plain_scalar(v)),
         }
     }
 

--- a/src/yaml_dom/tag.rs
+++ b/src/yaml_dom/tag.rs
@@ -1,0 +1,40 @@
+//! Spelling-independent inspection of YAML core-schema tags.
+//!
+//! `granit_parser::Tag::is_yaml_core_schema` inspects only the tag *handle*, so a
+//! verbatim core tag — `!<tag:yaml.org,2002:int>`, which granit scans to an empty
+//! handle with the full URI sitting in `suffix` — is not recognised as
+//! core-schema even though `PyYAML` and ruamel.yaml resolve every spelling to the
+//! same type (verified). These helpers collapse all three spellings (shorthand
+//! `!!int`, a `%TAG`-resolved handle, and verbatim) onto one core-schema suffix,
+//! so a rule matches a type regardless of how the author wrote the tag and the
+//! verbatim form cannot be used to evade a check.
+//!
+//! Prefer these over `Tag::is_yaml_core_schema` for any spelling-independent
+//! core-schema decision (issue #277).
+
+use granit_parser::Tag;
+
+/// The core-schema tag-handle prefix (`tag:yaml.org,2002:`) that `!!`-shorthand
+/// tags resolve to, and that a verbatim core tag carries inside its suffix.
+const CORE_SCHEMA_PREFIX: &str = "tag:yaml.org,2002:";
+
+/// The core-schema type suffix this tag resolves to regardless of spelling
+/// (`!!int`, a `%TAG`-resolved `tag:yaml.org,2002:` handle, and verbatim
+/// `!<tag:yaml.org,2002:int>` all yield `int`), or `None` for any non-core tag.
+#[must_use]
+pub fn core_schema_suffix(tag: &Tag) -> Option<&str> {
+    if tag.handle == CORE_SCHEMA_PREFIX {
+        Some(tag.suffix.as_str())
+    } else if tag.handle.is_empty() {
+        // Verbatim `!<…>` tags carry an empty handle and the full URI in `suffix`.
+        tag.suffix.strip_prefix(CORE_SCHEMA_PREFIX)
+    } else {
+        None
+    }
+}
+
+/// Whether `tag` resolves to a YAML core-schema type under any spelling.
+#[must_use]
+pub fn is_core_schema(tag: &Tag) -> bool {
+    core_schema_suffix(tag).is_some()
+}

--- a/tests/cli_key_duplicates_rule.rs
+++ b/tests/cli_key_duplicates_rule.rs
@@ -41,6 +41,25 @@ fn canonical_treats_numeric_spellings_of_one_integer_as_duplicate() {
 }
 
 #[test]
+fn canonical_resolves_verbatim_core_int_tag() {
+    // A verbatim `!<tag:yaml.org,2002:int>` resolves to the same integer as the
+    // shorthand, so `0xB` (int 11) collides with `11` even in long-form. Pre-#277
+    // the handle-only `is_yaml_core_schema` left the verbatim key as raw text.
+    let (code, output) = run_toml(
+        "check-canonical = true\n",
+        "? !<tag:yaml.org,2002:int> 0xB\n: a\n11: b\n",
+    );
+    assert_eq!(
+        code, 1,
+        "verbatim core int key should canonicalize: {output}"
+    );
+    assert!(
+        output.contains("duplication of key \"11\" in mapping"),
+        "verbatim !!int 0xB should collide with 11: {output}"
+    );
+}
+
+#[test]
 fn canonical_reports_each_duplicate_integer_spelling() {
     let (code, output) =
         run_toml("check-canonical = true\n", "0xB: a\n11: b\n0o13: c\n");

--- a/tests/cli_merge_keys_rule.rs
+++ b/tests/cli_merge_keys_rule.rs
@@ -114,6 +114,27 @@ fn flags_verbatim_merge_tag() {
 }
 
 #[test]
+fn flags_merge_tag_split_by_a_tag_directive() {
+    // The spec resolves a tag by concatenating the %TAG prefix with the suffix
+    // (YAML 1.2.2 §6.8.2.2), so a directive may split the merge URI anywhere. The
+    // play.yaml.com reference parser resolves `%TAG !m! tag:yaml.org,2002:m` +
+    // `!m!erge` to the same `tag:yaml.org,2002:merge` as `!!merge`, and
+    // PyYAML/ruamel merge it — so merge-keys must flag it. Guards against matching
+    // only the canonical handle split (which `core_schema_suffix` reports).
+    let (code, output) = lint_with_toml_config(
+        "%TAG !m! tag:yaml.org,2002:m\n---\nbase: &b {x: 1}\n!m!erge foo: *b\n",
+        ENABLE,
+    );
+    assert_eq!(code, 1, "a %TAG-split merge tag should fail: {output}");
+    assert!(
+        output.contains("4:9")
+            && output.contains("forbidden merge key \"foo\"")
+            && output.contains("merge-keys"),
+        "%TAG-split merge tag flagged with the actual key text: {output}"
+    );
+}
+
+#[test]
 fn rule_does_not_fire_when_not_enabled() {
     let (code, output) = lint_with_toml_config(
         "base: &b {x: 1}\nchild:\n  <<: *b\n",

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -355,3 +355,43 @@ fn fix_consistent_ignores_escaped_exception_when_seeding_style() {
         "escaped: \"line\\nbreak\"\nplain: 'value'\nquoted: 'two'\n"
     );
 }
+
+#[test]
+fn skips_verbatim_core_str_tag_like_shorthand() {
+    // An explicit core `!!str` tag (any spelling, verbatim included) declares the
+    // type, so `required: true` must not demand quotes around it. Pre-#277 the
+    // verbatim spelling was not recognised as core and was flagged. Only the
+    // untagged plain scalar should remain.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.yaml");
+    fs::write(
+        &file,
+        "shorthand: !!str scalar_one\nverbatim: !<tag:yaml.org,2002:str> scalar_two\nuntagged: scalar_three\n",
+    )
+    .unwrap();
+
+    let config = dir.path().join("config.yaml");
+    fs::write(
+        &config,
+        "rules:\n  document-start: disable\n  quoted-strings:\n    required: true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 1,
+        "the untagged plain scalar should still be flagged: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert_eq!(
+        output.matches("string value is not quoted").count(),
+        1,
+        "both tag spellings must be skipped; only the untagged value is flagged: {output}"
+    );
+    assert!(
+        output.contains("3:11"),
+        "the lone diagnostic should point at the untagged value on line 3: {output}"
+    );
+}

--- a/tests/yaml_dom.rs
+++ b/tests/yaml_dom.rs
@@ -154,6 +154,40 @@ fn unknown_core_schema_tag_is_bad_value() {
     assert!(matches!(v, YamlOwned::BadValue));
 }
 
+// granit scans a verbatim `!<…>` tag to an *empty* handle with the full URI in
+// the suffix, so a core tag must be recognised by suffix rather than handle to
+// resolve like its `!!` shorthand. Verified vs PyYAML + ruamel.yaml (issue #277).
+#[test]
+fn resolves_verbatim_core_schema_int_tag_like_shorthand() {
+    let doc = parse_single("v: !<tag:yaml.org,2002:int> 0xB\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_integer),
+        Some(11),
+        "a verbatim core int tag must resolve, not stay a Tagged node"
+    );
+}
+
+#[test]
+fn resolves_verbatim_core_schema_str_tag_forces_string() {
+    let doc = parse_single("v: !<tag:yaml.org,2002:str> 42\n");
+    assert_eq!(
+        doc.as_mapping_get("v").and_then(YamlOwned::as_str),
+        Some("42")
+    );
+}
+
+// The loader wraps only *non*-core tags as `Tagged`; a verbatim core collection
+// tag must unwrap to the plain collection just like the shorthand does.
+#[test]
+fn verbatim_core_schema_seq_tag_unwraps_like_shorthand() {
+    let doc = parse_single("v: !<tag:yaml.org,2002:seq>\n  - 1\n  - 2\n");
+    let seq = doc
+        .as_mapping_get("v")
+        .and_then(YamlOwned::as_sequence)
+        .expect("verbatim core seq tag resolves to a sequence, not a Tagged node");
+    assert_eq!(seq.len(), 2);
+}
+
 #[test]
 fn non_core_tagged_scalar_wraps_in_tagged() {
     let doc = parse_single("v: !foo bar\n");

--- a/tests/yaml_dom.rs
+++ b/tests/yaml_dom.rs
@@ -188,6 +188,53 @@ fn verbatim_core_schema_seq_tag_unwraps_like_shorthand() {
     assert_eq!(seq.len(), 2);
 }
 
+// A core tag matching the node kind is the node's implicit tag, so it is dropped
+// (the collection resolves as itself); both spellings behave the same.
+#[test]
+fn matching_core_collection_tag_unwraps() {
+    for src in ["v: !!map {a: b}\n", "v: !<tag:yaml.org,2002:map> {a: b}\n"] {
+        assert!(
+            matches!(
+                parse_single(src).as_mapping_get("v"),
+                Some(YamlOwned::Mapping(_))
+            ),
+            "{src:?} should resolve to a plain mapping"
+        );
+    }
+    for src in ["v: !!seq [1, 2]\n", "v: !<tag:yaml.org,2002:seq> [1, 2]\n"] {
+        assert!(
+            matches!(
+                parse_single(src).as_mapping_get("v"),
+                Some(YamlOwned::Sequence(_))
+            ),
+            "{src:?} should resolve to a plain sequence"
+        );
+    }
+}
+
+// A core tag that does NOT match the node kind (`!!seq` on a mapping) or an unknown
+// core suffix (`!!custom`) is not the implicit tag, so it is preserved as `Tagged`
+// (→ rejected by config validation) rather than silently discarded — matching the
+// scalar path's `BadValue` and the local-tag path, in both shorthand and verbatim
+// spellings (issue #277 review).
+#[test]
+fn mismatched_or_unknown_core_collection_tag_stays_tagged() {
+    for src in [
+        "v: !!seq {a: b}\n",
+        "v: !<tag:yaml.org,2002:seq> {a: b}\n",
+        "v: !!custom {a: b}\n",
+        "v: !<tag:yaml.org,2002:custom> {a: b}\n",
+    ] {
+        assert!(
+            matches!(
+                parse_single(src).as_mapping_get("v"),
+                Some(YamlOwned::Tagged(_, _))
+            ),
+            "{src:?} should preserve the non-matching core tag as Tagged"
+        );
+    }
+}
+
 #[test]
 fn non_core_tagged_scalar_wraps_in_tagged() {
     let doc = parse_single("v: !foo bar\n");


### PR DESCRIPTION
First of two PRs implementing the #277 pre-0.14.0 cleanup. This one is the single
**correctness** item (#277 items 1 & 4); the cross-cutting DRY/docs work follows in PR2.

## Problem

`granit_parser::Tag::is_yaml_core_schema()` inspects only the tag **handle**, so a verbatim
core tag — `!<tag:yaml.org,2002:int>`, which granit scans to an *empty* handle with the full
URI in `suffix` — was not recognised as core-schema. PyYAML and ruamel.yaml resolve every
spelling to the same type, so verbatim core tags silently slipped past scalar resolution,
`key-duplicates --check-canonical`, and `quoted-strings`. Pre-existing (not a #252–#256
regression), but a real contract gap.

## Fix

Add one shared helper `yaml_dom::core_schema_suffix(tag) -> Option<&str>` / `is_core_schema`
(the spelling-independent logic previously inlined in `tags::core_suffix`) and route the
canonical/verbatim core-tag sites through it:

- `yaml_dom::scalar::resolve_scalar`
- `key_duplicates::{key_id, tag_vid}`
- `quoted_strings` (replaces the handle-only `is_core_tag`)
- `tags` (delegates its `core_suffix`)
- both YAML config-loader guards (`yaml_dom::loader`)

Verbatim and shorthand core tags now behave identically at these sites.

## Why `merge_key` keeps its own match

`rules::support::merge_key` intentionally does **not** use `core_schema_suffix`; it compares
the **complete** resolved URI (`handle ++ suffix`). The spec resolves a tag by concatenating
the `%TAG` prefix with the suffix (YAML 1.2.2 §6.8.2.2), so the merge URI can be split at any
seam — `%TAG !m! tag:yaml.org,2002:m` + `!m!erge` resolves to `tag:yaml.org,2002:merge` on
the play.yaml.com reference parser and merges in PyYAML/ruamel. `core_schema_suffix` reports
only the canonical/verbatim splits (the bare suffix can't be a borrowed `&str` when it
straddles the handle/suffix boundary), so the merge check matches the whole URI to stay
spec-correct. A regression test pins the mid-token `%TAG` case.

## Verification

Verbatim resolution (`int`/`str`/`bool`/`null`/`merge`) and the `%TAG`-split merge checked
against ruamel.yaml, PyYAML, and the play.yaml.com reference parser. New DOM-level
(`tests/yaml_dom.rs`) and CLI-level regression tests; `prek` clean; coverage zero-missed.
