### PR TITLE
Add `--diff` flag previewing safe fixes as a unified diff (closes #269)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,11 +510,11 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
 - Files named explicitly are linted as their resolved source kind; one that
   matches no `[files]` kind is rejected with an error (rather than silently
   treated as YAML).
-- Inputs are de-duplicated: a file reached by two spellings (the walk plus an
-  explicit arg, e.g. `ryl . f.yaml`, or `f.yaml` listed twice) is processed once.
-  `gather_lint_files` keys a `seen` set on `main::canonical_input` (`std::path::absolute`
-  — lexical, no symlink resolution, no existence check), so this spans lint/`--fix`/
-  `--diff`/`--list-files`. Deliberately stricter than yamllint (which processes
+- Inputs are de-duplicated: a file reached by two spellings (`ryl . f.yaml`, `f.yaml`
+  twice, or `f.yaml sub/../f.yaml`) is processed once. `gather_lint_files` keys a `seen`
+  set on `main::canonical_input` (`std::path::absolute` + lexical `..` normalization —
+  purely lexical, no symlink resolution, so a symlink stays distinct from its target),
+  spanning lint/`--fix`/`--diff`/`--list-files`. Stricter than yamllint (which keeps
   duplicates); for `--diff` a duplicate would emit a repeat patch block that fails to
   apply on the second copy.
 - Source kinds (`config::SourceKind`): the `[files]` TOML table maps `yaml` and
@@ -551,9 +551,10 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   gate and symlink skip (both → a `skipped by --diff` notice, no exit effect). A
   non-UTF-8/BOM input is likewise skipped (`fix::non_utf8_diff_skip`; files via
   `DecodedFile::is_plain_utf8`, stdin via decoded==raw bytes) — a text diff can't apply
-  back to transcoded bytes, so `--fix` (which re-encodes) is the path for those. Markdown
-  diffs at host-file level. The diff *body* is verbatim (hk re-applies it byte-for-byte);
-  the header path is sanitized and relativized to CWD (like ruff) so it applies via
+  back to transcoded bytes, so `--fix` (which re-encodes) is the path for those — as is
+  a filename with control characters (no representable header). Markdown diffs at
+  host-file level. The diff *body* is verbatim (hk re-applies it byte-for-byte); the
+  header path is sanitized and relativized to CWD (like ruff) so it applies via
   `git apply -p0`.
 - Malicious-payload hardening (#246) — invariants to preserve: `--fix`/`--diff` never
   write/read through a symlink (`fix::refuse_symlink`) and the write target is always

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,15 +495,11 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
 
 ## Documentation Site
 
-- The Zensical documentation source lives under `/docs/` with site
-  configuration in `zensical.toml`. Built output goes to `/site/` (gitignored).
-- Zensical is pinned via the `docs` dependency group in `pyproject.toml` and
-  locked in `uv.lock`. Use the uv group commands so transitive deps stay in
-  sync with the lockfile.
-- Build the site: `uv run --group docs zensical build --clean`.
-- Preview locally with live reload: `uv run --group docs zensical serve`.
-- Bumping Zensical: edit the pin in `pyproject.toml`, run `uv lock`, then
-  rebuild to confirm the new version still renders cleanly.
+- Zensical docs source is under `/docs/` (config in `zensical.toml`); built output goes
+  to `/site/` (gitignored). Zensical is pinned via the `docs` dependency group in
+  `pyproject.toml`/`uv.lock` — use the uv group commands. Build: `uv run --group docs
+  zensical build --clean`; preview: `uv run --group docs zensical serve`. To bump, edit
+  the pin, run `uv lock`, and rebuild to confirm it renders.
 
 ## CLI Behavior
 
@@ -557,7 +553,8 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   `DecodedFile::is_plain_utf8`, stdin via decoded==raw bytes) — a text diff can't apply
   back to transcoded bytes, so `--fix` (which re-encodes) is the path for those. Markdown
   diffs at host-file level. The diff *body* is verbatim (hk re-applies it byte-for-byte);
-  only the header path is sanitized.
+  the header path is sanitized and relativized to CWD (like ruff) so it applies via
+  `git apply -p0`.
 - Malicious-payload hardening (#246) — invariants to preserve: `--fix`/`--diff` never
   write/read through a symlink (`fix::refuse_symlink`) and the write target is always
   the input path, never derived from YAML content. The YAML config loader

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -666,10 +666,13 @@ sticking to the quick-status step above.
   `fix::diff_outcome`, calling `apply_safe_fixes`/`fix_markdown_str`), so it inherits
   the same parse-error gate (unparsable files are skipped with a
   `<path>:L:C skipped by --diff: <error>` notice, no exit effect) and symlink skip
-  (`fix::refuse_symlink`, now parameterised by flag). Markdown diffs at the
-  host-file level (one diff per `.md`). The diff *body* is emitted verbatim (a
-  consumer such as hk must re-apply it byte-for-byte); only the header path is
-  sanitized.
+  (`fix::refuse_symlink`, now parameterised by flag). A non-UTF-8/BOM input is also
+  skipped (`fix::non_utf8_diff_skip`; files via `DecodedFile::is_plain_utf8`, stdin via
+  a decoded-bytes==raw-bytes check) — a textual diff of decoded content cannot apply
+  back to transcoded/BOM'd bytes, so `--fix` (which re-encodes) is the path for those.
+  Markdown diffs at the host-file level (one diff per `.md`). The diff *body* is
+  emitted verbatim (a consumer such as hk must re-apply it byte-for-byte); only the
+  header path is sanitized.
 - Malicious-payload hardening (issue #246): `--fix` never writes through a
   symlink — `fix::refuse_symlink` skips a symlinked input (still linted) with a
   warning, so an untrusted tree cannot redirect an in-place write outside itself.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,8 @@ ryl is a CLI tool for linting yaml files
 
 ## Coding Standards
 
-- Code maintainability is the top priority - ideally a new agent can be onboarded onto
-  using this repo and able to get all the necessary context from the documentation and
-  code with no surprising behaviour or pitfalls (this is the pit of success principle -
+- Code maintainability is the top priority: a new agent should get all needed context
+  from the docs and code with no surprising behaviour (the pit-of-success principle —
   the most likely way to do something is also the correct way).
 - Before implementing a new or changed rule — or any non-trivial feature — propose a
   short plan and agree the approach before writing code; don't jump straight to
@@ -31,21 +30,16 @@ ryl is a CLI tool for linting yaml files
   feedback without asking.
 - If you notice anything inaccurate or stale in this `AGENTS.md` while working, fix it as
   part of the change rather than leaving it for later.
-- In relation to maintainability / readability keep the code as succinct as practical.
-  Every line of code has a maintenance and read time cost (so try to keep code readable
-  with good naming of files, functions, structures, and variable instead of using
-  comments). Remember every new conditional added has a significant testing burden as it
-  will likely require a new test to be added and maintained. We want to keep code bloat
-  to a minimum and the best refactors generally are those that remove lines of code
-  while maintaining functionality.
-- Comment the *why*, not the *what*. Capture non-obvious invariants, spec/standard
-  rationale, verified-behaviour notes (e.g. "verified against ruamel/PyYAML"), deliberate
-  trade-offs/workarounds, third-party code smells, and version-pin reasons (link the
-  issue) &mdash; and "looks-wrong-but-isn't" reasoning that stops a later reader
-  "fixing" subtle logic. Because this codebase is maintained largely by AI agents across
-  many models and sessions, that durable *why*-context is usually worth more than the
-  tokens it costs, so lean toward including it. Still don't narrate self-evident *what*:
-  good names carry that, and *what*-comments are the ones that go stale fastest.
+- Keep code as succinct as practical: every line has a maintenance and read-time cost,
+  so prefer good naming over comments, and remember every new conditional adds a testing
+  burden. The best refactors remove lines while keeping functionality.
+- Comment the *why*, not the *what*: capture non-obvious invariants, spec rationale,
+  verified-behaviour notes ("verified against ruamel/PyYAML"), deliberate
+  trade-offs/workarounds, and version-pin reasons (link the issue) &mdash; plus
+  "looks-wrong-but-isn't" reasoning that stops a later reader "fixing" subtle logic. This
+  codebase is maintained across many AI sessions, so that durable *why*-context is
+  usually worth its tokens; lean toward including it. Don't narrate self-evident
+  *what* — good names carry that.
 - Leverage the provided linters and formatters to fix code, configuration, and
   documentation often - it's much cheaper to have the linters and formatters auto fix
   issues than correcting them yourself. Only correct what the linters and formatters
@@ -63,27 +57,22 @@ ryl is a CLI tool for linting yaml files
 - Don't rely on your memory of libraries and APIs. All external dependencies evolve fast
   so ensure current documentation and/or repo is consulted when working with third party
   dependencies.
-- Verify behaviour against an authoritative source before asserting it — to the
-  maintainer as much as in code. Prefer the ryl CLI, real `yamllint`, the play.yaml.com
-  reference parser, or a resolving loader (see the references below) over reasoning from
-  memory; and if an earlier claim or piece of guidance turns out wrong, correct the
-  record explicitly instead of quietly moving on.
+- Verify behaviour against an authoritative source before asserting it (to the
+  maintainer as much as in code): prefer the ryl CLI, real `yamllint`, the play.yaml.com
+  reference parser, or a resolving loader over memory; and if an earlier claim turns out
+  wrong, correct the record explicitly.
 - When mirroring yamllint behaviour, spot-check tricky inputs with the ryl CLI so
   our diagnostics and message text match (e.g., mixed newline styles or config keys of
   type int/bool/null/tagged scalar).
-- For questions about how YAML *itself* should parse (is an input valid, and what
-  event/structure does it produce?), the source of truth is the YAML Parser Playground
-  at <https://play.yaml.com/>: paste YAML in the top-left pane and read the canonical
-  **Reference Parser** output in the bottom-left pane (the test-suite event stream —
-  `+STR/+DOC/+MAP/+SEQ`, `=VAL`, `=ALI`, `&anchor`, tags, or a parse error such as
-  "Parser finished before end of input"). The other panes are alternative parsers that
-  need a local sandbox server and are normally left unconnected. Input can be driven via
-  the URL hash as base64 of the YAML (`https://play.yaml.com/#<base64>`), which is handy
-  for scripted/browser-automation checks. Scope caveat: the playground reports the
-  *parse/event* layer (validity and structure), not *schema resolution* — it shows
-  `=VAL :011`, never "int vs string". For type-resolution questions (does `011` resolve
-  to int 11, an empty scalar to null, etc.) use a resolving loader instead (e.g.
-  `ruamel.yaml` in 1.2 mode or PyYAML), since ryl targets the YAML 1.2 **core** schema.
+- For how YAML *itself* parses (is an input valid, what events does it produce?), the
+  source of truth is the YAML Parser Playground <https://play.yaml.com/>: paste YAML and
+  read the **Reference Parser** pane (the test-suite event stream — `+STR/+DOC/+MAP/+SEQ`,
+  `=VAL`, `=ALI`, `&anchor`, tags, or a parse error). It can be driven by a base64 URL
+  hash (`https://play.yaml.com/#<base64>`) for scripted checks. Caveat: it reports the
+  *parse/event* layer, not *schema resolution* (`=VAL :011`, never "int vs string"); for
+  type-resolution (does `011` resolve to int 11, an empty scalar to null?) use a
+  resolving loader (`ruamel.yaml` 1.2 mode or PyYAML), since ryl targets the YAML 1.2
+  **core** schema.
 - When parsers disagree on an input (e.g. granit vs yamllint/PyYAML vs `ruamel.yaml`)
   and a rule's behaviour turns on the disagreement, **decide against the YAML 1.2.2
   specification grammar and the play.yaml.com reference parser — they rank above
@@ -92,23 +81,18 @@ ryl is a CLI tool for linting yaml files
   reference-parser event stream when deciding, prefer the spec-correct behaviour, and
   record any deliberate yamllint divergence (with an example and the rationale) in the
   "How ryl differs from yamllint" catalog in
-  `docs/getting-started/migrating-from-yamllint.md`. Worked example: welded-colon
-  anchor/alias names — the spec (`ns-anchor-char` excludes only `,[]{}`), the reference
-  parser, and granit all read `&foo:bar` as the name `foo:bar`, while PyYAML narrows at
-  `:`; ryl follows the spec (see adrienverge/yamllint#686 and adrienverge/yamllint#780).
-- Keep YAML configuration strictly aligned with functionality that yamllint currently
-  supports. Put any ryl-only settings, experimental rule options, or ahead-of-upstream
-  behaviour in TOML configuration so future yamllint additions cannot clash with
-  existing YAML semantics. A whole ryl-only *rule* (one yamllint lacks, e.g. `tags`)
-  goes in `rules::RYL_ONLY_RULE_IDS`: the YAML config path rejects those rules and
-  `config_schema::yaml_schema` prunes them from the YAML schema, so they are
-  configurable only via TOML (`[rules.<id>]`).
+  `docs/getting-started/migrating-from-yamllint.md`.
+- Keep YAML configuration aligned with what yamllint currently supports; put any
+  ryl-only settings, experimental options, or ahead-of-upstream behaviour in TOML so
+  future yamllint additions can't clash with YAML semantics. A whole ryl-only *rule*
+  (e.g. `tags`) goes in `rules::RYL_ONLY_RULE_IDS` — the YAML path rejects it and
+  `config_schema::yaml_schema` prunes it, so it's configurable only via TOML
+  (`[rules.<id>]`).
 
 ## Adding a New Rule
 
 A rule touches several disconnected sites; a missing one usually fails a guard test
-rather than shipping silently. Work this checklist (the detailed test sections under
-*Automated Tests* expand on steps 5–6):
+rather than shipping silently. Work this checklist (*Automated Tests* expands steps 5–6):
 
 1. **Rule module** `src/rules/<rule>.rs`: a `pub const ID`, a `Config` with
    `resolve(&YamlLintConfig)`, a `check(...) -> Vec<Violation>` (or `Option`), and a
@@ -166,66 +150,37 @@ rather than shipping silently. Work this checklist (the detailed test sections u
 - `prek`, `rg`, `rumdl`, `typos`, `yamllint`, and `zizmor` should be installed as global
   tools (if they don't appear to be installed raise that with the user).
 - `gh` will be available in most, but not all environments to inspect GitHub.
-- When reviewing PR feedback, prefer `gh pr view <number> --json comments,reviews` for
-  summary threads and `gh api repos/<owner>/<repo>/pulls/<number>/comments` when you
-  need inline review details without guesswork. Avoid flags that the GitHub CLI does not
-  support (e.g., `--review-comments`).
-- Codex reviews must be triggered with an `@codex review` comment; do **not** rely on
-  auto-review. Only the initial PR open *sometimes* auto-triggers one — every subsequent
-  review, including after each push you want re-reviewed, must be prompted by commenting
-  `@codex review` (it takes minutes). So after pushing changes for review, always post the
-  comment rather than waiting for an auto-review that will not come. Confirm Codex picked
-  it up: within ~1 minute of the `@codex review` comment Codex adds an 👀 reaction (`eyes`,
-  from `chatgpt-codex-connector[bot]`) on the triggering comment to acknowledge it has
-  started. If that 👀 has not appeared after ~1 minute, the trigger did not take —
-  comment `@codex review` again, and re-check for the 👀. Once the review
-  finishes, Codex removes the 👀 and signals its verdict in one of three forms — a new PR
-  review (when it has findings), a new issue comment (often its "no major issues"
-  all-clear), or a 👍 reaction on the triggering comment — so poll for **any** of them;
-  watching only one misses the result. (Codex can be slow: a verdict occasionally takes
-  20+ minutes even after the 👀, so keep polling past a short timeout rather than assuming
-  it failed.) Capture baseline counts of Codex reviews, Codex issue comments, and the
-  trigger comment's reactions, then poll (~45s) for any to change, running the poller
-  as a background command since a thorough review can exceed a 10-minute foreground
-  timeout.
-  The bot login is `chatgpt-codex-connector[bot]` for PR reviews, inline review
-  comments, issue comments, and reactions alike. Filter reviews/comments with
-  `select(.user.login=="chatgpt-codex-connector[bot]")` (the bare
-  `chatgpt-codex-connector` without the `[bot]` suffix matches nothing).
+- For PR feedback, use `gh pr view <n> --json comments,reviews` for summary threads and
+  `gh api repos/<owner>/<repo>/pulls/<n>/comments` for inline review details (avoid
+  unsupported flags like `--review-comments`).
+- Codex reviews need an explicit `@codex review` comment; auto-review is unreliable
+  (even on PR open), so post it again after each push you want reviewed. Within ~1 min
+  Codex acks with a 👀 (`eyes`) reaction on the trigger comment; if it doesn't appear,
+  re-comment. The verdict then arrives as one of: a new PR review, a new issue comment
+  (often the "no major issues" all-clear), or a 👍 on the trigger comment — poll for
+  **any** of them (a verdict can take 20+ min). Capture baseline counts of reviews,
+  issue comments, and trigger-comment reactions, then poll (~45s) in a background
+  command. The bot login is `chatgpt-codex-connector[bot]`; filter with
+  `select(.user.login=="chatgpt-codex-connector[bot]")` (the bare login without `[bot]`
+  matches nothing).
 - When referencing another repository's issues/PRs in GitHub issues, PRs, or comments
   (e.g. an upstream `yamllint` issue), always use the fully-qualified
   `adrienverge/yamllint#123` form. A bare `#123` auto-links to *this* repo
   (`owenlamont/ryl#123`) and silently points at the wrong issue. Use a bare `#123` only
   for ryl's own issues/PRs.
-- Filing an issue/PR on **another** project's repo (e.g. `granit`, upstream `yamllint`):
-  do **not** open it directly. These go out under the maintainer's name, so first build
-  a self-contained draft for proof-read, and only file once approved. Two rules are
-  **non-negotiable**:
-  - **Never raise a report on an assumption.** Every claim about the target's behaviour
-    must be **verified by running that project itself**, at the actual version in use —
-    never inferred from its lineage, a sibling tool (PyYAML/libyaml), docs, the spec, or
-    memory. (Cautionary tale: granit-parser#14 was filed claiming granit narrowed anchor
-    names at `:` like PyYAML; it never reproduced on *any* granit version — granit is
-    spec-correct there — an embarrassing false positive filed on an untested assumption.)
-  - **Ship the draft as its own directory with a single-command reproduction.** Put it
-    outside the ryl repo (ask the maintainer where they keep issue drafts if you don't
-    already know) in a self-contained `<repo>-<topic>-repro/` directory: a `README.md`
-    with the draft issue/reply text and how to run, plus a minimal repro that runs
-    **unedited in one command** and prints a clear verdict. Reproduce against the
-    dependency's **latest** version — that's what its maintainer cares about, so there's
-    no need to sweep older releases. For a Rust dep, that's a tiny `cargo` project pinned
-    to the latest version, run with `cargo run`, printing observed-vs-expected; for other
-    ecosystems, the equivalent one-command script — so the maintainer can confirm the
-    behaviour first-hand before it is raised. No repro, no report. Keep the prose
-    succinct out of respect for these responsive volunteer maintainers' time: concrete
-    ask, then the
-    runnable repro, then authoritative evidence (spec quote / play.yaml.com event
-    stream), and cut the rest.
-- Linters and tests may write outside the workspace (e.g., `~/.cache/prek`). If
-  sandboxed, request permission escalation when running `prek`, `cargo test`,
-  or coverage commands.
-- Allow at least a 1-minute timeout per linter/test invocation; increase as
-  needed for larger runs or CI.
+- Filing an issue/PR on **another** project's repo (`granit`, upstream `yamllint`, …):
+  don't open it directly — these go out under the maintainer's name. Build a
+  self-contained draft for proof-read first, and only file once approved. Two
+  non-negotiables: (1) **never report on an assumption** — verify every claim by
+  *running that project itself* at the version in use, never inferred from its lineage,
+  a sibling tool, docs, or the spec; (2) **ship a one-command reproduction** in its own
+  `<repo>-<topic>-repro/` directory outside the ryl repo (ask where drafts live), pinned
+  to the dependency's **latest** version, printing observed-vs-expected. No repro, no
+  report. Keep it succinct: concrete ask, runnable repro, then authoritative evidence
+  (spec quote / play.yaml.com event stream).
+- Linters/tests may write outside the workspace (e.g. `~/.cache/prek`); if sandboxed,
+  request permission escalation for `prek`/`cargo test`/coverage. Allow ≥1-minute
+  timeouts per invocation (more for larger runs/CI).
 
 ## Automated Tests
 
@@ -250,32 +205,21 @@ rather than shipping silently. Work this checklist (the detailed test sections u
   `PROPTEST_CASES=512000 cargo test --release --test property_check` (the suites'
   in-CI default is 512 cases — tuned for speed, not exhaustiveness). Build `--release`
   and run it in the background; it routinely flushes rare interleavings the small count
-  misses (a 512k-case run on #252 surfaced a pre-existing alias/key-value desync bug in
-  `key-ordering` and `quoted-strings`). Commit only once it is green, and keep any
-  newly-persisted seeds in `tests/proptest-regressions/`.
+  misses. Commit only once it is green, and keep any newly-persisted seeds in
+  `tests/proptest-regressions/`.
 
 ### Property Tests For Safe Fixes
 
-`tests/property_safe_fix.rs` runs `proptest`-generated YAML through `apply_safe_fixes`
-and asserts three *soundness* invariants: idempotence, parse preservation (input
-that parses must produce output that parses to an equal `YamlOwned` value), and
-that a leading `# ryl disable` makes the fix a byte-for-byte no-op (the strongest
-form of "`--fix` never rewrites a disabled line"). A safe fix must be **sound**
-(never change a document's meaning), not **complete** (it may leave some reported
-violations unfixed when the fixer must not touch their context — e.g. trailing
-spaces inside a block scalar), so the suite deliberately does *not* assert "no
-diagnostics remain after fixing." Deterministic sibling tests pin known-dirty
-documents and known production-bug patterns (issues #184 and #206) through the same
-checks — and assert effectiveness (`safe_fix_rule_diagnostics` clears) on concrete
-inputs the fixer fully cleans — so the property assertions cannot silently become a
-no-op if the generator drifts.
-
-The suite runs against a matrix of named configs to catch config-specific
-regressions: five YAML configs (`yamllint-default`, `best-practice`, `strict-single`,
-`strict-double`, `consistent`) exercising the surface yamllint exposes, plus one
-TOML-backed config (`best-practice-toml`) loaded from a tempfile via
-`discover_config` so ryl-only options like `allow-double-quotes-for-escaping` are
-also covered.
+`tests/property_safe_fix.rs` runs generated YAML through `apply_safe_fixes` and asserts
+three *soundness* invariants (a safe fix must never change meaning, but need not be
+complete — so it does *not* assert "no diagnostics remain"): idempotence, parse
+preservation (parses to an equal `YamlOwned`), and a leading `# ryl disable` making the
+fix a byte-for-byte no-op. It runs a matrix of named configs — five YAML
+(`yamllint-default`, `best-practice`, `strict-single`, `strict-double`, `consistent`)
+plus one TOML-backed (`best-practice-toml`, covering ryl-only options like
+`allow-double-quotes-for-escaping`). Deterministic siblings pin known-dirty /
+production-bug inputs through the same checks (and assert the fixer clears them) so the
+property can't pass vacuously.
 
 When you add a new `FixSafety::Safe` rule:
 
@@ -299,32 +243,20 @@ follows the codebase, not the developer's machine.
 
 ### Property Tests For Rule Checkers
 
-`tests/property_check.rs` property-tests the **detection** path: it runs every
-rule's `check()` (including the unfixable rules above) over generated YAML and
-asserts two oracle-free invariants — `check()` never panics, and every reported
-violation has an in-bounds, **character-aligned** span (`1 <= line <=
-line_count`, `1 <= column <= chars_on_line + 1`). Two further invariants exercise
-the directive engine through `lint_str`: a leading `# ryl disable` mutes every
-rule (only a syntax error can survive), and block-disabling a rule that fires on
-a document removes all of that rule's diagnostics. This is the fast,
-yamllint-free complement to the slow `tests/yamllint_compat_*` differential
-suite; it targets ryl's historically fragile byte<->char offset arithmetic
-(issue #232) rather than semantic correctness.
-
-Layout mirrors the safe-fix suite: `property_check/strategy.rs` generates
-documents biased toward triggering every rule (truthy words, octal/float
-scalars, duplicate/unordered keys, flow spacing, anchors, over-long lines, odd
-indentation, trailing spaces) interleaved with multibyte characters, raw
-NEL/LS/PS (`unicode-line-breaks`, which are content not breaks in YAML 1.2), and
-mixed LF/CRLF endings (never a bare `\r`: ryl counts lines by `\n` only and does
-not support bare-CR endings — classic Mac OS, pre-2001 — so the generator omits
-them to keep line counting in agreement with the rules).
-`property_check/harness.rs` holds the trigger-all config (rule options
-are tuned so each rule actually emits), the per-rule `check()` dispatch, and the
-bounds invariant. The dispatch calls each `check()` directly rather than
-`lint_str` on purpose: `lint_str` discards every rule's spans in favour of the
-syntax error when a document fails to parse, but this suite must still bounds-check
-the spans rules emit on input that fails to parse.
+`tests/property_check.rs` property-tests the **detection** path: it runs every rule's
+`check()` over generated YAML and asserts oracle-free invariants — `check()` never
+panics, every span is in-bounds and **character-aligned** (`1 <= line <= line_count`,
+`1 <= column <= chars_on_line + 1`), a leading `# ryl disable` mutes every rule (only a
+syntax error survives), and block-disabling a firing rule removes its diagnostics. It
+targets ryl's fragile byte↔char offset arithmetic rather than semantic correctness (the
+fast complement to the slow `yamllint_compat_*` differential suite).
+`property_check/strategy.rs` generates documents biased to trigger every rule (truthy
+words, octal/float scalars, duplicate/unordered keys, flow spacing, anchors, long lines,
+odd indentation, trailing spaces) interleaved with multibyte chars, raw NEL/LS/PS, and
+mixed LF/CRLF (never a bare `\r` — ryl counts lines by `\n` only). `harness.rs` holds the
+trigger-all config and the per-rule dispatch, which calls each `check()` directly (not
+`lint_str`, which drops rule spans on a parse error) so spans are bounds-checked even on
+input that fails to parse.
 
 When you add a new rule, extend `collect_spans` in `harness.rs` to call its
 `check()` and add a `(rule-id, triggering-input)` row to `RULE_TRIGGERS` in
@@ -336,16 +268,14 @@ to the committed `tests/proptest-regressions/property_check.txt`. Run with
 
 ### Property Tests For Markdown `--fix`
 
-`tests/property_markdown_fix.rs` property-tests `fix::fix_markdown_str` — the
-write-back of safe fixes into YAML embedded in Markdown. It reuses the safe-fix
-generator via `#[path]` (`property_safe_fix/{ast,strategy,config}.rs`), wraps the
-generated `Document`s into a Markdown host (`property_markdown_fix/wrap.rs`), and
-asserts four oracle-free invariants across the safe-fix config matrix: host bytes
-outside regions stay byte-identical (with region count/kinds stable), each region's
-parsed value is preserved, each region is either untouched or rewritten to exactly
-its `apply_safe_fixes_filtered` form, and the operation is idempotent. Deterministic
-siblings pin known-dirty / CRLF / ragged / fence-crossing-front-matter cases so the
-random invariants cannot pass vacuously.
+`tests/property_markdown_fix.rs` property-tests `fix::fix_markdown_str` (write-back into
+embedded YAML). It reuses the safe-fix generator via `#[path]` and wraps the documents
+into a Markdown host (`property_markdown_fix/wrap.rs`), asserting four oracle-free
+invariants across the config matrix: host bytes outside regions stay byte-identical
+(region count/kinds stable), each region's parsed value is preserved, each region is
+untouched or rewritten to exactly its `apply_safe_fixes_filtered` form, and it's
+idempotent. Deterministic siblings pin known-dirty / CRLF / ragged /
+fence-crossing-front-matter cases.
 
 Extend this suite only when the Markdown extractor/wrapper grows new region shapes:
 add a `wrap.rs` variant and a deterministic sibling. Failing inputs persist to the
@@ -354,21 +284,16 @@ committed `tests/proptest-regressions/property_markdown_fix.txt`; run with
 
 ### Property Tests For Config Parsing
 
-`tests/property_config.rs` property-tests **configuration robustness** (issue #246
-hardening): `property_config/strategy.rs` generates randomized configs — random
-subsets of rules with random levels and options, mixing valid values with hostile
-ones (invalid regexes, ill-typed/out-of-range scalars, bogus locales) — and renders
-each model to both YAML and TOML. The oracle-free invariant is that the whole
-pipeline errors or succeeds but **never panics**: YAML goes through
-`YamlLintConfig::from_yaml_str` and, when it parses, lints sample documents (driving
-the `.expect()` calls in `key-ordering`/`quoted-strings` `resolve()`); TOML goes
-through `parse_toml_config_str -> validate_toml_config -> normalize_toml_config`.
-Deterministic siblings pin the empty-config (YAML and TOML), invalid-regex,
-billion-laughs, and rich-valid-config cases so the random invariant cannot pass
-vacuously. When a rule gains a config-compiled regex or a new typed option, add its
-real option key(s) to `CATALOG` in `strategy.rs`. Failing inputs persist to the
-committed `tests/proptest-regressions/property_config.txt`; run with
-`cargo test --test property_config`.
+`tests/property_config.rs` property-tests **configuration robustness**:
+`property_config/strategy.rs` generates randomized configs (random rule subsets, levels,
+and options, mixing valid with hostile values — invalid regexes, ill-typed/out-of-range
+scalars, bogus locales) rendered to both YAML and TOML. The oracle-free invariant: the
+pipeline errors or succeeds but **never panics** — YAML via `YamlLintConfig::from_yaml_str`
+(then linting samples, to drive the `.expect()`s in `key-ordering`/`quoted-strings`
+`resolve()`), TOML via `parse_toml_config_str -> validate_toml_config ->
+normalize_toml_config`. Deterministic siblings pin empty-config, invalid-regex,
+billion-laughs, and rich-valid cases. When a rule gains a config-compiled regex or typed
+option, add its key(s) to `CATALOG` in `strategy.rs`.
 
 ### Rules Without A Safe `--fix`
 
@@ -438,9 +363,8 @@ hunting through scattered tips:
    fix the failing tests, then rerun the coverage script.
 4. If the script reports files, extend CLI/system tests targeting those ranges until
    the script produces no output.
-5. For richer artifacts (HTML, LCOV, etc.), follow the cargo-llvm-cov documentation
-   after running the script. HTML is not easily machine readable though so not
-   recommended.
+5. For richer artifacts (HTML/LCOV), see the cargo-llvm-cov docs (HTML isn't easily
+   machine-readable).
 6. When coverage points to tricky regions, prefer CLI/system tests in `tests/`
    that drive `env!("CARGO_BIN_EXE_ryl")` so you exercise the same paths as users.
 7. When you need to observe the exact flow through an uncovered branch, run the
@@ -460,12 +384,10 @@ hunting through scattered tips:
 - When walking indices backwards, call `checked_sub(1).expect("…")` instead of
   matching on `checked_sub`; the `expect` documents the invariant and removes
   the uncovered `None` branch that instrumentation reports.
-- When collecting spans, store the raw tuple `(start, end)` and filter once at
-  the end instead of pushing `Range` conditionally; this keeps the guard logic
-  centralized and ensures LLVM records the conversion branch exactly once.
-- Normalize prefix checks with `strip_prefix(...).expect(...)` when downstream
-  code already guarantees the prefix; this removes the otherwise uncovered
-  `return` path that instrumentation would highlight.
+- When collecting spans, store the raw `(start, end)` and filter once at the end rather
+  than pushing `Range` conditionally, so LLVM records the conversion branch once.
+- Normalize prefix checks with `strip_prefix(...).expect(...)` when the prefix is already
+  guaranteed; this removes the otherwise-uncovered `return` path.
 
 Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already listed in
 `rust-toolchain.toml`). Run from a Developer Command Prompt if linker tools go missing.
@@ -486,9 +408,8 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   key/value position must advance it for *every* node-producing event, including
   `Event::Alias` (call `Walker::skip_node`). An alias in value position (`k: *a`, or a
   `<<: *base` merge) that does not advance the walker desyncs the key/value alternation,
-  so the following key is read as a value and vice-versa (this caused a phantom-key bug
-  in `key-ordering` and key/value misclassification in `quoted-strings`). Exercise rules
-  with aliases in both key and value position.
+  so the following key is read as a value and vice-versa. Exercise rules with aliases in
+  both key and value position.
 - Resolving a scalar to its typed value (int/bool/null/float/string) is centralised in
   `crate::yaml_dom::scalar` (`resolve_scalar` / `resolve_plain_scalar`); reuse it rather
   than reinventing parsing. ryl resolves scalars per the YAML 1.2 **core** schema
@@ -496,27 +417,18 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   radixes, full bool/null spelling sets); keep that schema choice consistent across rules
   instead of switching to JSON/1.1 semantics in any single rule.
 - Matching a core-schema tag (`!!int`, `!!str`, …): use
-  `crate::yaml_dom::core_schema_suffix(tag)` / `is_core_schema(tag)`, **never**
-  granit's `Tag::is_yaml_core_schema`. The latter inspects only the *handle*, so a
-  verbatim core tag (`!<tag:yaml.org,2002:int>` — granit scans it to an empty handle
-  with the full URI in `suffix`) slips past it even though PyYAML/ruamel resolve it to
-  the same type. The shared helpers report the core suffix for both the canonical
-  `tag:yaml.org,2002:` handle (including a `%TAG` that resolves to it) and the verbatim
-  spelling. They do **not** decompose a `%TAG` directive that splits the URI mid-token
-  (`%TAG !m! tag:yaml.org,2002:m` + `!m!erge`, which the reference parser still resolves
-  to `tag:yaml.org,2002:merge`); to match one specific type regardless of the split
-  point, compare the complete resolved URI (`handle` ++ `suffix`) as
-  `rules::support::merge_key` does for the merge tag (#277).
-
-CI will fail the build on any missed line or region, so keep local runs green by
-sticking to the quick-status step above.
+  `crate::yaml_dom::core_schema_suffix(tag)` / `is_core_schema(tag)`, **never** granit's
+  `Tag::is_yaml_core_schema` (it inspects only the *handle*, so a verbatim core tag
+  `!<tag:yaml.org,2002:int>` slips past it). The shared helpers handle the canonical
+  handle (incl. a resolving `%TAG`) and the verbatim spelling, but not a `%TAG` that
+  splits the URI mid-token; to match one type regardless of split point, compare the
+  full resolved URI (`handle` ++ `suffix`), as `rules::support::merge_key` does.
 
 ## Testing Tips
 
-- For Unicode-heavy fixtures, assert behaviour with multibyte characters and reuse the
-  helpers in `crate::rules::span_utils` instead of reinventing byte/char conversions.
-  When writing tests, prefer inputs like `"café"` or `"å"` to ensure coverage of
-  character vs byte offset logic.
+- For Unicode-heavy fixtures, assert with multibyte characters (e.g. `"café"`/`"å"`) and
+  reuse `crate::rules::span_utils` rather than reinventing byte/char conversions, to
+  cover character-vs-byte offset logic.
 - Lean on meaningful function/variable names and assertion messages to make tests
   self-documenting; add a comment only where it explains a non-obvious trade-off or
   opaque mechanic that names cannot (the standard minimal-comment bar applies).
@@ -540,25 +452,17 @@ sticking to the quick-status step above.
   `uv run scripts/print_ryl_schemastore_schema.py`; it targets only
   `ryl.toml` / `.ryl.toml` because SchemaStore cannot attach directly to
   `[tool.ryl]` inside `pyproject.toml`.
-- The committed config-schema files `ryl.toml.schema.json` and
-  `ryl.yaml.schema.json` are generated by `ryl --print-toml-config-schema` and
-  `ryl --print-yaml-config-schema`. **Always run `prek` after regenerating
-  them.** The `--print` output is in schemars *insertion* order, but the
-  `pretty-format-json` prek hook rewrites every JSON file with **recursively
-  sorted keys**, so the committed canonical form is sorted. Committing raw
-  `--print` output (unsorted) is the cause of the recurring "prek reordered the
-  schema" churn — the next `prek run` re-sorts it. Because the canonical form is
-  sorted, regeneration only changes lines when the schema *content* changes, so:
-  - a structural code change that does not alter schema content (e.g. adding a
-    defaulted generic parameter to `RulesTable`) produces a *zero* diff after
-    sorting — don't commit a reordered file in that case; regenerate, run `prek`,
-    and if `git diff` is empty (or `diff <(git show HEAD:FILE | jq -S .)
-    <(jq -S . FILE)` is empty) leave the file at `HEAD`;
-  - the `tests/config_schema.rs` checks compare schemas as order-insensitive
-    `serde_json::Value`, so key order never affects correctness — but the files
-    must still be committed sorted to keep `prek` idempotent. When an options
-    type is renamed (e.g. a new `Toml*Options` variant), update the concrete
-    `RuleEntryFor…`/`RuleOptionsFor…` names asserted in that test too.
+- The committed `ryl.toml.schema.json` / `ryl.yaml.schema.json` are generated by
+  `ryl --print-toml-config-schema` / `--print-yaml-config-schema`. **Always run `prek`
+  after regenerating**: `--print` emits schemars *insertion* order, but the
+  `pretty-format-json` hook rewrites JSON with recursively *sorted* keys, so the
+  committed form is sorted (committing raw `--print` output causes the recurring "prek
+  reordered the schema" churn). Because the canonical form is sorted, regeneration only
+  changes lines when schema *content* changes — a structural change that doesn't alter
+  content yields a zero diff after sorting, so don't commit a reordered file (leave it at
+  `HEAD`). `tests/config_schema.rs` compares order-insensitively, but the files must
+  still be committed sorted to keep `prek` idempotent; when an options type is renamed,
+  update the `RuleEntryFor…`/`RuleOptionsFor…` names asserted there too.
 
 ## Release Checklist
 
@@ -579,21 +483,15 @@ sticking to the quick-status step above.
   - `.github/workflows/release.yml` validates that the pushed tag version
     matches `Cargo.toml`, `pyproject.toml`, and `package.json` versions
     before release jobs run.
-- `.github/workflows/sync-schemastore.yml` projects `ryl.toml.schema.json`
-  into SchemaStore's draft-07 format and updates the user's SchemaStore fork.
-  The release workflow runs it after a successful release and prints a manual
-  upstream PR handoff for `owenlamont/schemastore:ryl-schema-update`.
-  - Publishing uses Trusted Publishing for all registries:
-    - crates.io via GitHub OIDC (`rust-lang/crates-io-auth-action`)
-    - PyPI via Trusted Publishing (`pypa/gh-action-pypi-publish`)
-    - NPM via Trusted Publishing (`actions/setup-node` OIDC)
-  - GitHub release creation is deferred until the end of the workflow, after
-    crates.io, PyPI, and NPM publishing succeed.
-  - GitHub release notes are generated automatically by GitHub when the release
-    draft is created.
-  - The workflow keeps GitHub releases as drafts until assets are uploaded and
-    supports reruns by skipping crates.io/PyPI publish steps when that exact
-    version already exists.
+- After a successful release, `.github/workflows/sync-schemastore.yml` projects
+  `ryl.toml.schema.json` into SchemaStore's draft-07 format, updates the user's
+  SchemaStore fork, and prints a manual upstream PR handoff for
+  `owenlamont/schemastore:ryl-schema-update`.
+- Publishing uses Trusted Publishing on all registries (crates.io via GitHub OIDC, PyPI
+  via `pypa/gh-action-pypi-publish`, NPM via `actions/setup-node` OIDC). GitHub release
+  creation is deferred until after crates.io/PyPI/NPM publishing succeeds, kept as a
+  draft until assets upload, with auto-generated notes; reruns skip publish steps for a
+  version that already exists.
 
 ## Documentation Site
 
@@ -627,118 +525,79 @@ sticking to the quick-status step above.
   `markdown` to glob lists (`yaml` defaults to `*.yaml`/`*.yml`/`.yamllint`). A
   file matching two kinds is a hard error. `yaml-files` is rejected in TOML (use
   `[files].yaml`); it remains valid in the legacy YAML config.
-- Markdown embedding (off by default; enabled by listing `[files].markdown`
-  globs, or for one run with the `--markdown` flag which injects default markdown
-  globs): ryl extracts front matter and fenced `yaml`/`yml` blocks (each linted as
-  its own document), mapping diagnostics back to the Markdown file. The
-  `[markdown]` table's `front-matter`/`fenced-blocks` booleans (default true)
-  select sources. The extractor lives in `src/markdown_embed/` (fenced blocks via
-  `pulldown-cmark`; front matter via a line scan); each `EmbeddedRegion` carries the
-  raw source `raw_span` used by write-back and the per-line column remap.
-  `document-start`, `document-end`, `new-line-at-end-of-file`, and `new-lines` are
-  suppressed inside embedded regions via `fix::suppressed_rules(kind)` (shared by
-  the check and fix paths). `--fix` writes safe fixes back into the Markdown
-  (`fix::fix_markdown_str`): it re-applies each line's stripped prefix (spaces, a
-  blockquote `> `, or a tab), preserves CRLF, and only rewrites a region when that
-  reproduces the original bytes exactly (the reconstruct-and-verify guard) — a
-  region whose lines lack a single shared prefix (ragged) is reported but left
-  untouched, so write-back cannot corrupt a document. See `docs/markdown.md`.
+- Markdown embedding (off by default; enabled by `[files].markdown` globs, or per-run
+  via `--markdown` which injects default globs): ryl extracts front matter and fenced
+  `yaml`/`yml` blocks (each linted as its own document) and maps diagnostics back to the
+  Markdown file. The `[markdown]` `front-matter`/`fenced-blocks` booleans (default true)
+  select sources. Extractor in `src/markdown_embed/` (fenced blocks via `pulldown-cmark`,
+  front matter via a line scan); each `EmbeddedRegion` carries the `raw_span` and per-line
+  column remap. `document-start`/`document-end`/`new-line-at-end-of-file`/`new-lines` are
+  suppressed in regions via `fix::suppressed_rules(kind)`. `--fix` writes back
+  (`fix::fix_markdown_str`): re-applies each line's stripped prefix (spaces, `> `, or a
+  tab), preserves CRLF, and only rewrites a region when that reproduces the original
+  bytes exactly — a ragged region (no single shared prefix) is reported but left
+  untouched. See `docs/markdown.md`.
 - `--fix` never mutates a file that does not fully parse:
   `fix::apply_safe_fixes_filtered` gates the whole pipeline on `lint::parse_error`
   (stricter than lint's `syntax_diagnostic` — it does *not* tolerate undefined
   aliases), so *any* granit parse error ⇒ the input is returned byte-for-byte
-  unchanged, and even the pure source-transform fixers (`new-lines`,
-  `new-line-at-end-of-file`) leave such a file untouched. `apply_safe_fixes_in_place`
-  returns `FixOutcome::Skipped(problem)` for those files and the CLI prints a
-  `<path>:L:C skipped by --fix: <error>` notice, so the user always learns why a
-  file was not fixed — this also closes the hole where an undefined alias masked a
-  later syntax error. Lint behavior is unchanged: an undefined alias is still not a
-  lint syntax error (the `anchors` rule reports it, matching yamllint); only `--fix`
-  applies the stricter gate. The gate flows through the in-place and per-region
-  Markdown fix paths.
-- `--diff` (issue #269) previews `--fix` instead of writing: it prints a unified
-  diff (3 lines of context) per changed file to **stdout** and exits `1` iff any
-  file would change, mirroring `ruff check --diff`. It is `conflicts_with` `--fix`,
-  ignores `--format`, and (unlike `--fix`) supports stdin. Crucially it is
-  diff-only: remaining *unfixable* findings are neither printed nor counted, so a
-  file that only trips an unfixable rule exits `0` (a plain lint run would exit
-  `1`). It reuses the fix pipeline (`fix::diff_safe_fixes_for_files` →
-  `fix::diff_outcome`, calling `apply_safe_fixes`/`fix_markdown_str`), so it inherits
-  the same parse-error gate (unparsable files are skipped with a
-  `<path>:L:C skipped by --diff: <error>` notice, no exit effect) and symlink skip
-  (`fix::refuse_symlink`, now parameterised by flag). A non-UTF-8/BOM input is also
-  skipped (`fix::non_utf8_diff_skip`; files via `DecodedFile::is_plain_utf8`, stdin via
-  a decoded-bytes==raw-bytes check) — a textual diff of decoded content cannot apply
-  back to transcoded/BOM'd bytes, so `--fix` (which re-encodes) is the path for those.
-  Markdown diffs at the host-file level (one diff per `.md`). The diff *body* is
-  emitted verbatim (a consumer such as hk must re-apply it byte-for-byte); only the
-  header path is sanitized.
-- Malicious-payload hardening (issue #246): `--fix` never writes through a
-  symlink — `fix::refuse_symlink` skips a symlinked input (still linted) with a
-  warning, so an untrusted tree cannot redirect an in-place write outside itself.
-  The write target is always the input path, never derived from YAML content. The
-  YAML config loader (`yaml_dom::loader`, used only for YAML config — `lint_str`
-  builds no DOM) bounds alias expansion at `MAX_EXPANDED_NODES`, rejecting
-  billion-laughs configs (`-c`/`-d`/discovered `.yamllint`) instead of exhausting
-  memory; cyclic `extends` is bounded by `MAX_EXTENDS_DEPTH` (was a stack overflow).
-  An empty/whitespace/comment-only YAML config reports "not a mapping"; an empty
-  TOML config (incl. an empty `[tool.ryl]`) reports "configuration is empty" instead
-  of silently linting zero rules — neither panics. The markdown extractor derives
-  each fenced block's line offset by binary search over precomputed newline
-  positions (`markdown_embed::collect_fenced_blocks`), not by rescanning from the
-  document start, so many embedded blocks stay linear rather than quadratic. Output
-  is injection-safe: the GitHub format escapes user text (`github_escape_data`/
-  `_property`, covering `::group::` and `file=`) so a crafted key/anchor/filename
-  cannot inject a `::command::` in CI, and the standard/colored/parsable formats run
-  user text through `sanitize_control` so control chars can't inject terminal escapes
-  or split a diagnostic line. Regression guards: `tests/cli_alias_bomb.rs`,
-  `tests/cli_fix_symlink.rs`, `tests/cli_config_data_error.rs`,
-  `tests/cli_toml_config.rs`, `tests/config_extends_inline.rs`,
-  `tests/cli_format_options.rs`, `cli_markdown_embed.rs`, and the randomized
-  `tests/property_config.rs`. granit-parser itself caps nesting recursion (~256), so
-  deep-nesting payloads are rejected before a deep DOM is built. Config-supplied
-  regexes (`key-ordering`, `quoted-strings`) are validated at config-parse time and
-  the `regex` crate is linear-time, so ReDoS is not reachable.
-- Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding
-  detection as files. `-` cannot be combined with other inputs and is not
-  compatible with `--fix`. `--stdin-filename <PATH>` (ruff convention) sets
-  the diagnostic label, anchors project-config discovery at the given path's
-  parent, resolves the source kind from `[files]` (so a `markdown`-matching path
-  is linted as embedded YAML), and runs `yaml-files`, per-file-ignore, and per-rule
-  `ignore` matching against that path. Omitting `--stdin-filename` labels
-  diagnostics as `<stdin>`, anchors config discovery at CWD, and skips all
-  path-based filtering (`yaml-files`, per-file-ignores, per-rule `ignore`) so every
-  enabled rule runs against the input; pass `--markdown` to lint that input as
-  Markdown rather than plain YAML.
-- Inline directives (`src/directives.rs`): `# ryl disable` / `enable` /
-  `disable-line` comments (and the `# yamllint …` compat aliases) suppress rules
-  for a block or a single line, mirroring yamllint's exact grammar
-  (`yamllint/linter.py`). A first-line `# ryl/yamllint disable-file`
-  (`directives::disables_file`) skips the whole file &mdash; no diagnostics, not
-  even syntax errors, and no `--fix`. Handling is global, not per-rule: `lint::lint_str`
-  filters every diagnostic through `Directives::is_disabled` before the
-  syntax-error check, and `fix` reverts a fixer's edits to disabled lines via
-  `Directives::reconcile`. Directives work region-locally inside embedded
-  Markdown. Match yamllint's semantics exactly (validate with
-  `tests/yamllint_compat_directives.rs`); the bare rule ids live in
-  `rules::ALL_RULE_IDS`. User docs: `docs/directives.md`.
-- ryl never enables a rule that wasn't explicitly turned on — there are no
-  "default-on" rules. Two cases converge on this, both rejected loudly by the lint
-  commands (exit 2) and both intentionally stricter than yamllint:
-  - **No config found anywhere** (no `-c`/`-d`, no `YAMLLINT_CONFIG_FILE`, no
-    discovered project/user-global config): resolution falls back to an *empty*
-    config (`config::ConfigContext::config_found == false`) rather than the `default`
-    preset, and the lint paths report `main::NO_CONFIG_ERROR`. yamllint instead lints
-    with `extends: default`.
-  - **A resolved config that enables no rules** (`rules: {}`, an empty
-    `[rules]`/`[tool.ryl]`, a `[files]`-only TOML config, or one disabling
-    everything): reported as `main::NO_RULES_ENABLED_ERROR`. yamllint silently lints
-    nothing.
-  Both checks live in the lint entrypoints via `YamlLintConfig::enables_any_rule`;
-  `main::no_rules_error(config_found)` picks the message. `config_found` flows from
-  `ConfigContext` through `resolve_ctx`/`gather_lint_files` (run-level) and
-  `resolve_stdin_ctx`. The `default`/`relaxed`/`empty` presets stay available as
-  explicit opt-ins via `extends:` (YAML config only). `--migrate-configs` (converts
-  configs, does not lint — it warns when a migrated config enables no rules) and
-  `--list-files` (a file query) are exempt; only the actual lint paths enforce it.
+  unchanged and `apply_safe_fixes_in_place` returns `FixOutcome::Skipped(problem)`; the
+  CLI prints a `<path>:L:C skipped by --fix: <error>` notice. Lint behavior is
+  unchanged: an undefined alias is still not a lint syntax error (the `anchors` rule
+  reports it, matching yamllint); only `--fix` applies the stricter gate, through the
+  in-place and per-region Markdown paths.
+- `--diff` (#269) previews `--fix` without writing: prints a unified diff (3 lines of
+  context) per changed file to **stdout** and exits `1` iff any file would change,
+  mirroring `ruff check --diff`. `conflicts_with` `--fix`, ignores `--format`, supports
+  stdin. Diff-only: remaining *unfixable* findings are neither printed nor counted (a
+  file tripping only an unfixable rule exits `0`). Reuses the fix pipeline
+  (`fix::diff_safe_fixes_for_files` → `fix::diff_outcome`), inheriting the parse-error
+  gate and symlink skip (both → a `skipped by --diff` notice, no exit effect). A
+  non-UTF-8/BOM input is likewise skipped (`fix::non_utf8_diff_skip`; files via
+  `DecodedFile::is_plain_utf8`, stdin via decoded==raw bytes) — a text diff can't apply
+  back to transcoded bytes, so `--fix` (which re-encodes) is the path for those. Markdown
+  diffs at host-file level. The diff *body* is verbatim (hk re-applies it byte-for-byte);
+  only the header path is sanitized.
+- Malicious-payload hardening (#246) — invariants to preserve: `--fix`/`--diff` never
+  write/read through a symlink (`fix::refuse_symlink`) and the write target is always
+  the input path, never derived from YAML content. The YAML config loader
+  (`yaml_dom::loader`; `lint_str` builds no DOM) bounds alias expansion at
+  `MAX_EXPANDED_NODES` and `extends` depth at `MAX_EXTENDS_DEPTH`, so billion-laughs and
+  cyclic-`extends` configs error instead of exhausting memory/stack. An empty
+  YAML/TOML config errors ("not a mapping" / "configuration is empty") rather than
+  silently linting nothing. Output is injection-safe: the GitHub format escapes user
+  text (`github_escape_data`/`_property`) so a crafted key/anchor/filename can't
+  inject a `::command::`; the other formats run user text through `sanitize_control`.
+  granit caps nesting recursion (~256), and config regexes
+  (`key-ordering`/`quoted-strings`) are validated at parse time with the linear-time
+  `regex` crate (no ReDoS). Guards:
+  `tests/cli_alias_bomb.rs`, `cli_fix_symlink.rs`, `cli_config_data_error.rs`,
+  `cli_toml_config.rs`, `config_extends_inline.rs`, `cli_format_options.rs`,
+  `cli_markdown_embed.rs`, `property_config.rs`.
+- Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding detection as
+  files; `-` can't be combined with other inputs or with `--fix`. `--stdin-filename
+  <PATH>` (ruff convention) sets the diagnostic label, anchors config discovery at the
+  path's parent, resolves the source kind from `[files]` (a `markdown` path → embedded
+  YAML), and runs `yaml-files`/per-file-ignore/per-rule `ignore` against it. Without it,
+  diagnostics are `<stdin>`, config is anchored at CWD, and all path-based filtering is
+  skipped so every enabled rule runs; `--markdown` forces Markdown.
+- Inline directives (`src/directives.rs`): `# ryl disable` / `enable` / `disable-line`
+  (and `# yamllint …` aliases) suppress rules for a block or line, mirroring yamllint's
+  grammar (`yamllint/linter.py`); a first-line `# ryl/yamllint disable-file`
+  (`directives::disables_file`) skips the whole file (no diagnostics, not even syntax
+  errors, no `--fix`). Handling is global: `lint_str` filters every diagnostic through
+  `Directives::is_disabled` before the syntax-error check, and `fix` reverts edits to
+  disabled lines via `Directives::reconcile`. Works region-locally in embedded Markdown.
+  Validate against yamllint with `tests/yamllint_compat_directives.rs`. User docs:
+  `docs/directives.md`.
+- ryl never enables a rule that wasn't explicitly turned on (no "default-on" rules). Two
+  cases exit `2`, both stricter than yamllint: **no config found anywhere** (resolution
+  falls back to an *empty* config — `ConfigContext::config_found == false` — not the
+  `default` preset; reports `main::NO_CONFIG_ERROR`; yamllint lints with `extends:
+  default`), and **a resolved config that enables no rules** (`rules: {}`, empty
+  `[rules]`/`[tool.ryl]`, a `[files]`-only TOML config, or one disabling everything;
+  reports `main::NO_RULES_ENABLED_ERROR`; yamllint silently lints nothing). Both via
+  `YamlLintConfig::enables_any_rule`; `main::no_rules_error(config_found)` picks the
+  message. The `default`/`relaxed`/`empty` presets stay available via `extends:` (YAML
+  only). `--migrate-configs` (warns instead) and `--list-files` are exempt.
 - Exit codes: `0` (ok/none), `1` (invalid YAML), `2` (usage error).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -616,6 +616,13 @@ sticking to the quick-status step above.
 - Files named explicitly are linted as their resolved source kind; one that
   matches no `[files]` kind is rejected with an error (rather than silently
   treated as YAML).
+- Inputs are de-duplicated: a file reached by two spellings (the walk plus an
+  explicit arg, e.g. `ryl . f.yaml`, or `f.yaml` listed twice) is processed once.
+  `gather_lint_files` keys a `seen` set on `main::canonical_input` (`std::path::absolute`
+  — lexical, no symlink resolution, no existence check), so this spans lint/`--fix`/
+  `--diff`/`--list-files`. Deliberately stricter than yamllint (which processes
+  duplicates); for `--diff` a duplicate would emit a repeat patch block that fails to
+  apply on the second copy.
 - Source kinds (`config::SourceKind`): the `[files]` TOML table maps `yaml` and
   `markdown` to glob lists (`yaml` defaults to `*.yaml`/`*.yml`/`.yamllint`). A
   file matching two kinds is a hard error. `yaml-files` is rejected in TOML (use
@@ -649,6 +656,20 @@ sticking to the quick-status step above.
   lint syntax error (the `anchors` rule reports it, matching yamllint); only `--fix`
   applies the stricter gate. The gate flows through the in-place and per-region
   Markdown fix paths.
+- `--diff` (issue #269) previews `--fix` instead of writing: it prints a unified
+  diff (3 lines of context) per changed file to **stdout** and exits `1` iff any
+  file would change, mirroring `ruff check --diff`. It is `conflicts_with` `--fix`,
+  ignores `--format`, and (unlike `--fix`) supports stdin. Crucially it is
+  diff-only: remaining *unfixable* findings are neither printed nor counted, so a
+  file that only trips an unfixable rule exits `0` (a plain lint run would exit
+  `1`). It reuses the fix pipeline (`fix::diff_safe_fixes_for_files` →
+  `fix::diff_outcome`, calling `apply_safe_fixes`/`fix_markdown_str`), so it inherits
+  the same parse-error gate (unparsable files are skipped with a
+  `<path>:L:C skipped by --diff: <error>` notice, no exit effect) and symlink skip
+  (`fix::refuse_symlink`, now parameterised by flag). Markdown diffs at the
+  host-file level (one diff per `.md`). The diff *body* is emitted verbatim (a
+  consumer such as hk must re-apply it byte-for-byte); only the header path is
+  sanitized.
 - Malicious-payload hardening (issue #246): `--fix` never writes through a
   symlink — `fix::refuse_symlink` skips a symlinked input (still linted) with a
   warning, so an untrusted tree cannot redirect an in-place write outside itself.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "diffy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +591,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1573,6 +1585,7 @@ name = "ryl"
 version = "0.14.0"
 dependencies = [
  "clap",
+ "diffy",
  "dirs-next",
  "encoding_rs",
  "globset",
@@ -1589,6 +1602,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "similar",
  "tempfile",
  "toml",
  "unicode-normalization",
@@ -1756,6 +1770,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,17 @@ dirs-next = "2.0.0"
 regex = "1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+similar = { version = "3.1.1", default-features = false, features = ["text"] }
 unicode-normalization = "0.1"
 encoding_rs = "0.8"
 toml = "1.1.2"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 
 [dev-dependencies]
+# Independent unified-diff applier for the `--diff` round-trip property test: a
+# different implementation than the `similar` crate that produces the diff, so the
+# round-trip validates the output is standard-compliant (what hk relies on).
+diffy = { version = "0.5.0", default-features = false }
 jsonschema = "0.46.2"
 proptest = "1.11.0"
 semver = "1"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ cargo install ryl                   # cargo
   `comments`, `comments-indentation`, `new-line-at-end-of-file`,
   `new-lines`, and `quoted-strings`. The set of rules that may apply
   fixes is configurable via the TOML `[fix]` table.
+- `--diff` previews those safe fixes as a unified diff on stdout instead
+  of writing them (modelled on `ruff check --diff`); it is mutually
+  exclusive with `--fix`, works with stdin, and exits `1` iff some file
+  would change.
 - TOML is the recommended configuration format and supports ryl-only
   features that have no upstream equivalent: the `[fix]` table,
   `[per-file-ignores]`, and rule options such as
@@ -68,8 +72,9 @@ cargo install ryl                   # cargo
   in TOML use `[files].yaml`.
 - YAML embedded in Markdown (front matter and fenced `yaml`/`yml` blocks)
   can be linted by listing globs under `[files].markdown`; diagnostics map back
-  to the Markdown file. It is off by default and check-only (`--fix` does not
-  modify Markdown). See <https://ryl-docs.pages.dev/markdown/>.
+  to the Markdown file. It is off by default; `--fix` writes safe fixes back into
+  the embedded blocks and `--diff` previews them at the host-file level. See
+  <https://ryl-docs.pages.dev/markdown/>.
 - yamllint-style YAML configuration is also accepted (`.yamllint`,
   `.yamllint.yml`, `.yamllint.yaml`) for drop-in compatibility, including
   the built-in `default`, `relaxed`, and `empty` presets via `extends`.
@@ -85,7 +90,8 @@ cargo install ryl                   # cargo
   `ignore`) use that filename. Without it, diagnostics are labelled
   `<stdin>`, config is anchored at the current working directory, and
   all path-based filtering is skipped so every enabled rule runs.
-  `-` cannot be combined with other inputs or with `--fix`.
+  `-` cannot be combined with other inputs; `--fix` cannot read from
+  stdin, but `--diff` can.
 - Run `ryl --help` for the authoritative CLI reference.
 
 For installation walkthroughs, configuration presets, and per-rule

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -66,9 +66,9 @@ produced.
 ## How ryl differs from yamllint
 
 ryl is a drop-in replacement, but it intentionally diverges from yamllint in a
-small number of places. Every divergence is deliberate and falls into one of two
-buckets: ryl is **more correct against the YAML 1.2.2 specification**, or it
-**fails loudly instead of silently**. The complete list:
+small number of places. Every divergence is deliberate: ryl is **more correct
+against the YAML 1.2.2 specification**, it **fails loudly instead of silently**, or
+it **avoids redundant output**. The complete list:
 
 ### No implicit default configuration
 
@@ -109,6 +109,19 @@ The portable, unambiguous way to use an alias as a mapping key is a **space befo
 the colon** &mdash; `*foo : bar` &mdash; which every parser reads identically. The
 ryl-only [`anchors: forbid-ambiguous-anchor-alias-names`](../rules/anchors.md)
 option flags welded colons so you can forbid the construct outright.
+
+### De-duplicated inputs
+
+When a single run names the same file more than once &mdash; listed twice, or reached
+by both a directory argument and an explicit path (`ryl . file.yaml`) &mdash; ryl
+processes it **once**. yamllint handles each occurrence, so it would report that
+file's diagnostics (or, under `ryl --diff`, emit its patch) twice.
+
+**Why ryl differs:** duplicate output is never useful, and it is actively harmful for
+`--diff`, whose output is meant to be applied as a patch &mdash; a repeated patch
+block fails to apply on the second copy. ryl normalizes each input path (lexically,
+without resolving symlinks, so a symlink and its target stay distinct) and skips a
+file it has already selected.
 
 ## Side-by-side example
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -40,7 +40,8 @@ Without `--stdin-filename`, diagnostics are labelled `<stdin>`, config
 discovery is anchored at the current working directory, and all
 path-based filtering (`yaml-files`, per-file-ignores, per-rule `ignore`
 patterns) is skipped so every enabled rule runs. `-` cannot be combined
-with other inputs or with `--fix`.
+with other inputs, and `--fix` cannot read from stdin (use `--diff` to
+preview fixes instead).
 
 Exit codes:
 
@@ -79,6 +80,32 @@ symlinked input is linted but skipped for fixing (with a warning on
 stderr), so a symlink in an untrusted tree cannot redirect a write to a
 file outside it. This mirrors directory scanning, which does not follow
 symlinks.
+
+## Preview fixes as a diff
+
+`--diff` runs the same safe fixes as `--fix` but, instead of writing,
+prints a unified diff (3 lines of context) of what would change to
+stdout &mdash; modelled on `ruff check --diff`:
+
+```bash
+ryl --diff .
+```
+
+This is handy for CI previews, PR review, and parallel-safe runners such
+as [hk](https://hk.jdx.dev) that apply the diff themselves rather than
+re-invoking the linter. `--diff` never modifies files, is mutually
+exclusive with `--fix`, and (unlike `--fix`) works with `-`/stdin.
+
+Like `ruff check --diff`, the exit code reflects only the diff &mdash;
+remaining *unfixable* findings are neither printed nor counted:
+
+- `1` &mdash; at least one file would change.
+- `0` &mdash; no file would change.
+- `2` &mdash; CLI usage error.
+
+A file that cannot be parsed (or a symlink) is skipped with a notice on
+stderr and does not affect the exit code. For embedded YAML in Markdown,
+the diff is reported at the host-file level (one diff per `.md`).
 
 ## Configure for your project
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -104,8 +104,11 @@ remaining *unfixable* findings are neither printed nor counted:
 - `2` &mdash; CLI usage error.
 
 A file that cannot be parsed (or a symlink) is skipped with a notice on
-stderr and does not affect the exit code. For embedded YAML in Markdown,
-the diff is reported at the host-file level (one diff per `.md`).
+stderr and does not affect the exit code. A non-UTF-8 or BOM-prefixed file
+is also skipped: a textual diff of its decoded content could not be applied
+back to the original bytes, so use `--fix` (which preserves the encoding)
+for those. For embedded YAML in Markdown, the diff is reported at the
+host-file level (one diff per `.md`).
 
 ## Configure for your project
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -162,6 +162,11 @@ where content lines are indented less than the fence, or other non-uniform layou
 `--fix` can never corrupt a Markdown document: the worst case is that an unusual
 region is reported but not auto-fixed.
 
+`--diff` previews these same fixes without writing: it emits one unified diff per
+Markdown file (at the host-file level, with the embedded edits shown in context)
+and exits `1` if any file would change. A region `--fix` would leave untouched
+(ragged, or one that does not parse) likewise produces no diff.
+
 ## Linting Markdown from stdin and the CLI
 
 Markdown linting is normally enabled by listing `[files].markdown` globs, but it can
@@ -177,7 +182,8 @@ also be turned on for a single run from the command line:
   doc.md` lints the piped bytes as Markdown when `doc.md` matches the `markdown`
   globs (front matter and fenced blocks are extracted exactly as for a file on
   disk). Without `--stdin-filename` and without `--markdown`, stdin is linted as
-  plain YAML. As with files, `--fix` is not supported when reading from stdin.
+  plain YAML. As with files, `--fix` is not supported when reading from stdin
+  (use `--diff` to preview fixes for piped Markdown instead).
 
 ## Use with pre-commit
 

--- a/src/cli_support.rs
+++ b/src/cli_support.rs
@@ -31,6 +31,35 @@ pub fn sanitize_control(text: &str) -> Cow<'_, str> {
     Cow::Owned(out)
 }
 
+/// Absolute, lexically-normalized form of `path`: `std::path::absolute` makes it
+/// absolute and drops `.`, then `..` components are collapsed (`a/../b` -> `b`). Purely
+/// lexical — symlinks are **not** resolved, so a symlink stays distinct from its target
+/// (matching ruff, and preserving ryl's `--fix`/`--diff` symlink skip). Used both as the
+/// input de-dup identity (`gather_lint_files`) and as the basis for a `git apply -p0`-able
+/// `--diff` header path.
+///
+/// # Panics
+///
+/// Panics if `path` is empty (`std::path::absolute` rejects it). Callers pass
+/// source-kind-matched file paths or the stdin label, all non-empty, so this does not
+/// arise in practice.
+#[must_use]
+pub fn lexical_abspath(path: &Path) -> PathBuf {
+    let absolute =
+        std::path::absolute(path).expect("a non-empty input path is absolutizable");
+    let mut out = PathBuf::new();
+    for component in absolute.components() {
+        if component == std::path::Component::ParentDir {
+            // `absolute` rooted the path, so `pop` removes the previous component or is
+            // a harmless no-op at the root (`/..` == `/`).
+            out.pop();
+        } else {
+            out.push(component.as_os_str());
+        }
+    }
+    out
+}
+
 /// Resolve the configuration context for a given file path, optionally using a cached
 /// global configuration.
 ///

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -92,6 +92,16 @@ impl DecodedFile {
         self.content
     }
 
+    /// True when the file is UTF-8 without a BOM, i.e. the UTF-8 bytes of
+    /// [`content`](Self::content) equal the original on-disk bytes. Only then can a
+    /// textual unified diff of the decoded content be applied back to the file; any
+    /// BOM or non-UTF-8 encoding is transcoded on decode, so `--diff` skips it (a
+    /// `git apply`/hk consumer could not apply the patch to the original bytes).
+    #[must_use]
+    pub(crate) fn is_plain_utf8(&self) -> bool {
+        self.encoding == FileEncoding::Utf8
+    }
+
     pub(crate) fn write(&self, path: &Path, content: &str) -> Result<(), String> {
         std::fs::write(path, self.encoding.encode(content)).map_err(|err| {
             format!("failed to write fixed file {}: {err}", path.display())

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -231,17 +231,26 @@ impl DiffStats {
 /// Render a unified diff from `original` and `fixed`, or `None` when they are
 /// identical. The format follows `ruff check --diff`: 3 lines of context (also
 /// `similar`'s default, pinned here so a crate upgrade can't silently change it) and a
-/// plain `--- path` / `+++ path` header — no git `a/`/`b/` prefixes or path quoting.
-/// The header path is sanitized so a control char in a crafted filename cannot inject
-/// terminal escapes or forge a hunk header; the diff *body* is emitted verbatim so a
-/// consumer such as hk can re-apply the content unchanged (which, like `git diff`,
-/// means the raw bytes — including any control chars already present in the file).
+/// plain `--- path` / `+++ path` header (no git `a/`/`b/` prefixes). Like ruff, an
+/// absolute path under the current directory is relativized so the patch applies from
+/// the repo root (`git apply -p0` / hk) instead of failing on an absolute header; a
+/// relative or out-of-tree path is left as given. The header path is sanitized so a
+/// crafted filename cannot inject terminal escapes or forge a hunk header; the diff
+/// *body* is emitted verbatim so a consumer can re-apply the content unchanged (which,
+/// like `git diff`, means the raw bytes — including any control chars already present).
 fn render_unified_diff(original: &str, fixed: &str, path: &Path) -> Option<String> {
     if original == fixed {
         return None;
     }
-    let label =
-        crate::cli_support::sanitize_control(&path.display().to_string()).into_owned();
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let display = path.strip_prefix(&cwd).unwrap_or(path);
+    let label = crate::cli_support::sanitize_control(&display.display().to_string())
+        .into_owned();
+    // git/patch headers use forward slashes; on Windows the path uses `\`, so normalize
+    // it (Unix leaves `\` alone — there it is a valid filename character, not a
+    // separator).
+    #[cfg(windows)]
+    let label = label.replace('\\', "/");
     Some(
         TextDiff::from_lines(original, fixed)
             .unified_diff()

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -231,19 +231,20 @@ impl DiffStats {
 /// Render a unified diff from `original` and `fixed`, or `None` when they are
 /// identical. The format follows `ruff check --diff`: 3 lines of context (also
 /// `similar`'s default, pinned here so a crate upgrade can't silently change it) and a
-/// plain `--- path` / `+++ path` header (no git `a/`/`b/` prefixes). Like ruff, an
-/// absolute path under the current directory is relativized so the patch applies from
-/// the repo root (`git apply -p0` / hk) instead of failing on an absolute header; a
-/// relative or out-of-tree path is left as given. The header path is sanitized so a
-/// crafted filename cannot inject terminal escapes or forge a hunk header; the diff
-/// *body* is emitted verbatim so a consumer can re-apply the content unchanged (which,
-/// like `git diff`, means the raw bytes — including any control chars already present).
+/// plain `--- path` / `+++ path` header (no git `a/`/`b/` prefixes). The header path is
+/// `lexical_abspath`-normalized (so `./f`/`sub/../f` become a clean `f`) and relativized
+/// to CWD — like ruff, an absolute path under CWD becomes relative, an out-of-tree one
+/// stays absolute — so the patch applies with `git apply -p0` / hk rather than failing
+/// on a `.`/`..`/absolute header. The path is sanitized so a crafted filename can't
+/// inject terminal escapes or forge a hunk header; the diff *body* is emitted verbatim
+/// so a consumer can re-apply the content unchanged (like `git diff`, the raw bytes).
 fn render_unified_diff(original: &str, fixed: &str, path: &Path) -> Option<String> {
     if original == fixed {
         return None;
     }
+    let abspath = crate::cli_support::lexical_abspath(path);
     let cwd = std::env::current_dir().unwrap_or_default();
-    let display = path.strip_prefix(&cwd).unwrap_or(path);
+    let display = abspath.strip_prefix(&cwd).unwrap_or(&abspath);
     let label = crate::cli_support::sanitize_control(&display.display().to_string())
         .into_owned();
     // git/patch headers use forward slashes; on Windows the path uses `\`, so normalize
@@ -322,14 +323,14 @@ pub fn non_utf8_diff_skip() -> crate::lint::LintProblem {
     diff_skip("non-UTF-8 or BOM content has no applicable text diff; use --fix")
 }
 
-/// Whether the path contains a control character. Such a name cannot appear in a
-/// unified-diff header: emitting it raw would corrupt the `---`/`+++` line (or inject),
-/// and the sanitized form no longer matches the on-disk file, so no consumer could apply
-/// the patch. `--diff` skips these like the non-UTF-8 case.
-fn path_has_control_char(path: &Path) -> bool {
-    path.as_os_str()
-        .to_string_lossy()
-        .contains(char::is_control)
+/// Whether the path can't be faithfully written in a unified-diff header — it is not
+/// valid UTF-8, or it contains a control character. Either way the header would name a
+/// different path than the on-disk file (non-UTF-8 bytes become `�`; a raw control char
+/// corrupts the `---`/`+++` line or is sanitized away), so no consumer could apply the
+/// patch. `--diff` skips these, like the non-UTF-8-*content* case.
+fn path_unrepresentable_in_diff(path: &Path) -> bool {
+    let name = path.as_os_str();
+    name.to_str().is_none() || name.to_string_lossy().contains(char::is_control)
 }
 
 /// Compute unified diffs for the safe fixes of each file, reading from disk. Never
@@ -347,10 +348,13 @@ pub fn diff_safe_fixes_for_files(
         if refuse_symlink(path, "--diff") {
             continue;
         }
-        if path_has_control_char(path) {
+        if path_unrepresentable_in_diff(path) {
             stats.skipped.push((
                 path.clone(),
-                diff_skip("filename has control characters; no applicable diff path"),
+                diff_skip(
+                    "filename has non-UTF-8 bytes or control characters; no applicable \
+                     diff path",
+                ),
             ));
             continue;
         }

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -264,7 +264,9 @@ fn render_unified_diff(original: &str, fixed: &str, path: &Path) -> Option<Strin
 /// Compute the `--diff` outcome for in-memory `content` (shared by the file and stdin
 /// paths). Mirrors the in-place fixers' gating: an unparsable plain YAML file yields
 /// no diff and one skip so the CLI can tell the user why; a Markdown file diffs at the
-/// host level via [`fix_markdown_str`] and reports each region that does not parse.
+/// host level via [`fix_markdown_str`] and reports each region that does not parse. A
+/// path (or `--stdin-filename` label) that can't be written in a diff header is skipped
+/// here, so the file and stdin paths share the guard.
 #[must_use]
 pub fn diff_outcome(
     content: &str,
@@ -273,6 +275,15 @@ pub fn diff_outcome(
     base_dir: &Path,
     kind: SourceKind,
 ) -> DiffOutcome {
+    if path_unrepresentable_in_diff(path) {
+        return DiffOutcome {
+            diff: None,
+            skipped: vec![diff_skip(
+                "filename has non-UTF-8 bytes or control characters; no applicable \
+                 diff path",
+            )],
+        };
+    }
     match kind {
         SourceKind::Yaml => {
             if let Some(problem) = crate::lint::parse_error(content) {
@@ -334,8 +345,9 @@ fn path_unrepresentable_in_diff(path: &Path) -> bool {
 }
 
 /// Compute unified diffs for the safe fixes of each file, reading from disk. Never
-/// writes; an input is skipped (with a notice) when it can't yield an applicable diff:
-/// a symlink (parity with `--fix`), a non-UTF-8/BOM file, or a name with control chars.
+/// writes; a symlinked input is skipped with a warning (parity with `--fix`). Other
+/// un-diffable inputs (non-UTF-8/BOM content, an unparsable file, or a name that can't
+/// appear in a header) are skipped with a notice via [`diff_outcome`].
 ///
 /// # Errors
 ///
@@ -346,16 +358,6 @@ pub fn diff_safe_fixes_for_files(
     let mut stats = DiffStats::default();
     for (path, base_dir, cfg, kind) in files {
         if refuse_symlink(path, "--diff") {
-            continue;
-        }
-        if path_unrepresentable_in_diff(path) {
-            stats.skipped.push((
-                path.clone(),
-                diff_skip(
-                    "filename has non-UTF-8 bytes or control characters; no applicable \
-                     diff path",
-                ),
-            ));
             continue;
         }
         let decoded = decoder::read_file_lossless(path)?;

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -291,9 +291,26 @@ pub fn diff_outcome(
     }
 }
 
+/// The skip a non-UTF-8 (or BOM) input gets under `--diff`: a textual unified diff of
+/// the decoded content cannot be applied back to the BOM'd/transcoded on-disk bytes,
+/// and a text diff has no way to round-trip the original encoding the way `--fix`'s
+/// re-encode does — so `--diff` skips it with a notice pointing at `--fix`. Shared by
+/// the file path and the stdin path (`main::run_stdin_diff`).
+#[must_use]
+pub fn non_utf8_diff_skip() -> crate::lint::LintProblem {
+    crate::lint::LintProblem {
+        line: 1,
+        column: 1,
+        level: crate::lint::Severity::Error,
+        message: "non-UTF-8 or BOM content has no applicable text diff; use --fix"
+            .to_string(),
+        rule: None,
+    }
+}
+
 /// Compute unified diffs for the safe fixes of each file, reading from disk. Never
 /// writes; a symlinked input is skipped with a warning (parity with `--fix`, whose
-/// preview this is).
+/// preview this is), and a non-UTF-8/BOM input is skipped (see [`non_utf8_diff_skip`]).
 ///
 /// # Errors
 ///
@@ -307,6 +324,10 @@ pub fn diff_safe_fixes_for_files(
             continue;
         }
         let decoded = decoder::read_file_lossless(path)?;
+        if !decoded.is_plain_utf8() {
+            stats.skipped.push((path.clone(), non_utf8_diff_skip()));
+            continue;
+        }
         let outcome = diff_outcome(decoded.content(), cfg, path, base_dir, *kind);
         stats.record(path, outcome);
     }

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -300,26 +300,41 @@ pub fn diff_outcome(
     }
 }
 
-/// The skip a non-UTF-8 (or BOM) input gets under `--diff`: a textual unified diff of
-/// the decoded content cannot be applied back to the BOM'd/transcoded on-disk bytes,
-/// and a text diff has no way to round-trip the original encoding the way `--fix`'s
-/// re-encode does — so `--diff` skips it with a notice pointing at `--fix`. Shared by
-/// the file path and the stdin path (`main::run_stdin_diff`).
+/// A `--diff` skip notice (`<path>:1:1 skipped by --diff: <message>`) for an input that
+/// cannot produce an applicable diff.
 #[must_use]
-pub fn non_utf8_diff_skip() -> crate::lint::LintProblem {
+fn diff_skip(message: &str) -> crate::lint::LintProblem {
     crate::lint::LintProblem {
         line: 1,
         column: 1,
         level: crate::lint::Severity::Error,
-        message: "non-UTF-8 or BOM content has no applicable text diff; use --fix"
-            .to_string(),
+        message: message.to_string(),
         rule: None,
     }
 }
 
+/// The skip a non-UTF-8 (or BOM) input gets under `--diff`: a textual unified diff of the
+/// decoded content cannot be applied back to the BOM'd/transcoded on-disk bytes, and a
+/// text diff cannot round-trip the original encoding the way `--fix`'s re-encode does.
+/// Shared by the file path and the stdin path (`main::run_stdin_diff`).
+#[must_use]
+pub fn non_utf8_diff_skip() -> crate::lint::LintProblem {
+    diff_skip("non-UTF-8 or BOM content has no applicable text diff; use --fix")
+}
+
+/// Whether the path contains a control character. Such a name cannot appear in a
+/// unified-diff header: emitting it raw would corrupt the `---`/`+++` line (or inject),
+/// and the sanitized form no longer matches the on-disk file, so no consumer could apply
+/// the patch. `--diff` skips these like the non-UTF-8 case.
+fn path_has_control_char(path: &Path) -> bool {
+    path.as_os_str()
+        .to_string_lossy()
+        .contains(char::is_control)
+}
+
 /// Compute unified diffs for the safe fixes of each file, reading from disk. Never
-/// writes; a symlinked input is skipped with a warning (parity with `--fix`, whose
-/// preview this is), and a non-UTF-8/BOM input is skipped (see [`non_utf8_diff_skip`]).
+/// writes; an input is skipped (with a notice) when it can't yield an applicable diff:
+/// a symlink (parity with `--fix`), a non-UTF-8/BOM file, or a name with control chars.
 ///
 /// # Errors
 ///
@@ -330,6 +345,13 @@ pub fn diff_safe_fixes_for_files(
     let mut stats = DiffStats::default();
     for (path, base_dir, cfg, kind) in files {
         if refuse_symlink(path, "--diff") {
+            continue;
+        }
+        if path_has_control_char(path) {
+            stats.skipped.push((
+                path.clone(),
+                diff_skip("filename has control characters; no applicable diff path"),
+            ));
             continue;
         }
         let decoded = decoder::read_file_lossless(path)?;

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use similar::TextDiff;
+
 use crate::config::{SourceKind, YamlLintConfig};
 use crate::decoder;
 use crate::directives::Directives;
@@ -114,7 +116,9 @@ pub struct FixOutcome {
 /// it (e.g. `innocent.yaml -> ~/.bashrc`). Skip a symlinked input with a warning —
 /// consistent with the directory walker's `follow_links(false)`, which is the path
 /// by which untrusted trees are scanned. Linting (read-only) through symlinks is
-/// unaffected.
+/// unaffected. `--diff` skips symlinks too (`flag` distinguishes the message): it is
+/// a preview of `--fix`, so it must report the same skip rather than diffing a file
+/// `--fix` would never touch.
 ///
 /// This checks only the final path component (`symlink_metadata` resolves parent
 /// components), and the check is not atomic with the later write. It is therefore
@@ -122,10 +126,10 @@ pub struct FixOutcome {
 /// parent directory, or an attacker who swaps the file for a symlink between this
 /// check and the write (TOCTOU), is not covered. A complete defense would need
 /// `openat`/`O_NOFOLLOW`, which is not portable here.
-fn refuse_symlink(path: &Path) -> bool {
+fn refuse_symlink(path: &Path, flag: &str) -> bool {
     if std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
         eprintln!(
-            "skipping {}: refusing to apply --fix through a symlink",
+            "skipping {}: refusing to follow a symlink for {flag}",
             crate::cli_support::sanitize_control(&path.display().to_string())
         );
         return true;
@@ -143,7 +147,7 @@ pub fn apply_safe_fixes_in_place(
     cfg: &YamlLintConfig,
     base_dir: &Path,
 ) -> Result<FixOutcome, String> {
-    if refuse_symlink(path) {
+    if refuse_symlink(path, "--fix") {
         return Ok(FixOutcome::default());
     }
     let decoded = decoder::read_file_lossless(path)?;
@@ -191,6 +195,124 @@ pub fn apply_safe_fixes_to_files(
     Ok(stats)
 }
 
+/// A single file's `--diff` result: the unified diff (`None` when the safe fixes
+/// would change nothing) plus any parse-skips — a plain YAML file contributes at most
+/// one (its whole-file parse error); a Markdown file one per region that does not
+/// parse — reported like [`FixStats::skipped`].
+#[derive(Debug, Default)]
+pub struct DiffOutcome {
+    pub diff: Option<String>,
+    pub skipped: Vec<crate::lint::LintProblem>,
+}
+
+/// Aggregated `--diff` results across all linted files.
+#[derive(Debug, Default)]
+pub struct DiffStats {
+    /// Unified diffs for files that would change, in input order.
+    pub diffs: Vec<String>,
+    /// Files left unchanged because they (or, for Markdown, a region) do not parse.
+    pub skipped: Vec<(PathBuf, crate::lint::LintProblem)>,
+}
+
+impl DiffStats {
+    /// Fold one file's outcome into the aggregate: record its diff (if any) and tag
+    /// each parse-skip with the file path. Shared by the file-walk and stdin paths so
+    /// the diff-vs-skip routing lives in one place.
+    pub fn record(&mut self, path: &Path, outcome: DiffOutcome) {
+        if let Some(diff) = outcome.diff {
+            self.diffs.push(diff);
+        }
+        for problem in outcome.skipped {
+            self.skipped.push((path.to_path_buf(), problem));
+        }
+    }
+}
+
+/// Render a unified diff from `original` and `fixed`, or `None` when they are
+/// identical. The format follows `ruff check --diff`: 3 lines of context (also
+/// `similar`'s default, pinned here so a crate upgrade can't silently change it) and a
+/// plain `--- path` / `+++ path` header — no git `a/`/`b/` prefixes or path quoting.
+/// The header path is sanitized so a control char in a crafted filename cannot inject
+/// terminal escapes or forge a hunk header; the diff *body* is emitted verbatim so a
+/// consumer such as hk can re-apply the content unchanged (which, like `git diff`,
+/// means the raw bytes — including any control chars already present in the file).
+fn render_unified_diff(original: &str, fixed: &str, path: &Path) -> Option<String> {
+    if original == fixed {
+        return None;
+    }
+    let label =
+        crate::cli_support::sanitize_control(&path.display().to_string()).into_owned();
+    Some(
+        TextDiff::from_lines(original, fixed)
+            .unified_diff()
+            .context_radius(3)
+            .header(&label, &label)
+            .to_string(),
+    )
+}
+
+/// Compute the `--diff` outcome for in-memory `content` (shared by the file and stdin
+/// paths). Mirrors the in-place fixers' gating: an unparsable plain YAML file yields
+/// no diff and one skip so the CLI can tell the user why; a Markdown file diffs at the
+/// host level via [`fix_markdown_str`] and reports each region that does not parse.
+#[must_use]
+pub fn diff_outcome(
+    content: &str,
+    cfg: &YamlLintConfig,
+    path: &Path,
+    base_dir: &Path,
+    kind: SourceKind,
+) -> DiffOutcome {
+    match kind {
+        SourceKind::Yaml => {
+            if let Some(problem) = crate::lint::parse_error(content) {
+                return DiffOutcome {
+                    diff: None,
+                    skipped: vec![problem],
+                };
+            }
+            let fixed = apply_safe_fixes(content, cfg, path, base_dir);
+            DiffOutcome {
+                diff: render_unified_diff(content, &fixed, path),
+                skipped: Vec::new(),
+            }
+        }
+        SourceKind::Markdown => {
+            let fixed = fix_markdown_str(content, path, cfg, base_dir);
+            // Skips are reported against the *original* content, not `fixed`: unlike
+            // the in-place path (which writes `fixed`, so its skip line numbers must
+            // match the post-fix file), `--diff` never writes, so the file on disk
+            // stays `content` and a skip notice must point at the original line.
+            let skipped = crate::markdown_embed::markdown_parse_skips(content, cfg);
+            let diff =
+                fixed.and_then(|fixed| render_unified_diff(content, &fixed, path));
+            DiffOutcome { diff, skipped }
+        }
+    }
+}
+
+/// Compute unified diffs for the safe fixes of each file, reading from disk. Never
+/// writes; a symlinked input is skipped with a warning (parity with `--fix`, whose
+/// preview this is).
+///
+/// # Errors
+///
+/// Returns an error if any file cannot be read.
+pub fn diff_safe_fixes_for_files(
+    files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
+) -> Result<DiffStats, String> {
+    let mut stats = DiffStats::default();
+    for (path, base_dir, cfg, kind) in files {
+        if refuse_symlink(path, "--diff") {
+            continue;
+        }
+        let decoded = decoder::read_file_lossless(path)?;
+        let outcome = diff_outcome(decoded.content(), cfg, path, base_dir, *kind);
+        stats.record(path, outcome);
+    }
+    Ok(stats)
+}
+
 /// Apply safe fixes to every embedded YAML region of a markdown file in place.
 ///
 /// # Errors
@@ -202,7 +324,7 @@ pub fn apply_markdown_safe_fixes_in_place(
     cfg: &YamlLintConfig,
     base_dir: &Path,
 ) -> Result<FixOutcome, String> {
-    if refuse_symlink(path) {
+    if refuse_symlink(path, "--fix") {
         return Ok(FixOutcome::default());
     }
     let decoded = decoder::read_file_lossless(path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::process::ExitCode;
 use clap::{Parser, ValueEnum};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
-use ryl::cli_support::{resolve_ctx, sanitize_control};
+use ryl::cli_support::{lexical_abspath, resolve_ctx, sanitize_control};
 use ryl::config::{
     ConfigContext, Overrides, SourceKind, YamlLintConfig, discover_config,
 };
@@ -713,38 +713,6 @@ fn lint_files(
     results
 }
 
-/// Identity used to de-duplicate inputs so a file reached by two spellings is linted
-/// once — e.g. `ryl . f.yaml` (walk `./f.yaml` + explicit `f.yaml`), `ryl f.yaml f.yaml`,
-/// or `ryl f.yaml sub/../f.yaml`. `absolute` makes the path absolute and drops `.`;
-/// [`lexically_normalize`] then collapses `..`. Both are purely lexical — symlinks are
-/// **not** resolved, so a symlink and its target keep distinct identities (preserving
-/// the `--fix`/`--diff` symlink skip). It is only called on source-kind-matched (hence
-/// non-empty) paths, so `absolute` cannot fail here.
-fn canonical_input(path: &Path) -> PathBuf {
-    let absolute = std::path::absolute(path)
-        .expect("a source-kind-matched input path is absolutizable");
-    lexically_normalize(&absolute)
-}
-
-/// Collapse `..` components lexically (without touching the filesystem): a `..` after a
-/// normal component pops it (`a/../b` -> `b`), matching how ruff treats `dir/../file` as
-/// the same input. Symlinks are not resolved — a `..` after a *symlinked* directory is
-/// the rare case this over-collapses, but resolving symlinks (`canonicalize`) would
-/// instead merge a symlink with its target and break the `--fix`/`--diff` skip.
-fn lexically_normalize(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        if component == std::path::Component::ParentDir {
-            // `canonical_input` always passes an absolute path, so `pop` removes the
-            // previous component or is a harmless no-op at the root (`/..` == `/`).
-            out.pop();
-        } else {
-            out.push(component.as_os_str());
-        }
-    }
-    out
-}
-
 #[allow(clippy::too_many_arguments)]
 fn gather_lint_files(
     candidates: &[PathBuf],
@@ -777,7 +745,7 @@ fn gather_lint_files(
             continue;
         }
         if let Some(kind) = cfg.source_kind(f, &base_dir)? {
-            if !seen.insert(canonical_input(f)) {
+            if !seen.insert(lexical_abspath(f)) {
                 continue;
             }
             if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
@@ -800,7 +768,7 @@ fn gather_lint_files(
         }
         match cfg.source_kind(ef, &base_dir)? {
             Some(kind) => {
-                if !seen.insert(canonical_input(ef)) {
+                if !seen.insert(lexical_abspath(ef)) {
                     continue;
                 }
                 if !cfg.enables_any_rule() && ruleless_config_found.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ use ryl::config::{
 };
 use ryl::config_schema::{schema_string_pretty, yaml_schema_string_pretty};
 use ryl::decoder;
-use ryl::fix::apply_safe_fixes_to_files;
+use ryl::fix::{
+    DiffStats, apply_safe_fixes_to_files, diff_outcome, diff_safe_fixes_for_files,
+};
 use ryl::migrate::{
     MigrateOptions, OutputMode as MigrateOutputMode, SourceCleanup, WriteMode,
     migrate_configs,
@@ -235,6 +237,11 @@ struct FixFlags {
     /// Apply safe fixes in place before reporting remaining diagnostics
     #[arg(long = "fix", default_value_t = false)]
     fix: bool,
+
+    /// Print a unified diff of the safe fixes to stdout instead of writing them;
+    /// never modifies files and exits 1 if any file would change
+    #[arg(long = "diff", default_value_t = false, conflicts_with = "fix")]
+    diff: bool,
 }
 
 #[derive(clap::Args, Debug, Default)]
@@ -451,24 +458,15 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         return Err(no_rules_error(config_found));
     }
 
-    let mut initial_problem_count = 0usize;
-    if cli.lint.fix.fix {
-        let initial_results = lint_files(&files);
-        initial_problem_count = count_reported_problems(
-            &initial_results,
-            cli.lint.compatibility.no_warnings,
-        );
-        let fix_stats = apply_safe_fixes_to_files(&files)?;
-        for (path, problem) in &fix_stats.skipped {
-            eprintln!(
-                "{}:{}:{} skipped by --fix: {}",
-                sanitize_control(&path.display().to_string()),
-                problem.line,
-                problem.column,
-                sanitize_control(&problem.message),
-            );
-        }
+    if cli.lint.fix.diff {
+        return Ok(emit_diff(&diff_safe_fixes_for_files(&files)?));
     }
+
+    let initial_problem_count = if cli.lint.fix.fix {
+        apply_fixes_reporting_skips(&files, cli.lint.compatibility.no_warnings)?
+    } else {
+        0
+    };
 
     let results = lint_files(&files);
 
@@ -491,6 +489,31 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
     }
 
     Ok(summary_to_exit(&summary, cli.lint.compatibility.strict))
+}
+
+/// Run the initial lint, apply safe fixes in place, and report any files skipped
+/// because they do not parse. Returns the pre-fix problem count for the fix summary.
+///
+/// # Errors
+///
+/// Returns an error if any file cannot be read or written.
+fn apply_fixes_reporting_skips(
+    files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
+    no_warnings: bool,
+) -> Result<usize, String> {
+    let initial_problem_count =
+        count_reported_problems(&lint_files(files), no_warnings);
+    let fix_stats = apply_safe_fixes_to_files(files)?;
+    for (path, problem) in &fix_stats.skipped {
+        eprintln!(
+            "{}:{}:{} skipped by --fix: {}",
+            sanitize_control(&path.display().to_string()),
+            problem.line,
+            problem.column,
+            sanitize_control(&problem.message),
+        );
+    }
+    Ok(initial_problem_count)
 }
 
 fn summary_to_exit(summary: &LintSummary, strict: bool) -> ExitCode {
@@ -518,6 +541,10 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
 
     if !cfg.enables_any_rule() {
         return Err(no_rules_error(config_found));
+    }
+
+    if cli.lint.fix.diff {
+        return run_stdin_diff(&path, &base_dir, &cfg, kind);
     }
 
     let outcome = read_and_lint_stdin(&path, &base_dir, &cfg, kind);
@@ -567,22 +594,67 @@ fn resolve_stdin_kind(
     }
 }
 
+fn read_stdin_decoded(path: &Path) -> Result<String, String> {
+    let mut buf = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut buf)
+        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    decoder::decode_bytes(&buf)
+        .map_err(|err| format!("failed to read {}: {err}", path.display()))
+}
+
 fn read_and_lint_stdin(
     path: &Path,
     base_dir: &Path,
     cfg: &YamlLintConfig,
     kind: SourceKind,
 ) -> Result<Vec<LintProblem>, String> {
-    let mut buf = Vec::new();
-    std::io::stdin()
-        .read_to_end(&mut buf)
-        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-    let content = decoder::decode_bytes(&buf)
-        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    let content = read_stdin_decoded(path)?;
     Ok(match kind {
         SourceKind::Markdown => lint_markdown_str(&content, path, cfg, base_dir),
         SourceKind::Yaml => lint_str(&content, path, cfg, base_dir),
     })
+}
+
+fn run_stdin_diff(
+    path: &Path,
+    base_dir: &Path,
+    cfg: &YamlLintConfig,
+    kind: SourceKind,
+) -> Result<ExitCode, String> {
+    let content = read_stdin_decoded(path)?;
+    let outcome = diff_outcome(&content, cfg, path, base_dir, kind);
+    let mut stats = DiffStats::default();
+    stats.record(path, outcome);
+    Ok(emit_diff(&stats))
+}
+
+/// Write per-file unified diffs to stdout and parse-skip notices to stderr, returning
+/// the `--diff` exit code: `1` if any file would change, else `0`. Mirrors
+/// `ruff check --diff` — only the diff drives the exit code; remaining (unfixable)
+/// diagnostics are neither printed nor counted here.
+fn emit_diff(stats: &DiffStats) -> ExitCode {
+    for (path, problem) in &stats.skipped {
+        eprintln!(
+            "{}:{}:{} skipped by --diff: {}",
+            sanitize_control(&path.display().to_string()),
+            problem.line,
+            problem.column,
+            sanitize_control(&problem.message),
+        );
+    }
+    // Each diff already carries the trailing newline similar emits, so concatenating
+    // and printing once keeps stdout a clean sequence of `--- / +++ / @@` blocks.
+    let mut rendered = String::new();
+    for diff in &stats.diffs {
+        rendered.push_str(diff);
+    }
+    print!("{rendered}");
+    if stats.diffs.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
 }
 
 fn resolve_stdin_ctx(
@@ -629,6 +701,18 @@ fn lint_files(
     results
 }
 
+/// Identity used to de-duplicate inputs so a file reached by two spellings is linted
+/// once — e.g. `ryl . f.yaml` lists `f.yaml` via both the directory walk (`./f.yaml`)
+/// and the explicit arg (`f.yaml`), and `ryl f.yaml f.yaml` lists it twice. `absolute`
+/// normalizes `.`/relative segments lexically *without* resolving symlinks (so a
+/// symlink and its target stay distinct, preserving the `--fix`/`--diff` symlink skip)
+/// and without requiring the path to exist. It is only called on paths that already
+/// matched a source kind, which are non-empty, so `absolute` cannot fail here.
+fn canonical_input(path: &Path) -> PathBuf {
+    std::path::absolute(path)
+        .expect("a source-kind-matched input path is absolutizable")
+}
+
 #[allow(clippy::too_many_arguments)]
 fn gather_lint_files(
     candidates: &[PathBuf],
@@ -644,6 +728,11 @@ fn gather_lint_files(
     // found" vs "config enables no rules" — even when other files did find a config.
     // `None` means every selected file enables at least one rule.
     let mut ruleless_config_found = None;
+    // De-duplicate selected files across the walk and explicit args; without this a
+    // file listed twice is linted twice (and `--diff` would emit a duplicate patch
+    // block that fails to apply on the second copy). Unlike yamllint, which keeps
+    // duplicates.
+    let mut seen: HashSet<PathBuf> = HashSet::new();
     for f in candidates {
         let (base_dir, cfg, notices, found) =
             resolve_ctx(f, global_cfg, markdown, cache)?;
@@ -656,6 +745,9 @@ fn gather_lint_files(
             continue;
         }
         if let Some(kind) = cfg.source_kind(f, &base_dir)? {
+            if !seen.insert(canonical_input(f)) {
+                continue;
+            }
             if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
                 ruleless_config_found = Some(found);
             }
@@ -676,6 +768,9 @@ fn gather_lint_files(
         }
         match cfg.source_kind(ef, &base_dir)? {
             Some(kind) => {
+                if !seen.insert(canonical_input(ef)) {
+                    continue;
+                }
                 if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
                     ruleless_config_found = Some(found);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -714,15 +714,35 @@ fn lint_files(
 }
 
 /// Identity used to de-duplicate inputs so a file reached by two spellings is linted
-/// once — e.g. `ryl . f.yaml` lists `f.yaml` via both the directory walk (`./f.yaml`)
-/// and the explicit arg (`f.yaml`), and `ryl f.yaml f.yaml` lists it twice. `absolute`
-/// normalizes `.`/relative segments lexically *without* resolving symlinks (so a
-/// symlink and its target stay distinct, preserving the `--fix`/`--diff` symlink skip)
-/// and without requiring the path to exist. It is only called on paths that already
-/// matched a source kind, which are non-empty, so `absolute` cannot fail here.
+/// once — e.g. `ryl . f.yaml` (walk `./f.yaml` + explicit `f.yaml`), `ryl f.yaml f.yaml`,
+/// or `ryl f.yaml sub/../f.yaml`. `absolute` makes the path absolute and drops `.`;
+/// [`lexically_normalize`] then collapses `..`. Both are purely lexical — symlinks are
+/// **not** resolved, so a symlink and its target keep distinct identities (preserving
+/// the `--fix`/`--diff` symlink skip). It is only called on source-kind-matched (hence
+/// non-empty) paths, so `absolute` cannot fail here.
 fn canonical_input(path: &Path) -> PathBuf {
-    std::path::absolute(path)
-        .expect("a source-kind-matched input path is absolutizable")
+    let absolute = std::path::absolute(path)
+        .expect("a source-kind-matched input path is absolutizable");
+    lexically_normalize(&absolute)
+}
+
+/// Collapse `..` components lexically (without touching the filesystem): a `..` after a
+/// normal component pops it (`a/../b` -> `b`), matching how ruff treats `dir/../file` as
+/// the same input. Symlinks are not resolved — a `..` after a *symlinked* directory is
+/// the rare case this over-collapses, but resolving symlinks (`canonicalize`) would
+/// instead merge a symlink with its target and break the `--fix`/`--diff` skip.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        if component == std::path::Component::ParentDir {
+            // `canonical_input` always passes an absolute path, so `pop` removes the
+            // previous component or is a harmless no-op at the root (`/..` == `/`).
+            out.pop();
+        } else {
+            out.push(component.as_os_str());
+        }
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,13 +594,18 @@ fn resolve_stdin_kind(
     }
 }
 
-fn read_stdin_decoded(path: &Path) -> Result<String, String> {
+/// Read and decode stdin. The bool is whether the bytes were plain UTF-8 (no BOM, no
+/// transcode), i.e. whether a textual `--diff` of the decoded content would apply back
+/// to the original bytes; `read_and_lint_stdin` ignores it.
+fn read_stdin_decoded(path: &Path) -> Result<(String, bool), String> {
     let mut buf = Vec::new();
     std::io::stdin()
         .read_to_end(&mut buf)
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-    decoder::decode_bytes(&buf)
-        .map_err(|err| format!("failed to read {}: {err}", path.display()))
+    let content = decoder::decode_bytes(&buf)
+        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    let plain_utf8 = content.as_bytes() == buf.as_slice();
+    Ok((content, plain_utf8))
 }
 
 fn read_and_lint_stdin(
@@ -609,7 +614,7 @@ fn read_and_lint_stdin(
     cfg: &YamlLintConfig,
     kind: SourceKind,
 ) -> Result<Vec<LintProblem>, String> {
-    let content = read_stdin_decoded(path)?;
+    let (content, _) = read_stdin_decoded(path)?;
     Ok(match kind {
         SourceKind::Markdown => lint_markdown_str(&content, path, cfg, base_dir),
         SourceKind::Yaml => lint_str(&content, path, cfg, base_dir),
@@ -622,10 +627,17 @@ fn run_stdin_diff(
     cfg: &YamlLintConfig,
     kind: SourceKind,
 ) -> Result<ExitCode, String> {
-    let content = read_stdin_decoded(path)?;
-    let outcome = diff_outcome(&content, cfg, path, base_dir, kind);
+    let (content, plain_utf8) = read_stdin_decoded(path)?;
     let mut stats = DiffStats::default();
-    stats.record(path, outcome);
+    if plain_utf8 {
+        stats.record(path, diff_outcome(&content, cfg, path, base_dir, kind));
+    } else {
+        // Same reason as the file path: the decoded-UTF-8 diff would not apply to the
+        // BOM'd/transcoded source, so skip rather than emit a patch that won't apply.
+        stats
+            .skipped
+            .push((path.to_path_buf(), ryl::fix::non_utf8_diff_skip()));
+    }
     Ok(emit_diff(&stats))
 }
 

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -1,0 +1,428 @@
+//! `--diff` previews safe fixes as a unified diff without writing.
+//!
+//! Behaviour mirrors `ruff check --diff`: the diff goes to stdout, the exit code is
+//! `1` iff some file would change and `0` otherwise, and remaining *unfixable*
+//! findings are neither printed nor counted (a file that only trips an unfixable rule
+//! produces no diff and exits `0`, unlike a plain lint run). Files that cannot be
+//! parsed — or, on Unix, symlinks — are skipped with a stderr notice and do not
+//! affect the exit code.
+
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use tempfile::tempdir;
+
+mod common;
+use common::cli::run;
+
+const TRAILING: &str = "rules: {trailing-spaces: enable}";
+
+fn run_with_stdin(cmd: &mut Command, input: &[u8]) -> (i32, String, String) {
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ryl");
+    if let Err(error) = child.stdin.as_mut().expect("stdin").write_all(input) {
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::BrokenPipe,
+            "write stdin: {error}"
+        );
+    }
+    let out = child.wait_with_output().expect("wait");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn diff_prints_unified_diff_and_leaves_file_unchanged() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    let original = "key:   value  \n";
+    fs::write(&file, original).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 1, "a pending fix must exit 1: {stderr}");
+    assert!(stdout.contains("@@"), "expected a hunk header: {stdout}");
+    assert!(
+        stdout.contains("-key:   value  ") && stdout.contains("+key:   value"),
+        "expected the trailing-space removal in the diff: {stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("--- {}", file.display()))
+            && stdout.contains(&format!("+++ {}", file.display())),
+        "diff header must carry the file path on both sides: {stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        original,
+        "--diff must never write the file"
+    );
+}
+
+#[test]
+fn diff_clean_file_exits_zero_with_empty_stdout() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("clean.yaml");
+    fs::write(&file, "key: value\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 0, "a clean file must exit 0: {stderr}");
+    assert!(stdout.is_empty(), "no diff expected: {stdout}");
+}
+
+#[test]
+fn diff_ignores_remaining_unfixable_findings() {
+    // The crux of mirroring `ruff check --diff`: an unfixable-only finding
+    // (octal-values has no safe fix) yields no diff, so --diff exits 0 even though a
+    // plain lint run would exit 1 on the same file.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("octal.yaml");
+    fs::write(&file, "port: 010\n").unwrap();
+    let cfg = "rules: {octal-values: {forbid-implicit-octal: true}}";
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (diff_code, stdout, _e) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(cfg)
+        .arg(&file));
+    assert_eq!(diff_code, 0, "no safe fix means no diff and exit 0");
+    assert!(
+        stdout.is_empty(),
+        "unfixable findings must not diff: {stdout}"
+    );
+
+    let (lint_code, ..) = run(Command::new(exe).arg("-d").arg(cfg).arg(&file));
+    assert_eq!(
+        lint_code, 1,
+        "plain lint still reports the unfixable finding"
+    );
+}
+
+#[test]
+fn diff_conflicts_with_fix() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("input.yaml");
+    fs::write(&file, "key: value\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("--fix")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 2, "--diff and --fix are mutually exclusive: {stderr}");
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected a clap conflict error: {stderr}"
+    );
+}
+
+#[test]
+fn diff_skips_unparsable_file_with_notice() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("broken.yaml");
+    let original = "[1, 2\n[3, 4\n";
+    fs::write(&file, original).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 0, "an unparsable file yields no diff: {stderr}");
+    assert!(stdout.is_empty(), "no diff for unparsable input: {stdout}");
+    assert!(
+        stderr.contains("skipped by --diff"),
+        "the user must learn why the file was skipped: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        original,
+        "a skipped file is left untouched"
+    );
+}
+
+#[test]
+fn diff_reads_stdin_with_default_label() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--diff")
+            .arg("-d")
+            .arg(TRAILING)
+            .arg("-"),
+        b"key:   value  \n",
+    );
+
+    assert_eq!(code, 1, "stdin with a pending fix exits 1: {stderr}");
+    assert!(
+        stdout.contains("--- <stdin>") && stdout.contains("+++ <stdin>"),
+        "stdin diff is labelled <stdin>: {stdout}"
+    );
+}
+
+#[test]
+fn diff_reads_stdin_with_filename_label() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, _stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--diff")
+            .arg("--stdin-filename")
+            .arg("foo.yaml")
+            .arg("-d")
+            .arg(TRAILING)
+            .arg("-"),
+        b"key:   value  \n",
+    );
+
+    assert_eq!(code, 1, "stdin with a pending fix exits 1");
+    assert!(
+        stdout.contains("--- foo.yaml") && stdout.contains("+++ foo.yaml"),
+        "--stdin-filename sets the diff label on both header sides: {stdout}"
+    );
+}
+
+#[test]
+fn diff_stdin_unparsable_is_skipped() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--diff")
+            .arg("-d")
+            .arg(TRAILING)
+            .arg("-"),
+        b"[1, 2\n[3, 4\n",
+    );
+
+    assert_eq!(code, 0, "unparsable stdin yields no diff: {stderr}");
+    assert!(stdout.is_empty(), "no diff for unparsable stdin: {stdout}");
+    assert!(
+        stderr.contains("skipped by --diff"),
+        "skip notice expected for unparsable stdin: {stderr}"
+    );
+}
+
+#[test]
+fn diff_rewrites_yaml_embedded_in_markdown_at_host_level() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(&file, "# Title\n\n```yaml\nkey:   value  \n```\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("--markdown")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 1, "a fixable embedded block exits 1: {stderr}");
+    assert!(
+        stdout.contains(&format!("--- {}", file.display())),
+        "markdown diffs at the host-file level: {stdout}"
+    );
+    assert!(
+        stdout.contains("-key:   value  ") && stdout.contains("+key:   value"),
+        "the embedded fix appears in the host diff: {stdout}"
+    );
+}
+
+#[test]
+fn diff_reports_a_file_that_cannot_be_decoded() {
+    // A read/decode failure (here invalid UTF-8) must surface as a usage error, not a
+    // panic or a silent skip — exercises the error propagation out of the file walk.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("bad.yaml");
+    fs::write(&file, [0xff, 0xff, 0xfe]).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 2, "an unreadable file is a usage error: {stderr}");
+    assert!(
+        stdout.is_empty(),
+        "no diff for an unreadable file: {stdout}"
+    );
+    assert!(
+        stderr.contains("failed to read"),
+        "the read failure must be reported: {stderr}"
+    );
+}
+
+#[test]
+fn diff_reports_stdin_that_cannot_be_decoded() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--diff")
+            .arg("-d")
+            .arg(TRAILING)
+            .arg("-"),
+        &[0xff, 0xff, 0xfe],
+    );
+
+    assert_eq!(code, 2, "undecodable stdin is a usage error: {stderr}");
+    assert!(
+        stderr.contains("failed to read"),
+        "the decode failure must be reported: {stderr}"
+    );
+}
+
+#[test]
+fn diff_across_multiple_files_orders_diffs_and_coexists_with_skips() {
+    // Pins emit_diff's exit/ordering logic: diffs appear in input order, a clean file
+    // emits no block, and an unparsable file is skipped (stderr) without stopping the
+    // run or downgrading the exit code from 1.
+    let dir = tempdir().unwrap();
+    let first = dir.path().join("1-first.yaml");
+    let clean = dir.path().join("2-clean.yaml");
+    let second = dir.path().join("3-second.yaml");
+    let broken = dir.path().join("4-broken.yaml");
+    fs::write(&first, "key:   value  \n").unwrap();
+    fs::write(&clean, "key: value\n").unwrap();
+    fs::write(&second, "name:   other  \n").unwrap();
+    fs::write(&broken, "[1, 2\n[3, 4\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&first)
+        .arg(&clean)
+        .arg(&second)
+        .arg(&broken));
+
+    assert_eq!(code, 1, "a pending fix exits 1 despite the skip: {stderr}");
+    let first_at = stdout.find("1-first.yaml").expect("first file diffed");
+    let second_at = stdout.find("3-second.yaml").expect("second file diffed");
+    assert!(
+        first_at < second_at,
+        "diffs appear in input order: {stdout}"
+    );
+    assert!(
+        !stdout.contains("2-clean.yaml"),
+        "a clean file emits no diff block: {stdout}"
+    );
+    assert!(
+        stderr.contains("4-broken.yaml") && stderr.contains("skipped by --diff"),
+        "the unparsable file is skipped on stderr: {stderr}"
+    );
+}
+
+#[test]
+fn diff_markdown_skip_reports_original_line_not_post_fix() {
+    // Regression: `--diff` never writes, so a skipped region's notice must use the
+    // ORIGINAL line. Block 1's blank lines collapse (empty-lines), shifting block 2 up
+    // by two lines in the fixed output; the skip notice for block 2's undefined alias
+    // must still point at its original line (10) — as a plain lint does — not the
+    // post-fix line (8).
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(
+        &file,
+        "```yaml\na: 1\n\n\n\nb: 2\n```\n\n```yaml\nc: *missing\n```\n",
+    )
+    .unwrap();
+    let cfg = "rules: {empty-lines: {max: 1}}";
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("--markdown")
+        .arg("-d")
+        .arg(cfg)
+        .arg(&file));
+
+    assert_eq!(code, 1, "block 1 has a fixable diff: {stderr}");
+    assert!(stdout.contains("@@"), "host-level diff expected: {stdout}");
+    assert!(
+        stderr.contains(":10:") && stderr.contains("skipped by --diff"),
+        "skip notice must use the original line 10: {stderr}"
+    );
+    assert!(
+        !stderr.contains(":8:"),
+        "skip notice must not use the post-fix line 8: {stderr}"
+    );
+}
+
+#[test]
+fn diff_deduplicates_inputs_listed_under_multiple_spellings() {
+    // A file reached by several spellings (the directory walk, here twice, plus an
+    // explicit arg) must be diffed once — a duplicate patch block would fail to apply
+    // on the second copy. Exercises both the candidate-loop and explicit-loop dedup
+    // paths and that `./dirty.yaml` (walk) and `dirty.yaml` (explicit) normalize to
+    // one identity. Run from the temp dir so the inputs are relative.
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("dirty.yaml"), "key:   value  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .current_dir(dir.path())
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(".")
+        .arg(".")
+        .arg("dirty.yaml"));
+
+    assert_eq!(code, 1, "a pending fix exits 1: {stderr}");
+    assert_eq!(
+        stdout.matches("+++ ").count(),
+        1,
+        "the file must be diffed once despite three spellings: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn diff_skips_symlink_with_notice() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("real.yaml");
+    fs::write(&target, "key:   value  \n").unwrap();
+    let link = dir.path().join("link.yaml");
+    symlink(&target, &link).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&link));
+
+    assert_eq!(code, 0, "a skipped symlink produces no diff: {stderr}");
+    assert!(stdout.is_empty(), "no diff for a symlink: {stdout}");
+    assert!(
+        stderr.contains("refusing to follow a symlink for --diff"),
+        "expected the symlink skip warning: {stderr}"
+    );
+}

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -374,6 +374,36 @@ fn diff_markdown_skip_reports_original_line_not_post_fix() {
 }
 
 #[test]
+fn diff_header_relativizes_absolute_path_under_cwd() {
+    // Mirrors ruff: an absolute path under the run directory is relativized in the
+    // header so the patch applies from there (`git apply -p0` / hk) instead of an
+    // absolute `--- /abs/...` header that git apply rejects. Canonicalize the temp dir
+    // so this holds where the system temp dir is symlinked (e.g. macOS /var -> /private).
+    let dir = tempdir().unwrap();
+    let root = fs::canonicalize(dir.path()).unwrap();
+    let file = root.join("input.yaml");
+    fs::write(&file, "key:   value  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .current_dir(&root)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file)); // absolute path under the run directory
+
+    assert_eq!(code, 1, "a pending fix exits 1: {stderr}");
+    assert!(
+        stdout.contains("--- input.yaml") && stdout.contains("+++ input.yaml"),
+        "an absolute path under cwd must be relativized in the header: {stdout}"
+    );
+    assert!(
+        !stdout.contains(&format!("--- {}", file.display())),
+        "the absolute path must not appear in the header: {stdout}"
+    );
+}
+
+#[test]
 fn diff_deduplicates_inputs_listed_under_multiple_spellings() {
     // A file reached by several spellings (the directory walk, here twice, plus an
     // explicit arg) must be diffed once — a duplicate patch block would fail to apply

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -482,6 +482,61 @@ fn diff_skips_non_utf8_stdin_with_notice() {
 }
 
 #[test]
+fn diff_header_normalizes_dot_and_dotdot_segments() {
+    // `git apply -p0` rejects `./f` and `sub/../f` headers, so the header path is
+    // lexically normalized to a clean relative path. Canonicalize the temp dir so the
+    // relativization holds where the system temp dir is symlinked (macOS).
+    let dir = tempdir().unwrap();
+    let root = fs::canonicalize(dir.path()).unwrap();
+    fs::create_dir(root.join("sub")).unwrap();
+    fs::write(root.join("f.yaml"), "key:   value  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .current_dir(&root)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg("sub/../f.yaml"));
+
+    assert_eq!(code, 1, "a pending fix exits 1: {stderr}");
+    assert!(
+        stdout.contains("--- f.yaml") && stdout.contains("+++ f.yaml"),
+        "`sub/../f.yaml` must normalize to a clean `f.yaml` header: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn diff_skips_non_utf8_filename_with_notice() {
+    // A non-UTF-8 filename can't be faithfully written in a diff header (it would become
+    // a `�`-mangled, nonexistent path), so --diff skips it like a control-char name.
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let dir = tempdir().unwrap();
+    let file = dir.path().join(OsStr::from_bytes(b"bad\xFF.yaml"));
+    fs::write(&file, "key:   value  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 0, "a skipped file yields no diff: {stderr}");
+    assert!(
+        stdout.is_empty(),
+        "no diff for a non-UTF-8 filename: {stdout}"
+    );
+    assert!(
+        stderr.contains("skipped by --diff") && stderr.contains("non-UTF-8 bytes"),
+        "the non-UTF-8 filename must be skipped with a notice: {stderr}"
+    );
+}
+
+#[test]
 fn diff_deduplicates_dotdot_spelled_paths() {
     // `f.yaml` and `sub/../f.yaml` (sub a real dir) are the same file; --diff must emit
     // one patch, not a duplicate that can't both apply (matches ruff). Exercises the

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -481,6 +481,61 @@ fn diff_skips_non_utf8_stdin_with_notice() {
     );
 }
 
+#[test]
+fn diff_deduplicates_dotdot_spelled_paths() {
+    // `f.yaml` and `sub/../f.yaml` (sub a real dir) are the same file; --diff must emit
+    // one patch, not a duplicate that can't both apply (matches ruff). Exercises the
+    // lexical `..` collapse in `canonical_input`. Both args are absolute so the dedup is
+    // independent of the run directory.
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("f.yaml"), "key:   value  \n").unwrap();
+    let direct = dir.path().join("f.yaml");
+    let dotdot = dir.path().join("sub/../f.yaml");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&direct)
+        .arg(&dotdot));
+
+    assert_eq!(code, 1, "a pending fix exits 1: {stderr}");
+    assert_eq!(
+        stdout.matches("+++ ").count(),
+        1,
+        "`f.yaml` and `sub/../f.yaml` are one file — diff it once: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn diff_skips_filename_with_control_character() {
+    // A newline in a filename can't appear in a unified-diff header (raw corrupts it,
+    // sanitized no longer matches the on-disk name), so --diff skips it with a notice.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("a\nb.yaml");
+    fs::write(&file, "key:   value  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 0, "a skipped file yields no diff: {stderr}");
+    assert!(
+        stdout.is_empty(),
+        "no diff for a control-char filename: {stdout}"
+    );
+    assert!(
+        stderr.contains("skipped by --diff") && stderr.contains("control character"),
+        "the control-char filename must be skipped with a notice: {stderr}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn diff_skips_symlink_with_notice() {

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -206,6 +206,33 @@ fn diff_reads_stdin_with_filename_label() {
 }
 
 #[test]
+fn diff_skips_stdin_filename_with_control_character() {
+    // The `--stdin-filename` label feeds the diff header just like a disk path, so a
+    // control character in it is gated the same way (no representable header).
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--diff")
+            .arg("--stdin-filename")
+            .arg("a\nb.yaml")
+            .arg("-d")
+            .arg(TRAILING)
+            .arg("-"),
+        b"key:   value  \n",
+    );
+
+    assert_eq!(code, 0, "a skipped stdin label yields no diff: {stderr}");
+    assert!(
+        stdout.is_empty(),
+        "no diff for a control-char label: {stdout}"
+    );
+    assert!(
+        stderr.contains("skipped by --diff") && stderr.contains("control characters"),
+        "the control-char stdin label must be skipped with a notice: {stderr}"
+    );
+}
+
+#[test]
 fn diff_stdin_unparsable_is_skipped() {
     let exe = env!("CARGO_BIN_EXE_ryl");
     let (code, stdout, stderr) = run_with_stdin(

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -401,6 +401,56 @@ fn diff_deduplicates_inputs_listed_under_multiple_spellings() {
     );
 }
 
+#[test]
+fn diff_skips_non_utf8_file_with_notice() {
+    // A textual diff of decoded content can't be applied back to BOM'd/transcoded
+    // bytes (git apply / hk would reject it), and a text diff can't round-trip the
+    // encoding the way --fix's re-encode does. So --diff skips non-plain-UTF-8 inputs.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("bom.yaml");
+    let original: &[u8] = b"\xEF\xBB\xBFkey: value  \n"; // UTF-8 BOM + trailing spaces
+    fs::write(&file, original).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("-d")
+        .arg(TRAILING)
+        .arg(&file));
+
+    assert_eq!(code, 0, "a skipped file yields no diff: {stderr}");
+    assert!(stdout.is_empty(), "no diff for a non-UTF-8 file: {stdout}");
+    assert!(
+        stderr.contains("skipped by --diff") && stderr.contains("non-UTF-8 or BOM"),
+        "the BOM file must be skipped with a notice: {stderr}"
+    );
+    assert_eq!(
+        fs::read(&file).unwrap().as_slice(),
+        original,
+        "a skipped file is left untouched"
+    );
+}
+
+#[test]
+fn diff_skips_non_utf8_stdin_with_notice() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run_with_stdin(
+        Command::new(exe)
+            .arg("--diff")
+            .arg("-d")
+            .arg(TRAILING)
+            .arg("-"),
+        b"\xEF\xBB\xBFkey: value  \n",
+    );
+
+    assert_eq!(code, 0, "skipped stdin yields no diff: {stderr}");
+    assert!(stdout.is_empty(), "no diff for non-UTF-8 stdin: {stdout}");
+    assert!(
+        stderr.contains("skipped by --diff") && stderr.contains("non-UTF-8 or BOM"),
+        "non-UTF-8 stdin must be skipped with a notice: {stderr}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn diff_skips_symlink_with_notice() {

--- a/tests/cli_fix_symlink.rs
+++ b/tests/cli_fix_symlink.rs
@@ -36,7 +36,7 @@ fn fix_symlink_warning_sanitizes_the_path() {
         .arg("rules:\n  trailing-spaces: enable\n")
         .arg(&link));
     assert!(
-        err.contains("refusing to apply --fix through a symlink"),
+        err.contains("refusing to follow a symlink for --fix"),
         "expected the symlink skip warning: {err:?}"
     );
     assert!(
@@ -65,7 +65,7 @@ fn fix_skips_explicit_symlink_arg_and_leaves_target_untouched() {
         .arg("rules:\n  trailing-spaces: enable\n")
         .arg(&link));
     assert!(
-        err.contains("refusing to apply --fix through a symlink"),
+        err.contains("refusing to follow a symlink for --fix"),
         "expected the symlink skip warning: {err}"
     );
     assert_eq!(
@@ -91,7 +91,7 @@ fn fix_skips_symlink_pointing_outside_the_scanned_directory() {
         .arg("rules:\n  trailing-spaces: enable\n")
         .arg(&repo));
     assert!(
-        err.contains("refusing to apply --fix through a symlink"),
+        err.contains("refusing to follow a symlink for --fix"),
         "directory-walk --fix must skip symlinks: {err}"
     );
     assert_eq!(
@@ -118,7 +118,7 @@ fn fix_skips_symlinked_markdown_target() {
         .arg("rules:\n  trailing-spaces: enable\n")
         .arg(&link));
     assert!(
-        err.contains("refusing to apply --fix through a symlink"),
+        err.contains("refusing to follow a symlink for --fix"),
         "embedded-markdown --fix must skip symlinks: {err}"
     );
     assert_eq!(

--- a/tests/property_diff.rs
+++ b/tests/property_diff.rs
@@ -1,0 +1,285 @@
+//! Property tests for `--diff` (`ryl::fix::diff_outcome`).
+//!
+//! `--diff` is a *preview* of `--fix`: it renders the safe-fix result as a unified
+//! diff instead of writing it. The invariants here pin that the preview is both
+//! **faithful** and **applicable**, across the safe-fix config matrix:
+//!
+//!  * *faithful* — a diff is emitted exactly when `--fix` would change the file, and
+//!    a plain YAML file is never both diffed and skipped;
+//!  * *applicable* — the emitted diff, applied by an **independent** implementation
+//!    (`diffy`, not the `similar` crate that produced it), reproduces the fix output
+//!    byte-for-byte. This is the contract a runner like hk relies on when it applies
+//!    the diff itself rather than re-invoking ryl, and it stresses the unified-diff
+//!    edge cases the generator already produces (CRLF, no-final-newline, multibyte).
+//!
+//! The YAML generator is reused from the safe-fix suite via `#[path]`
+//! (`ast`/`strategy`/`config`) and wrapped into a markdown host (`wrap`), so the
+//! embedded YAML matches the flat `--fix` suite. Deterministic siblings pin
+//! known-dirty / CRLF / unparsable / markdown cases so the random property cannot
+//! pass vacuously.
+
+// Shared with the safe-fix suite (which uses every item); this binary reuses only
+// the generator and a few helpers, so allow the rest to be unused.
+#[path = "property_safe_fix/ast.rs"]
+#[allow(dead_code)]
+mod ast;
+#[path = "property_safe_fix/config.rs"]
+#[allow(dead_code)]
+mod config;
+#[path = "property_safe_fix/strategy.rs"]
+mod strategy;
+#[path = "property_markdown_fix/wrap.rs"]
+mod wrap;
+
+use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+use ryl::config::{SourceKind, YamlLintConfig};
+use ryl::fix::{apply_safe_fixes, diff_outcome, fix_markdown_str};
+
+use config::{safe_fix_configs, synthetic_base_dir, synthetic_path};
+use strategy::arb_document;
+use wrap::arb_markdown_doc;
+
+/// Apply a unified diff with an implementation independent of the one that produced
+/// it, so a round-trip proves the emitted diff is standard-compliant. Panicking here
+/// is the intended failure mode: a diff ryl emits that a conforming applier cannot
+/// parse or apply is a bug, and proptest shrinks the offending input.
+fn apply_unified(original: &str, diff: &str) -> String {
+    let patch = diffy::Patch::from_str(diff).unwrap_or_else(|err| {
+        panic!("emitted diff must parse as a patch: {err}\n{diff}")
+    });
+    diffy::apply(original, &patch)
+        .unwrap_or_else(|err| panic!("emitted diff must apply cleanly: {err}\n{diff}"))
+}
+
+fn assert_yaml_preview(input: &str) -> Result<(), TestCaseError> {
+    for prepared in safe_fix_configs() {
+        let cfg = &prepared.cfg;
+        let fixed =
+            apply_safe_fixes(input, cfg, synthetic_path(), synthetic_base_dir());
+        let outcome = diff_outcome(
+            input,
+            cfg,
+            synthetic_path(),
+            synthetic_base_dir(),
+            SourceKind::Yaml,
+        );
+        prop_assert_eq!(
+            outcome.diff.is_some(),
+            fixed != input,
+            "a diff must be emitted exactly when the fix changes the file under '{}'; input {:?}",
+            prepared.name,
+            input
+        );
+        if let Some(diff) = &outcome.diff {
+            prop_assert!(
+                outcome.skipped.is_empty(),
+                "a diffed YAML file must not also be skipped under '{}'; input {:?}",
+                prepared.name,
+                input
+            );
+            let applied = apply_unified(input, diff);
+            prop_assert_eq!(
+                applied.as_str(),
+                fixed.as_str(),
+                "applying the emitted diff must reproduce the fix output under '{}'; input {:?}; diff {:?}",
+                prepared.name,
+                input,
+                diff
+            );
+        }
+    }
+    Ok(())
+}
+
+fn assert_markdown_preview(input: &str) -> Result<(), TestCaseError> {
+    for prepared in safe_fix_configs() {
+        let cfg = &prepared.cfg;
+        let fixed =
+            fix_markdown_str(input, synthetic_path(), cfg, synthetic_base_dir());
+        let outcome = diff_outcome(
+            input,
+            cfg,
+            synthetic_path(),
+            synthetic_base_dir(),
+            SourceKind::Markdown,
+        );
+        prop_assert_eq!(
+            outcome.diff.is_some(),
+            fixed.is_some(),
+            "a host-level diff must be emitted exactly when the markdown fix changes the file under '{}'; input {:?}",
+            prepared.name,
+            input
+        );
+        if let (Some(diff), Some(fixed)) = (&outcome.diff, &fixed) {
+            let applied = apply_unified(input, diff);
+            prop_assert_eq!(
+                applied.as_str(),
+                fixed.as_str(),
+                "applying the emitted markdown diff must reproduce the fix output under '{}'; input {:?}; diff {:?}",
+                prepared.name,
+                input,
+                diff
+            );
+        }
+    }
+    Ok(())
+}
+
+fn yaml_produces_a_diff(input: &str) -> bool {
+    safe_fix_configs().iter().any(|prepared| {
+        diff_outcome(
+            input,
+            &prepared.cfg,
+            synthetic_path(),
+            synthetic_base_dir(),
+            SourceKind::Yaml,
+        )
+        .diff
+        .is_some()
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "tests/proptest-regressions/property_diff.txt",
+        ))),
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn yaml_diff_is_a_faithful_applicable_preview(document in arb_document()) {
+        assert_yaml_preview(&document.render())?;
+    }
+
+    /// A leading `# ryl disable` mutes every rule, so the fix is a byte-for-byte
+    /// no-op and `--diff` must emit nothing (mirrors property_safe_fix's strongest
+    /// disable invariant).
+    #[test]
+    fn leading_disable_yields_no_diff(document in arb_document()) {
+        let input = format!("# ryl disable\n{}", document.render());
+        for prepared in safe_fix_configs() {
+            let outcome = diff_outcome(
+                &input,
+                &prepared.cfg,
+                synthetic_path(),
+                synthetic_base_dir(),
+                SourceKind::Yaml,
+            );
+            prop_assert!(
+                outcome.diff.is_none(),
+                "leading `# ryl disable` must produce no diff under '{}'; input {:?}",
+                prepared.name,
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn markdown_diff_is_a_faithful_applicable_preview(document in arb_markdown_doc()) {
+        assert_markdown_preview(&document.render())?;
+    }
+}
+
+#[test]
+fn known_dirty_yaml_diff_round_trips() {
+    // commas (space before `,`) and trailing-spaces both fire, so the "diff present"
+    // branch is exercised on a concrete input — the random property cannot pass
+    // vacuously if the generator drifts.
+    let input = "items: [a ,b]  \n";
+    assert!(
+        yaml_produces_a_diff(input),
+        "known-dirty input must produce a diff under at least one config"
+    );
+    assert_yaml_preview(input).expect("known-dirty YAML invariants hold");
+}
+
+#[test]
+fn crlf_without_final_newline_diff_round_trips() {
+    // CRLF + space-before-comma + no final newline: new-lines (enabled in the matrix)
+    // rewrites CRLF->LF across the whole file, so the diff is a multi-line transform
+    // — the case most likely to expose a malformed/inapplicable unified diff.
+    let input = "a: [1 ,2]\r\nb: [3 ,4]";
+    assert!(
+        yaml_produces_a_diff(input),
+        "CRLF dirty input must produce a diff"
+    );
+    assert_yaml_preview(input).expect("CRLF/no-final-newline invariants hold");
+}
+
+#[test]
+fn unparsable_yaml_is_skipped_not_diffed() {
+    let input = "[1, 2\n[3, 4\n";
+    for prepared in safe_fix_configs() {
+        let outcome = diff_outcome(
+            input,
+            &prepared.cfg,
+            synthetic_path(),
+            synthetic_base_dir(),
+            SourceKind::Yaml,
+        );
+        assert!(
+            outcome.diff.is_none(),
+            "an unparsable file must not be diffed under '{}'",
+            prepared.name
+        );
+        assert!(
+            !outcome.skipped.is_empty(),
+            "an unparsable file must be reported as skipped under '{}'",
+            prepared.name
+        );
+    }
+}
+
+#[test]
+fn crlf_preserving_config_diff_round_trips_via_diffy() {
+    // Every config in the safe-fix matrix enables `new-lines` (CRLF->LF), so the
+    // property matrix never feeds diffy a CRLF-*preserved* diff (CR on both sides). A
+    // trailing-spaces-only config keeps CRLF, exercising the unified-diff shape with
+    // embedded CR bytes that the hk / `git apply` consumer relies on for Windows files.
+    let cfg = YamlLintConfig::from_yaml_str("rules:\n  trailing-spaces: enable\n")
+        .expect("config parses");
+    let input = "a:   1  \r\nb: 2  \r\nc: 3\r\n";
+    let fixed = apply_safe_fixes(input, &cfg, synthetic_path(), synthetic_base_dir());
+    assert_ne!(fixed, input, "trailing spaces must be removed");
+    assert!(
+        fixed.contains("\r\n"),
+        "CRLF must be preserved (no new-lines rule)"
+    );
+    let outcome = diff_outcome(
+        input,
+        &cfg,
+        synthetic_path(),
+        synthetic_base_dir(),
+        SourceKind::Yaml,
+    );
+    let diff = outcome
+        .diff
+        .expect("a CRLF file with trailing spaces must diff");
+    assert_eq!(
+        apply_unified(input, &diff),
+        fixed,
+        "diffy must round-trip a CRLF-preserved diff: {diff:?}"
+    );
+}
+
+#[test]
+fn known_dirty_markdown_diff_round_trips() {
+    // A fenced block with a space before `,` is fixed at the host level, exercising
+    // the markdown branch's "diff present" path deterministically.
+    let input = "# Title\n\n```yaml\nitems: [a ,b]\n```\n";
+    let cfg = &safe_fix_configs()[0].cfg;
+    let outcome = diff_outcome(
+        input,
+        cfg,
+        synthetic_path(),
+        synthetic_base_dir(),
+        SourceKind::Markdown,
+    );
+    assert!(
+        outcome.diff.is_some(),
+        "known-dirty markdown must produce a host-level diff"
+    );
+    assert_markdown_preview(input).expect("known-dirty markdown invariants hold");
+}


### PR DESCRIPTION
Closes #269.

Adds a `--diff` flag that runs the existing safe-fix pipeline but, instead of
writing files, prints a unified diff per changed file to stdout — modelled on
`ruff check --diff`. Useful for CI previews, PR review, and parallel-safe runners
such as [hk](https://hk.jdx.dev) that apply the diff themselves rather than
re-invoking the linter.

## Behaviour (diff-only, mirrors `ruff check --diff`)

- Prints a unified diff (3 lines of context) per file whose safe-fix output differs
  from the original, to **stdout**.
- Exit `1` iff any file would change, `0` otherwise, `2` for usage errors.
- Remaining **unfixable** findings are neither printed nor counted (verified that
  `ruff check --diff` does the same — it exits `0` on an unfixable-only file).
- Preview-only: never writes. `conflicts_with --fix`, ignores `--format`, and —
  unlike `--fix` — supports stdin (`-` / `--stdin-filename`).
- Unparsable or symlinked inputs are skipped with a `skipped by --diff` notice on
  **stderr** and do not affect the exit code.
- Markdown-embedded YAML diffs at the host-file level (one diff per `.md`). Skip
  notices use the **original** (pre-fix) line numbers, since `--diff` never writes.

## Implementation

- `fix::diff_outcome` / `fix::diff_safe_fixes_for_files` reuse `apply_safe_fixes` /
  `fix_markdown_str`; rendering via the `similar` crate. The diff body is emitted
  verbatim (only the header path is sanitized) so a consumer can re-apply it.
- **Input de-duplication** (`gather_lint_files`): a file reached by several spellings
  (`ryl . f.yaml`, `f.yaml f.yaml`, `./f.yaml` vs `f.yaml`) is now processed once,
  across all modes — a duplicate `--diff` block would fail to apply on the second
  copy. Keyed on lexical absolute path (no symlink resolution, so a symlink and its
  target stay distinct). Deliberately stricter than yamllint; documented in the
  migrating guide.

## Tests

- `tests/cli_diff.rs` — CLI behaviour (exit codes, stdout/stderr split, stdin,
  markdown host-level diff + original-coordinate skips, dedup, symlink skip,
  unfixable-only → exit 0).
- `tests/property_diff.rs` — reuses the safe-fix generator; asserts the preview is
  **faithful** (diff present ⟺ `--fix` would change the file) and **applicable**:
  the `similar`-generated diff, applied by the independent `diffy` crate, reproduces
  the fix output byte-for-byte across CRLF / no-final-newline / multibyte. 512k-case
  thorough run is green.

prek, full coverage (zero uncovered regions), and the suite all pass.

## Reviewed

Claude `/code-review` (max effort) fixed a Markdown skip-coordinate bug + cleanups;
two local Codex passes then drove the global input-dedup change. The one residual
Codex flagged — duplicate patches for two **hard links** to the same inode — matches
ruff's behaviour (verified) and is tracked as a possible follow-up in #281.

No version bump in this branch (batching features before the next release).

## Docs

README, quickstart, `docs/markdown.md`, the migrating-from-yamllint divergence
catalog, and AGENTS.md updated. Also corrected a stale README claim that embedded
Markdown was "check-only" (`--fix` writes back into Markdown).
