### PR TITLE
Pre-0.14.0 cleanup: lint dispatch macro, shared test harness, rule docs (#277)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,17 +207,18 @@ rather than shipping silently. Work this checklist (the detailed test sections u
     memory. (Cautionary tale: granit-parser#14 was filed claiming granit narrowed anchor
     names at `:` like PyYAML; it never reproduced on *any* granit version — granit is
     spec-correct there — an embarrassing false positive filed on an untested assumption.)
-  - **Ship the draft as its own directory with a single-command reproduction**, the format
-    in `/home/owen/Code/ryl_repos/granit-issue-14-repro/` (use it as the template): a
-    sub-directory `/home/owen/Code/ryl_repos/<repo>-<topic>-repro/` holding a `README.md`
-    (the draft issue/reply text + how to run) and a minimal repro that runs **unedited in
-    one command** and prints a clear verdict — for a Rust dep, a tiny `cargo` project
-    (`cargo run`, plus a `bash check-all-versions.sh` sweeping the version pins) printing
-    observed-vs-expected; for other ecosystems, the equivalent one-command script. So the
-    maintainer can confirm the behaviour first-hand before it is raised. No repro, no
-    report. Keep the prose succinct out of respect for these responsive volunteer
-    maintainers' time: concrete ask, then the runnable repro, then authoritative evidence
-    (spec quote / play.yaml.com event stream), and cut the rest.
+  - **Ship the draft as its own directory with a single-command reproduction.** Put it
+    outside the ryl repo (ask the maintainer where they keep issue drafts if you don't
+    already know) in a self-contained `<repo>-<topic>-repro/` directory: a `README.md`
+    with the draft issue/reply text and how to run, plus a minimal repro that runs
+    **unedited in one command** and prints a clear verdict. For a Rust dep, that's a tiny
+    `cargo` project (`cargo run`, plus a `bash check-all-versions.sh` over the version
+    pins) printing observed-vs-expected; for other ecosystems, the equivalent
+    one-command script. The point is that the maintainer can confirm the behaviour
+    first-hand before it is raised. No repro, no report. Keep the prose succinct out of
+    respect for these responsive volunteer maintainers' time: concrete ask, then the
+    runnable repro, then authoritative evidence (spec quote / play.yaml.com event
+    stream), and cut the rest.
 - Linters and tests may write outside the workspace (e.g., `~/.cache/prek`). If
   sandboxed, request permission escalation when running `prek`, `cargo test`,
   or coverage commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,12 +211,14 @@ rather than shipping silently. Work this checklist (the detailed test sections u
     outside the ryl repo (ask the maintainer where they keep issue drafts if you don't
     already know) in a self-contained `<repo>-<topic>-repro/` directory: a `README.md`
     with the draft issue/reply text and how to run, plus a minimal repro that runs
-    **unedited in one command** and prints a clear verdict. For a Rust dep, that's a tiny
-    `cargo` project (`cargo run`, plus a `bash check-all-versions.sh` over the version
-    pins) printing observed-vs-expected; for other ecosystems, the equivalent
-    one-command script. The point is that the maintainer can confirm the behaviour
-    first-hand before it is raised. No repro, no report. Keep the prose succinct out of
-    respect for these responsive volunteer maintainers' time: concrete ask, then the
+    **unedited in one command** and prints a clear verdict. Reproduce against the
+    dependency's **latest** version — that's what its maintainer cares about, so there's
+    no need to sweep older releases. For a Rust dep, that's a tiny `cargo` project pinned
+    to the latest version, run with `cargo run`, printing observed-vs-expected; for other
+    ecosystems, the equivalent one-command script — so the maintainer can confirm the
+    behaviour first-hand before it is raised. No repro, no report. Keep the prose
+    succinct out of respect for these responsive volunteer maintainers' time: concrete
+    ask, then the
     runnable repro, then authoritative evidence (spec quote / play.yaml.com event
     stream), and cut the rest.
 - Linters and tests may write outside the workspace (e.g., `~/.cache/prek`). If

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,40 @@ ryl is a CLI tool for linting yaml files
   `config_schema::yaml_schema` prunes them from the YAML schema, so they are
   configurable only via TOML (`[rules.<id>]`).
 
+## Adding a New Rule
+
+A rule touches several disconnected sites; a missing one usually fails a guard test
+rather than shipping silently. Work this checklist (the detailed test sections under
+*Automated Tests* expand on steps 5–6):
+
+1. **Rule module** `src/rules/<rule>.rs`: a `pub const ID`, a `Config` with
+   `resolve(&YamlLintConfig)`, a `check(...) -> Vec<Violation>` (or `Option`), and a
+   `Violation { line, column, message }`. Open with a `//!` header — one-line purpose,
+   a `Sources:` line (spec / yamllint / authoritative refs), and the "no safe `--fix`"
+   note where applicable. Prefer granit scanner/event tokens over char heuristics; if
+   the rule tracks key/value position, advance the shared
+   `support::mapping_key_walker::Walker` on *every* node event, including
+   `Event::Alias` (`Walker::skip_node`), or key/value alternation desyncs.
+2. **Register** in `src/rules/mod.rs`: `pub mod <rule>;` plus the `ID` in `ALL_RULE_IDS`
+   — and in `RYL_ONLY_RULE_IDS` when yamllint has no equivalent (that reserves it to
+   TOML config; see the YAML-vs-TOML note above).
+3. **Dispatch**: one `lint_rule!(...)` call in `src/lint.rs`, in the right
+   reported-order slot of the matching batch fn (`collect_layout` / `collect_value` /
+   `collect_block_diagnostics`). Pick the arm matching the rule's shape (config or not,
+   `Vec`/`Option`, per-violation or fixed `MESSAGE`).
+4. **TOML config wiring** (`src/config_schema.rs` + `config_schema/serialization.rs`):
+   a `RuleName` variant + `as_str` arm, a `RulesTable` field with its `…Options` type,
+   and the `insert_serialized` line in `rules_table_to_value`. These four parallel lists
+   have no compile-time cross-check; the `every_rule_round_trips_through_toml_serialization`
+   guard test catches a forgotten serialization line. Regenerate the committed
+   `ryl.{toml,yaml}.schema.json` (see *Testing Tips*) and run `prek`.
+5. **Tests**: add the rule to `property_check`'s `collect_spans` + a `RULE_TRIGGERS`
+   row; if it has a safe `--fix`, also `SAFE_FIX_RULES` and the safe-fix generator. Add
+   a CLI test `tests/cli_<rule>_rule.rs` (use the shared `common::cli` harness) and an
+   embedded-markdown regression test in `tests/cli_markdown_embed.rs`.
+6. **Docs**: a `docs/rules/<rule>.md` page + the index, and a "How ryl differs from
+   yamllint" entry for any deliberate divergence.
+
 ## Code Change Requirements
 
 - Whenever any files are edited ensure all prek linters pass (run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,27 @@ ryl is a CLI tool for linting yaml files
   `adrienverge/yamllint#123` form. A bare `#123` auto-links to *this* repo
   (`owenlamont/ryl#123`) and silently points at the wrong issue. Use a bare `#123` only
   for ryl's own issues/PRs.
+- Filing an issue/PR on **another** project's repo (e.g. `granit`, upstream `yamllint`):
+  do **not** open it directly. These go out under the maintainer's name, so first build
+  a self-contained draft for proof-read, and only file once approved. Two rules are
+  **non-negotiable**:
+  - **Never raise a report on an assumption.** Every claim about the target's behaviour
+    must be **verified by running that project itself**, at the actual version in use —
+    never inferred from its lineage, a sibling tool (PyYAML/libyaml), docs, the spec, or
+    memory. (Cautionary tale: granit-parser#14 was filed claiming granit narrowed anchor
+    names at `:` like PyYAML; it never reproduced on *any* granit version — granit is
+    spec-correct there — an embarrassing false positive filed on an untested assumption.)
+  - **Ship the draft as its own directory with a single-command reproduction**, the format
+    in `/home/owen/Code/ryl_repos/granit-issue-14-repro/` (use it as the template): a
+    sub-directory `/home/owen/Code/ryl_repos/<repo>-<topic>-repro/` holding a `README.md`
+    (the draft issue/reply text + how to run) and a minimal repro that runs **unedited in
+    one command** and prints a clear verdict — for a Rust dep, a tiny `cargo` project
+    (`cargo run`, plus a `bash check-all-versions.sh` sweeping the version pins) printing
+    observed-vs-expected; for other ecosystems, the equivalent one-command script. So the
+    maintainer can confirm the behaviour first-hand before it is raised. No repro, no
+    report. Keep the prose succinct out of respect for these responsive volunteer
+    maintainers' time: concrete ask, then the runnable repro, then authoritative evidence
+    (spec quote / play.yaml.com event stream), and cut the rest.
 - Linters and tests may write outside the workspace (e.g., `~/.cache/prek`). If
   sandboxed, request permission escalation when running `prek`, `cargo test`,
   or coverage commands.

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -80,12 +80,231 @@ pub fn lint_markdown_file(
     ))
 }
 
+/// Run one rule under the standard gate — skip a disabled rule or a
+/// per-rule-ignored file — and append a [`LintProblem`] per reported violation in
+/// the rule's own report order. This replaces the hand-written `collect_*` helper
+/// each rule used to need. The arms cover the shapes rules actually have: a
+/// resolved `&Config` or none, a `Vec` or `Option` of violations, and a
+/// per-violation message or a fixed module `MESSAGE`. `$m` is the rule module; its
+/// `ID` / `check` / `Config` / `MESSAGE` are reached through it.
+macro_rules! lint_rule {
+    // config, `Vec<Violation>`, per-violation message (the common rule shape)
+    ($d:ident, $cfg:expr, $content:expr, $path:expr, $base:expr, $m:ident) => {
+        if let Some(level) = $cfg.rule_level($m::ID)
+            && !$cfg.is_rule_ignored($m::ID, $path, $base)
+        {
+            for hit in $m::check($content, &$m::Config::resolve($cfg)) {
+                $d.push(LintProblem {
+                    line: hit.line,
+                    column: hit.column,
+                    level: level.into(),
+                    message: hit.message,
+                    rule: Some($m::ID),
+                });
+            }
+        }
+    };
+    // config, `Vec<Violation>`, fixed module `MESSAGE`
+    ($d:ident, $cfg:expr, $content:expr, $path:expr, $base:expr, $m:ident, message) => {
+        if let Some(level) = $cfg.rule_level($m::ID)
+            && !$cfg.is_rule_ignored($m::ID, $path, $base)
+        {
+            for hit in $m::check($content, &$m::Config::resolve($cfg)) {
+                $d.push(LintProblem {
+                    line: hit.line,
+                    column: hit.column,
+                    level: level.into(),
+                    message: $m::MESSAGE.to_string(),
+                    rule: Some($m::ID),
+                });
+            }
+        }
+    };
+    // no config, `Vec<Violation>`, per-violation message
+    ($d:ident, $cfg:expr, $content:expr, $path:expr, $base:expr, $m:ident, no_config) => {
+        if let Some(level) = $cfg.rule_level($m::ID)
+            && !$cfg.is_rule_ignored($m::ID, $path, $base)
+        {
+            for hit in $m::check($content) {
+                $d.push(LintProblem {
+                    line: hit.line,
+                    column: hit.column,
+                    level: level.into(),
+                    message: hit.message,
+                    rule: Some($m::ID),
+                });
+            }
+        }
+    };
+    // no config, `Vec<Violation>`, fixed module `MESSAGE`
+    ($d:ident, $cfg:expr, $content:expr, $path:expr, $base:expr, $m:ident, no_config, message) => {
+        if let Some(level) = $cfg.rule_level($m::ID)
+            && !$cfg.is_rule_ignored($m::ID, $path, $base)
+        {
+            for hit in $m::check($content) {
+                $d.push(LintProblem {
+                    line: hit.line,
+                    column: hit.column,
+                    level: level.into(),
+                    message: $m::MESSAGE.to_string(),
+                    rule: Some($m::ID),
+                });
+            }
+        }
+    };
+    // no config, `Option<Violation>`, fixed module `MESSAGE` (new-line-at-end-of-file)
+    ($d:ident, $cfg:expr, $content:expr, $path:expr, $base:expr, $m:ident, option, message) => {
+        if let Some(level) = $cfg.rule_level($m::ID)
+            && !$cfg.is_rule_ignored($m::ID, $path, $base)
+            && let Some(hit) = $m::check($content)
+        {
+            $d.push(LintProblem {
+                line: hit.line,
+                column: hit.column,
+                level: level.into(),
+                message: $m::MESSAGE.to_string(),
+                rule: Some($m::ID),
+            });
+        }
+    };
+    // config by value + platform newline, `Option<Violation>`, per-violation
+    // message (new-lines: the platform default is injected for testability)
+    ($d:ident, $cfg:expr, $content:expr, $path:expr, $base:expr, $m:ident, platform) => {
+        if let Some(level) = $cfg.rule_level($m::ID)
+            && !$cfg.is_rule_ignored($m::ID, $path, $base)
+            && let Some(hit) =
+                $m::check($content, $m::Config::resolve($cfg), $m::platform_newline())
+        {
+            $d.push(LintProblem {
+                line: hit.line,
+                column: hit.column,
+                level: level.into(),
+                message: hit.message,
+                rule: Some($m::ID),
+            });
+        }
+    };
+}
+
+// `lint_str`'s rule dispatch is split into three ordered batches purely to keep
+// each function within clippy's cognitive-complexity threshold (one flat 26-rule
+// table trips it). The batch boundaries are pragmatic, not a strict taxonomy; what
+// matters is that they run in this order — layout, then value, then block —
+// because that concatenation IS ryl's reported diagnostic order (there is no later
+// per-file sort) and must match yamllint's. The `yamllint_compat_*` suite guards
+// it, so keep the overall sequence stable when editing.
+
+/// Document-shape and layout / punctuation rules (first dispatch batch).
+fn collect_layout_diagnostics(
+    diagnostics: &mut Vec<LintProblem>,
+    content: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+) {
+    lint_rule!(diagnostics, cfg, content, path, base_dir, document_start);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, document_end);
+    lint_rule!(
+        diagnostics,
+        cfg,
+        content,
+        path,
+        base_dir,
+        new_line_at_end_of_file,
+        option,
+        message
+    );
+    lint_rule!(
+        diagnostics,
+        cfg,
+        content,
+        path,
+        base_dir,
+        new_lines,
+        platform
+    );
+    lint_rule!(diagnostics, cfg, content, path, base_dir, empty_lines);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, commas);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, colons);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, braces);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, brackets);
+}
+
+/// Comment, node-property, and scalar-value rules (second dispatch batch).
+fn collect_value_diagnostics(
+    diagnostics: &mut Vec<LintProblem>,
+    content: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+) {
+    lint_rule!(diagnostics, cfg, content, path, base_dir, comments);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, anchors);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, tags);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, octal_values);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, float_values);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, empty_values);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, quoted_strings);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, truthy);
+}
+
+/// Key, indentation, and line / whitespace rules (third dispatch batch).
+fn collect_block_diagnostics(
+    diagnostics: &mut Vec<LintProblem>,
+    content: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+) {
+    lint_rule!(diagnostics, cfg, content, path, base_dir, key_duplicates);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, key_ordering);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, hyphens, message);
+    lint_rule!(
+        diagnostics,
+        cfg,
+        content,
+        path,
+        base_dir,
+        comments_indentation,
+        message
+    );
+    lint_rule!(diagnostics, cfg, content, path, base_dir, indentation);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, line_length);
+    lint_rule!(
+        diagnostics,
+        cfg,
+        content,
+        path,
+        base_dir,
+        trailing_spaces,
+        no_config,
+        message
+    );
+    lint_rule!(
+        diagnostics,
+        cfg,
+        content,
+        path,
+        base_dir,
+        unicode_line_breaks,
+        no_config
+    );
+    lint_rule!(
+        diagnostics,
+        cfg,
+        content,
+        path,
+        base_dir,
+        merge_keys,
+        no_config
+    );
+}
+
 /// Lint YAML content held in memory and return diagnostics in yamllint format
 /// order.
 ///
 /// `path` is used purely for diagnostic context and per-rule ignore matching;
 /// no filesystem reads are performed.
-#[allow(clippy::too_many_lines)]
 #[must_use]
 pub fn lint_str(
     content: &str,
@@ -98,203 +317,9 @@ pub fn lint_str(
     }
 
     let mut diagnostics: Vec<LintProblem> = Vec::new();
-
-    collect_document_start_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_document_end_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    if let Some(level) = cfg.rule_level(new_line_at_end_of_file::ID)
-        && !cfg.is_rule_ignored(new_line_at_end_of_file::ID, path, base_dir)
-        && let Some(hit) = new_line_at_end_of_file::check(content)
-    {
-        diagnostics.push(LintProblem {
-            line: hit.line,
-            column: hit.column,
-            level: level.into(),
-            message: new_line_at_end_of_file::MESSAGE.to_string(),
-            rule: Some(new_line_at_end_of_file::ID),
-        });
-    }
-
-    if let Some(level) = cfg.rule_level(new_lines::ID)
-        && !cfg.is_rule_ignored(new_lines::ID, path, base_dir)
-    {
-        let rule_cfg = new_lines::Config::resolve(cfg);
-        if let Some(hit) =
-            new_lines::check(content, rule_cfg, new_lines::platform_newline())
-        {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(new_lines::ID),
-            });
-        }
-    }
-
-    collect_empty_lines_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_commas_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_colons_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_braces_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-    collect_brackets_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_comments_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_anchors_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_tags_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_octal_values_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    collect_float_values_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    if let Some(level) = cfg.rule_level(empty_values::ID)
-        && !cfg.is_rule_ignored(empty_values::ID, path, base_dir)
-    {
-        let rule_cfg = empty_values::Config::resolve(cfg);
-        for hit in empty_values::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(empty_values::ID),
-            });
-        }
-    }
-
-    if let Some(level) = cfg.rule_level(quoted_strings::ID)
-        && !cfg.is_rule_ignored(quoted_strings::ID, path, base_dir)
-    {
-        let rule_cfg = quoted_strings::Config::resolve(cfg);
-        for hit in quoted_strings::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(quoted_strings::ID),
-            });
-        }
-    }
-
-    if let Some(level) = cfg.rule_level(truthy::ID)
-        && !cfg.is_rule_ignored(truthy::ID, path, base_dir)
-    {
-        let rule_cfg = truthy::Config::resolve(cfg);
-        for hit in truthy::check(content, &rule_cfg) {
-            let truthy::Violation {
-                line,
-                column,
-                message,
-            } = hit;
-            diagnostics.push(LintProblem {
-                line,
-                column,
-                level: level.into(),
-                message,
-                rule: Some(truthy::ID),
-            });
-        }
-    }
-
-    if let Some(level) = cfg.rule_level(key_duplicates::ID)
-        && !cfg.is_rule_ignored(key_duplicates::ID, path, base_dir)
-    {
-        let rule_cfg = key_duplicates::Config::resolve(cfg);
-        for hit in key_duplicates::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(key_duplicates::ID),
-            });
-        }
-    }
-
-    if let Some(level) = cfg.rule_level(key_ordering::ID)
-        && !cfg.is_rule_ignored(key_ordering::ID, path, base_dir)
-    {
-        let rule_cfg = key_ordering::Config::resolve(cfg);
-        for hit in key_ordering::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(key_ordering::ID),
-            });
-        }
-    }
-
-    if let Some(level) = cfg.rule_level(hyphens::ID)
-        && !cfg.is_rule_ignored(hyphens::ID, path, base_dir)
-    {
-        let rule_cfg = hyphens::Config::resolve(cfg);
-        for hit in hyphens::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hyphens::MESSAGE.to_string(),
-                rule: Some(hyphens::ID),
-            });
-        }
-    }
-
-    collect_comments_indentation_diagnostics(
-        &mut diagnostics,
-        content,
-        cfg,
-        path,
-        base_dir,
-    );
-
-    if let Some(level) = cfg.rule_level(indentation::ID)
-        && !cfg.is_rule_ignored(indentation::ID, path, base_dir)
-    {
-        let rule_cfg = indentation::Config::resolve(cfg);
-        for hit in indentation::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(indentation::ID),
-            });
-        }
-    }
-
-    collect_line_length_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
-
-    if let Some(level) = cfg.rule_level(trailing_spaces::ID)
-        && !cfg.is_rule_ignored(trailing_spaces::ID, path, base_dir)
-    {
-        for hit in trailing_spaces::check(content) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: trailing_spaces::MESSAGE.to_string(),
-                rule: Some(trailing_spaces::ID),
-            });
-        }
-    }
-
-    collect_unicode_line_breaks_diagnostics(
-        &mut diagnostics,
-        content,
-        cfg,
-        path,
-        base_dir,
-    );
-
-    collect_merge_keys_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
+    collect_layout_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
+    collect_value_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
+    collect_block_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
     let directives = crate::directives::Directives::parse(content);
     diagnostics.retain(|problem| {
@@ -309,372 +334,6 @@ pub fn lint_str(
     }
 
     diagnostics
-}
-
-fn collect_document_end_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(document_end::ID)
-        && !cfg.is_rule_ignored(document_end::ID, path, base_dir)
-    {
-        let rule_cfg = document_end::Config::resolve(cfg);
-        for hit in document_end::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(document_end::ID),
-            });
-        }
-    }
-}
-
-fn collect_document_start_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(document_start::ID)
-        && !cfg.is_rule_ignored(document_start::ID, path, base_dir)
-    {
-        let rule_cfg = document_start::Config::resolve(cfg);
-        for hit in document_start::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(document_start::ID),
-            });
-        }
-    }
-}
-
-fn collect_empty_lines_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(empty_lines::ID)
-        && !cfg.is_rule_ignored(empty_lines::ID, path, base_dir)
-    {
-        let rule_cfg = empty_lines::Config::resolve(cfg);
-        for hit in empty_lines::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(empty_lines::ID),
-            });
-        }
-    }
-}
-
-fn collect_commas_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(commas::ID)
-        && !cfg.is_rule_ignored(commas::ID, path, base_dir)
-    {
-        let rule_cfg = commas::Config::resolve(cfg);
-        for hit in commas::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(commas::ID),
-            });
-        }
-    }
-}
-
-fn collect_colons_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(colons::ID)
-        && !cfg.is_rule_ignored(colons::ID, path, base_dir)
-    {
-        let rule_cfg = colons::Config::resolve(cfg);
-        for hit in colons::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(colons::ID),
-            });
-        }
-    }
-}
-
-fn collect_brackets_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(brackets::ID)
-        && !cfg.is_rule_ignored(brackets::ID, path, base_dir)
-    {
-        let rule_cfg = brackets::Config::resolve(cfg);
-        for hit in brackets::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(brackets::ID),
-            });
-        }
-    }
-}
-
-fn collect_braces_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(braces::ID)
-        && !cfg.is_rule_ignored(braces::ID, path, base_dir)
-    {
-        let rule_cfg = braces::Config::resolve(cfg);
-        for hit in braces::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(braces::ID),
-            });
-        }
-    }
-}
-
-fn collect_comments_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(comments::ID)
-        && !cfg.is_rule_ignored(comments::ID, path, base_dir)
-    {
-        let rule_cfg = comments::Config::resolve(cfg);
-        for hit in comments::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(comments::ID),
-            });
-        }
-    }
-}
-
-fn collect_anchors_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(anchors::ID)
-        && !cfg.is_rule_ignored(anchors::ID, path, base_dir)
-    {
-        let rule_cfg = anchors::Config::resolve(cfg);
-        for hit in anchors::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(anchors::ID),
-            });
-        }
-    }
-}
-
-fn collect_tags_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(tags::ID)
-        && !cfg.is_rule_ignored(tags::ID, path, base_dir)
-    {
-        let rule_cfg = tags::Config::resolve(cfg);
-        for hit in tags::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(tags::ID),
-            });
-        }
-    }
-}
-
-fn collect_unicode_line_breaks_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(unicode_line_breaks::ID)
-        && !cfg.is_rule_ignored(unicode_line_breaks::ID, path, base_dir)
-    {
-        for hit in unicode_line_breaks::check(content) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(unicode_line_breaks::ID),
-            });
-        }
-    }
-}
-
-fn collect_merge_keys_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(merge_keys::ID)
-        && !cfg.is_rule_ignored(merge_keys::ID, path, base_dir)
-    {
-        for hit in merge_keys::check(content) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(merge_keys::ID),
-            });
-        }
-    }
-}
-
-fn collect_comments_indentation_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(comments_indentation::ID)
-        && !cfg.is_rule_ignored(comments_indentation::ID, path, base_dir)
-    {
-        let rule_cfg = comments_indentation::Config::resolve(cfg);
-        for hit in comments_indentation::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: comments_indentation::MESSAGE.to_string(),
-                rule: Some(comments_indentation::ID),
-            });
-        }
-    }
-}
-
-fn collect_octal_values_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(octal_values::ID)
-        && !cfg.is_rule_ignored(octal_values::ID, path, base_dir)
-    {
-        let rule_cfg = octal_values::Config::resolve(cfg);
-        for hit in octal_values::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(octal_values::ID),
-            });
-        }
-    }
-}
-
-fn collect_float_values_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(float_values::ID)
-        && !cfg.is_rule_ignored(float_values::ID, path, base_dir)
-    {
-        let rule_cfg = float_values::Config::resolve(cfg);
-        for hit in float_values::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(float_values::ID),
-            });
-        }
-    }
-}
-
-fn collect_line_length_diagnostics(
-    diagnostics: &mut Vec<LintProblem>,
-    content: &str,
-    cfg: &YamlLintConfig,
-    path: &Path,
-    base_dir: &Path,
-) {
-    if let Some(level) = cfg.rule_level(line_length::ID)
-        && !cfg.is_rule_ignored(line_length::ID, path, base_dir)
-    {
-        let rule_cfg = line_length::Config::resolve(cfg);
-        for hit in line_length::check(content, &rule_cfg) {
-            diagnostics.push(LintProblem {
-                line: hit.line,
-                column: hit.column,
-                level: level.into(),
-                message: hit.message,
-                rule: Some(line_length::ID),
-            });
-        }
-    }
 }
 
 fn scan(content: &str) -> Result<(), granit_parser::ScanError> {

--- a/src/rules/braces.rs
+++ b/src/rules/braces.rs
@@ -1,3 +1,8 @@
+//! `braces`: control spacing inside flow mappings `{ }` and, optionally, forbid
+//! flow mappings entirely. Mirrors yamllint's `braces`; built from the shared
+//! `support::flow_collection::define_rule!` (its sequence twin is `brackets`).
+//! Safe `--fix` normalises the inside-brace spacing.
+
 crate::rules::support::flow_collection::define_rule!(
     "braces",
     '{',

--- a/src/rules/brackets.rs
+++ b/src/rules/brackets.rs
@@ -1,3 +1,8 @@
+//! `brackets`: control spacing inside flow sequences `[ ]` and, optionally, forbid
+//! flow sequences entirely. Mirrors yamllint's `brackets`; built from the shared
+//! `support::flow_collection::define_rule!` (its mapping twin is `braces`).
+//! Safe `--fix` normalises the inside-bracket spacing.
+
 crate::rules::support::flow_collection::define_rule!(
     "brackets",
     '[',

--- a/src/rules/commas.rs
+++ b/src/rules/commas.rs
@@ -1,3 +1,6 @@
+//! `commas`: spacing around `,` separators in flow collections — no space before,
+//! exactly one after. Mirrors yamllint's `commas`. Safe `--fix` normalises the spacing.
+
 use crate::config::YamlLintConfig;
 use crate::rules::support::punctuation::{
     build_line_starts, collect_scalar_ranges, line_and_column, skip_comment,

--- a/src/rules/comments.rs
+++ b/src/rules/comments.rs
@@ -1,3 +1,7 @@
+//! `comments`: `#` comment formatting — a required space after the `#`, a minimum
+//! gap from preceding inline content, and an optional shebang exemption. Mirrors
+//! yamllint's `comments`. Safe `--fix` inserts the missing spaces.
+
 use granit_parser::Placement;
 
 use crate::config::YamlLintConfig;

--- a/src/rules/comments_indentation.rs
+++ b/src/rules/comments_indentation.rs
@@ -1,3 +1,8 @@
+//! `comments-indentation`: a comment must be indented like the content that follows
+//! it (else like the content it trails). Mirrors yamllint's `comments-indentation`.
+//! Safe `--fix` re-indents the comment — comments carry no YAML structure, so moving
+//! one cannot change the parse.
+
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::{
     block_scalar_marker_index, leading_whitespace_width, split_lines_preserve_endings,

--- a/src/rules/empty_values.rs
+++ b/src/rules/empty_values.rs
@@ -1,3 +1,8 @@
+//! `empty-values`: flag an empty value in a block mapping, flow mapping, or block
+//! sequence (a `key:` with nothing after it). Mirrors yamllint's `empty-values`. No
+//! safe `--fix`: the rule exists to make the author choose between `~`, `null`, or
+//! restructuring, so auto-inserting a literal would contradict its purpose.
+
 use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;

--- a/src/rules/float_values.rs
+++ b/src/rules/float_values.rs
@@ -1,3 +1,9 @@
+//! `float-values`: constrain float scalar spelling — require a numeral before the
+//! decimal point, and optionally forbid scientific notation, `.nan`, and `.inf`
+//! (resolved under the YAML 1.2 core schema). Mirrors yamllint's `float-values`. No
+//! safe `--fix`: rewrites such as `.5` to `0.5` or expanding `1e3` to `1000` change the
+//! scalar's text and, for tagged or string consumers, its value.
+
 use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;

--- a/src/rules/hyphens.rs
+++ b/src/rules/hyphens.rs
@@ -1,3 +1,8 @@
+//! `hyphens`: at most `max-spaces-after` spaces after a block-sequence `-` (default
+//! 1). Mirrors yamllint's `hyphens`. No safe `--fix`: collapsing the spaces shifts the
+//! indent of any nested block that follows on later lines, which can change the parsed
+//! structure.
+
 use crate::config::YamlLintConfig;
 
 pub const ID: &str = "hyphens";

--- a/src/rules/indentation.rs
+++ b/src/rules/indentation.rs
@@ -1,3 +1,8 @@
+//! `indentation`: block indentation width and whether block sequences are indented.
+//! Mirrors yamllint's `indentation`. No safe `--fix`: re-indenting moves the
+//! block-structure boundaries the grammar uses to delimit mappings, sequences, and
+//! scalars, so any non-trivial rewrite risks changing the parsed value.
+
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::{
     block_scalar_marker_index, strip_trailing_comment_preserving_quotes,

--- a/src/rules/key_ordering.rs
+++ b/src/rules/key_ordering.rs
@@ -1,3 +1,7 @@
+//! `key-ordering`: mapping keys must appear in order (optionally locale-aware, with
+//! an ignore list). Mirrors yamllint's `key-ordering`. No safe `--fix`: reordering keys
+//! silently disassociates any comment the author placed above or beside a key.
+
 use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 use regex::Regex;
 use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};

--- a/src/rules/line_length.rs
+++ b/src/rules/line_length.rs
@@ -1,3 +1,8 @@
+//! `line-length`: lines may not exceed `max` characters (counted as characters, not
+//! bytes), with an optional allowance for an unbreakable long word/URL. Mirrors
+//! yamllint's `line-length`. No safe `--fix`: splitting an over-long line needs folding
+//! decisions that depend on the scalar's style and whether folding is legal there.
+
 use std::convert::TryFrom;
 
 use granit_parser::{Event, Parser, Span, SpannedEventReceiver};

--- a/src/rules/new_line_at_end_of_file.rs
+++ b/src/rules/new_line_at_end_of_file.rs
@@ -1,3 +1,6 @@
+//! `new-line-at-end-of-file`: the file must end with a newline. Mirrors yamllint's
+//! `new-line-at-end-of-file`. Safe `--fix` appends the missing newline.
+
 pub const ID: &str = "new-line-at-end-of-file";
 pub const MESSAGE: &str = "no new line character at the end of file";
 

--- a/src/rules/new_lines.rs
+++ b/src/rules/new_lines.rs
@@ -1,3 +1,7 @@
+//! `new-lines`: enforce one line-ending style across the file — Unix (LF), DOS
+//! (CRLF), or the platform default. Mirrors yamllint's `new-lines`. Safe `--fix`
+//! rewrites the endings to the configured style.
+
 use std::borrow::Cow;
 
 use crate::config::YamlLintConfig;

--- a/src/rules/octal_values.rs
+++ b/src/rules/octal_values.rs
@@ -1,3 +1,8 @@
+//! `octal-values`: flag implicit (`0777`) and/or explicit (`0o777`) octal integers,
+//! which surprise readers expecting decimal. Mirrors yamllint's `octal-values`. No safe
+//! `--fix`: resolving `010` needs the author's intent (integer 8, integer 10, or the
+//! string "010"), which the source alone cannot disambiguate.
+
 use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -1,3 +1,8 @@
+//! `quoted-strings`: enforce a scalar quoting policy — quote type (single/double/any),
+//! when quotes are required versus redundant, and extra allow/require patterns. Mirrors
+//! yamllint's `quoted-strings`. Safe `--fix` adds or normalises quoting only where the
+//! rewrite provably preserves the scalar's value.
+
 use granit_parser::{
     Event, Parser, ScalarStyle, Span, SpannedEventReceiver, StructureStyle, Tag,
 };

--- a/src/rules/truthy.rs
+++ b/src/rules/truthy.rs
@@ -1,3 +1,8 @@
+//! `truthy`: flag YAML 1.1 boolean-ish words (`yes`/`no`/`on`/`off`/`True`/…) that are
+//! plain strings under the YAML 1.2 core schema and so a portability trap. Mirrors
+//! yamllint's `truthy`. No safe `--fix`: rewriting `Yes` means choosing between quoting
+//! it (keeps the string), normalising to `true`/`false` (a type change), or rewording.
+
 use std::collections::HashSet;
 
 use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};

--- a/tests/cli_alias_bomb.rs
+++ b/tests/cli_alias_bomb.rs
@@ -17,13 +17,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 fn alias_bomb() -> String {
     let mut payload = String::from("a0: &a0 \"lol\"\n");

--- a/tests/cli_anchors_rule.rs
+++ b/tests/cli_anchors_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn anchors_reports_error() {

--- a/tests/cli_colons_rule.rs
+++ b/tests/cli_colons_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn colons_reports_spacing_errors() {

--- a/tests/cli_commas_rule.rs
+++ b/tests/cli_commas_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn commas_reports_errors() {

--- a/tests/cli_comments_indentation_rule.rs
+++ b/tests/cli_comments_indentation_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn comments_indentation_reports_error() {

--- a/tests/cli_comments_rule.rs
+++ b/tests/cli_comments_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn comments_rule_emits_diagnostics() {

--- a/tests/cli_config_data_error.rs
+++ b/tests/cli_config_data_error.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn invalid_inline_config_causes_exit_2() {

--- a/tests/cli_document_end_rule.rs
+++ b/tests/cli_document_end_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn missing_marker_reports_error() {

--- a/tests/cli_document_start_rule.rs
+++ b/tests/cli_document_start_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn missing_marker_reports_error() {

--- a/tests/cli_empty_lines_rule.rs
+++ b/tests/cli_empty_lines_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 #[test]
 fn reports_interior_blank_run() {

--- a/tests/cli_empty_values_rule.rs
+++ b/tests/cli_empty_values_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn empty_values_reports_all_diagnostics() {

--- a/tests/cli_env_config.rs
+++ b/tests/cli_env_config.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn env_config_file_is_honored() {

--- a/tests/cli_fix.rs
+++ b/tests/cli_fix.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn fix_applies_safe_newline_and_comment_fixes() {

--- a/tests/cli_fix_encoding.rs
+++ b/tests/cli_fix_encoding.rs
@@ -2,13 +2,8 @@ use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 fn write_config(dir: &std::path::Path) {
     fs::write(

--- a/tests/cli_fix_ignore_new_lines.rs
+++ b/tests/cli_fix_ignore_new_lines.rs
@@ -2,13 +2,8 @@ use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn fix_respects_new_lines_ignore_for_eof_newline() {

--- a/tests/cli_fix_symlink.rs
+++ b/tests/cli_fix_symlink.rs
@@ -14,13 +14,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 const FIXABLE_YAML: &str = "secret: topsecret   \n";
 

--- a/tests/cli_float_values_rule.rs
+++ b/tests/cli_float_values_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 #[test]
 fn float_values_rule_reports_forbidden_variants() {

--- a/tests/cli_hyphens_rule.rs
+++ b/tests/cli_hyphens_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn hyphens_reports_error() {

--- a/tests/cli_indentation_rule.rs
+++ b/tests/cli_indentation_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn indentation_reports_error() {

--- a/tests/cli_key_duplicates_rule.rs
+++ b/tests/cli_key_duplicates_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 /// Lint `yaml` with a TOML config whose `[rules.key-duplicates]` body is
 /// `options`, returning the exit code and whichever stream carried output.

--- a/tests/cli_key_ordering_rule.rs
+++ b/tests/cli_key_ordering_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn key_ordering_reports_error() {

--- a/tests/cli_line_length_rule.rs
+++ b/tests/cli_line_length_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn line_length_reports_error() {

--- a/tests/cli_list_files.rs
+++ b/tests/cli_list_files.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn list_files_outputs_expected_entries() {

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 fn project(
     config: &str,

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -393,8 +393,8 @@ fn unicode_line_breaks_fires_in_fenced_block() {
 
     assert_eq!(code, 1, "{err}");
     assert!(
-        err.contains("2:") && err.contains("unicode-line-breaks"),
-        "raw U+2028 flagged on host line 2 inside the fenced block: {err}"
+        err.contains("2:7") && err.contains("unicode-line-breaks"),
+        "raw U+2028 flagged at host 2:7 inside the fenced block: {err}"
     );
 }
 
@@ -408,9 +408,9 @@ fn anchors_ambiguous_name_fires_in_fenced_block() {
 
     assert_eq!(code, 1, "{err}");
     assert!(
-        err.contains("2:")
+        err.contains("2:4")
             && err.contains("ambiguous anchor name")
             && err.contains("anchors"),
-        "colon-welded anchor name flagged on host line 2 in the fenced block: {err}"
+        "colon-welded anchor name flagged at host 2:4 in the fenced block: {err}"
     );
 }

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -343,3 +343,74 @@ fn directory_scan_overlap_is_a_hard_error() {
     assert_eq!(code, 2, "expected overlap error: {err}");
     assert!(err.contains("matches both"), "{err}");
 }
+
+// Embedded-markdown regression tests for the rules added in #252-#256: each must
+// fire inside a fenced block with positions remapped to the host markdown file
+// (#277 item 6). ryl-only options go through TOML config.
+
+#[test]
+fn merge_keys_fires_in_fenced_block() {
+    let cfg = "files = { markdown = [\"*.md\"] }\n[rules]\nmerge-keys = \"enable\"\n";
+    let body = "intro\n\n```yaml\nbase: &b {x: 1}\nchild:\n  <<: *b\n```\n";
+    let (_dir, file) = project(cfg, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "{err}");
+    assert!(
+        err.contains("6:3")
+            && err.contains("forbidden merge key")
+            && err.contains("merge-keys"),
+        "merge key remapped to host line 6: {err}"
+    );
+}
+
+#[test]
+fn key_duplicates_canonical_fires_in_fenced_block() {
+    let cfg = "files = { markdown = [\"*.md\"] }\n[rules.key-duplicates]\ncheck-canonical = true\n";
+    let body = "```yaml\n0xB: a\n11: b\n```\n";
+    let (_dir, file) = project(cfg, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "{err}");
+    assert!(
+        err.contains("3:1")
+            && err.contains("duplication of key \"11\"")
+            && err.contains("key-duplicates"),
+        "canonical integer duplicate remapped to host line 3: {err}"
+    );
+}
+
+#[test]
+fn unicode_line_breaks_fires_in_fenced_block() {
+    let cfg = "files = { markdown = [\"*.md\"] }\n[rules]\nunicode-line-breaks = \"enable\"\n";
+    // A raw U+2028 line separator inside the fenced scalar (content, not a break).
+    let body = "```yaml\nkey: a\u{2028}b\n```\n";
+    let (_dir, file) = project(cfg, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "{err}");
+    assert!(
+        err.contains("2:") && err.contains("unicode-line-breaks"),
+        "raw U+2028 flagged on host line 2 inside the fenced block: {err}"
+    );
+}
+
+#[test]
+fn anchors_ambiguous_name_fires_in_fenced_block() {
+    let cfg = "files = { markdown = [\"*.md\"] }\n[rules.anchors]\nforbid-ambiguous-anchor-alias-names = true\n";
+    let body = "```yaml\na: &:foo 1\n```\n";
+    let (_dir, file) = project(cfg, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "{err}");
+    assert!(
+        err.contains("2:")
+            && err.contains("ambiguous anchor name")
+            && err.contains("anchors"),
+        "colon-welded anchor name flagged on host line 2 in the fenced block: {err}"
+    );
+}

--- a/tests/cli_markdown_fix.rs
+++ b/tests/cli_markdown_fix.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 fn project(
     config: &str,

--- a/tests/cli_merge_keys_rule.rs
+++ b/tests/cli_merge_keys_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 /// `merge-keys` is a ryl-only rule, so it is configured through TOML rather than
 /// the yamllint-compatible YAML config that `-d` carries.

--- a/tests/cli_new_line_rule.rs
+++ b/tests/cli_new_line_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn missing_newline_reports_error() {

--- a/tests/cli_new_lines_rule.rs
+++ b/tests/cli_new_lines_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 #[test]
 fn unix_type_reports_crlf() {

--- a/tests/cli_octal_values_rule.rs
+++ b/tests/cli_octal_values_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 #[test]
 fn octal_rule_reports_plain_values() {

--- a/tests/cli_per_file_ignores.rs
+++ b/tests/cli_per_file_ignores.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn toml_per_file_ignores_combine_matching_patterns() {

--- a/tests/cli_quoted_strings_rule.rs
+++ b/tests/cli_quoted_strings_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 #[test]
 fn quoted_strings_reports_redundant_quotes() {

--- a/tests/cli_stdin.rs
+++ b/tests/cli_stdin.rs
@@ -25,13 +25,8 @@ fn run_with_stdin(cmd: &mut Command, input: &[u8]) -> (i32, String, String) {
     (code, stdout, stderr)
 }
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn stdin_with_no_enabled_rules_errors() {

--- a/tests/cli_tags_rule.rs
+++ b/tests/cli_tags_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 /// `tags` is a ryl-only rule, so it is configured through TOML rather than the
 /// yamllint-compatible YAML config that `-d` carries.

--- a/tests/cli_trailing_spaces_rule.rs
+++ b/tests/cli_trailing_spaces_rule.rs
@@ -3,13 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 #[test]
 fn trailing_spaces_reports_error() {

--- a/tests/cli_truthy_rule.rs
+++ b/tests/cli_truthy_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 #[test]
 fn truthy_rule_reports_plain_truthy_values() {

--- a/tests/cli_unicode_line_breaks_rule.rs
+++ b/tests/cli_unicode_line_breaks_rule.rs
@@ -3,17 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
-
-fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
-    if stderr.is_empty() { stdout } else { stderr }
-}
+mod common;
+use common::cli::{command_output, run};
 
 /// `unicode-line-breaks` is a ryl-only rule, so it is configured through TOML
 /// rather than the yamllint-compatible YAML config that `-d` carries.

--- a/tests/common/cli.rs
+++ b/tests/common/cli.rs
@@ -1,0 +1,24 @@
+//! Shared CLI test harness: invoke the `ryl` binary and read its output. The
+//! `cli_*` integration tests use these instead of each re-defining `run` /
+//! `command_output`. Items are `#[allow(dead_code)]` because every test binary
+//! that does `mod common;` compiles the whole module, but each uses only the
+//! helpers it needs (the same pattern `fake_env` follows).
+
+use std::process::Command;
+
+/// Run `cmd` to completion, returning `(exit code, stdout, stderr)`.
+#[allow(dead_code)]
+pub fn run(cmd: &mut Command) -> (i32, String, String) {
+    let out = cmd.output().expect("process");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+/// Whichever stream carried the diagnostics: `stderr` when non-empty (ryl prints
+/// diagnostics there), otherwise `stdout`.
+#[allow(dead_code)]
+pub fn command_output<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
+    if stderr.is_empty() { stdout } else { stderr }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,1 +1,2 @@
+pub mod cli;
 pub mod fake_env;

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -1022,3 +1022,37 @@ fn normalize_toml_config_preserves_quoted_strings_in_fixable() {
         fix.fixable[0]
     );
 }
+
+#[test]
+fn every_rule_round_trips_through_toml_serialization() {
+    // `rules_table_to_value` serializes each rule via a hand-written
+    // `insert_serialized` line with no compile-time cross-check, so a new rule
+    // whose line is forgotten is silently dropped from normalized output. Enable
+    // every rule and assert each survives the round trip, so that omission fails
+    // a test instead of shipping (#277 item 5).
+    let body: String = std::iter::once("[rules]\n".to_string())
+        .chain(
+            ryl::rules::ALL_RULE_IDS
+                .iter()
+                .map(|id| format!("{id} = \"enable\"\n")),
+        )
+        .collect();
+    let parsed = parse_toml_config_str(&body, false)
+        .expect("typed TOML parse should succeed")
+        .expect("config enabling every rule should produce a config");
+    let value = toml_config_to_value(&parsed);
+    let rules = value
+        .get("rules")
+        .and_then(|rules| rules.as_table())
+        .expect("serialized config should have a rules table");
+    let mut dropped: Vec<&str> = ryl::rules::ALL_RULE_IDS
+        .iter()
+        .copied()
+        .filter(|id| !rules.contains_key(*id))
+        .collect();
+    dropped.sort_unstable();
+    assert!(
+        dropped.is_empty(),
+        "rules dropped from rules_table_to_value serialization: {dropped:?}"
+    );
+}

--- a/tests/flow_collection_cli.rs
+++ b/tests/flow_collection_cli.rs
@@ -13,13 +13,8 @@ struct CliSuite {
     empty_message: &'static str,
 }
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("process");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::run;
 
 fn assert_command_output(
     cmd: &mut Command,


### PR DESCRIPTION
Second and final PR for the #277 pre-0.14.0 cleanup (PR1 #278, the verbatim core-tag
correctness fix, is already merged). This is the cross-cutting DRY / consistency / docs
work — **net −362 lines**, no behaviour change. Covers #277 items 2, 3, 5, 6, 7, 8.

## What's here

- **`lint.rs` dispatch macro (item 3)** — replace the 16 hand-written
  `collect_<rule>_diagnostics` helpers and the inline blocks in `lint_str` with one
  `lint_rule!` macro, split into three ordered batch fns (`collect_layout` /
  `collect_value` / `collect_block_diagnostics`). Drops the
  `#[allow(clippy::too_many_lines)]` with **no replacement allow** (the batch split keeps
  each fn under the cognitive-complexity threshold). The dispatch order — which is the
  reported order, since there is no per-file sort — is preserved exactly; the
  `yamllint_compat_*` differential suite guards it. **−359 lines in lint.rs.**
- **Shared CLI test harness (item 2)** — add `tests/common/cli.rs` (`run`,
  `command_output`) and migrate the 37 `cli_*` tests that each re-defined them.
- **Embedded-markdown tests (item 6)** — pin that merge-keys, key-duplicates
  `--check-canonical`, unicode-line-breaks, and anchors' ambiguous-name option each fire
  inside a fenced block with positions remapped to the host file.
- **New-rule checklist + serialization guard (item 5)** — an "Adding a New Rule" checklist
  in AGENTS.md, and a `config_schema` round-trip guard test that fails if a rule is dropped
  from `rules_table_to_value` (mutation-verified).
- **`//!` module headers (item 7)** — add headers to the 16 rule modules that lacked one
  (purpose + yamllint source + `--fix` safety); every rule module now opens with one.
- **AGENTS.md report-safety rule (item 8)** — never raise a third-party-repo issue on an
  assumption; ship each draft as its own directory with a single-command reproduction.

## Verification

`prek` clean, `coverage-missing.sh` zero-missed, full suite green throughout. Reviewed by
Claude `/code-review` (max — 3 finders over the macro, the migration, and the new tests,
all clean) and a local Codex pass (clean: dispatch preserves gating/order/messages).

Closes #277.
