### PR TITLE
Bump version to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "clap",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.13.0"
+  "version": "0.14.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.13.0"
+version = "0.14.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Lockstep version bump to **0.14.0** for the release. Bumps `Cargo.toml`, `pyproject.toml`,
`package.json`, and refreshes `Cargo.lock` + `uv.lock` (ryl's own version only — no
dependency churn).

0.14.0 ships Tier-1 rules #251–#256 (`tags`, `key-duplicates` canonical/merge,
`unicode-line-breaks`, `colons` alias-key fix, `anchors` ambiguous-names, `merge-keys`)
plus the #277 pre-0.14.0 cleanup (#278, #279). The `v0.14.0` tag — which triggers the
publish workflow (crates.io / PyPI / npm) and is validated against these manifests — is
pushed once this merges.
