### PR TITLE
Add block-scalar-chomping rule

### DIFF
--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -26,6 +26,9 @@ forbid-undeclared-aliases = true
 forbid-duplicated-anchors = true
 forbid-unused-anchors = false
 
+[rules.block-scalar-chomping]
+level = "warning"
+
 [rules.braces]
 level = "warning"
 forbid = "non-empty"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,10 @@ the unsafe-trigger subset in that rule's module-level doc comment instead.
 - `anchors` — Fixing requires choosing which anchor an undeclared alias
   should point at, which duplicate to keep, or whether an "unused" anchor is
   actually referenced from a template the linter cannot see.
+- `block-scalar-chomping` — YAML has no explicit *clip* indicator (only `-`
+  strip and `+` keep exist), so a bare `|`/`>` cannot be annotated without
+  switching it to strip or keep, which changes the scalar's trailing newlines
+  and resolved value; the choice is the author's intent.
 - `colons` — Collapsing extra space around colons safely needs precise parser
   context tracking (plain scalars, alias keys, explicit `?`/`:` mappings)
   equivalent to re-implementing the YAML mapping scanner.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "clap",
  "diffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-ryl implements 26 rules for checking YAML files. This page is a categorised
+ryl implements 27 rules for checking YAML files. This page is a categorised
 index of every rule with a brief description and a link to its detailed
 documentation. Each rule page covers what the rule does, why it matters,
 configuration options, and (where applicable) automatic fix behaviour.
@@ -28,6 +28,7 @@ Rules that auto-fix are marked with :wrench: in the **Fix** column.
 
 | Rule | Description | Fix |
 | :--- | :--- | :---: |
+| [`block-scalar-chomping`](rules/block-scalar-chomping.md) | Explicit chomping indicator (`-`/`+`) on block scalars. |  |
 | [`braces`](rules/braces.md) | Spaces inside flow mapping braces (`{...}`). | :wrench: |
 | [`brackets`](rules/brackets.md) | Spaces inside flow sequence brackets (`[...]`). | :wrench: |
 | [`colons`](rules/colons.md) | Spaces around mapping colons. |  |

--- a/docs/rules/block-scalar-chomping.md
+++ b/docs/rules/block-scalar-chomping.md
@@ -40,7 +40,8 @@ This rule therefore asks you to choose deliberately between strip and keep rathe
 than rely on the silent clip default; it cannot be satisfied by "making clip
 explicit", because there is no such spelling.
 
-Sources: YAML 1.2.2 §8.1.1.2 (block chomping indicator).
+Sources: YAML 1.2.2 §8.1.1.2 (block chomping indicator);
+[yaml.info block-scalar chomp examples](https://www.yaml.info/learn/quote#chomp).
 
 ## Configuration
 
@@ -57,13 +58,6 @@ level = "error"
 
 The rule has no options: when enabled it requires an explicit `-`/`+` on every
 literal/folded block scalar.
-
-A block scalar whose value is only line breaks &mdash; a truly empty `key: |`, or
-a header sitting above blank lines &mdash; is not checked: the parser does not
-expose a stable header position for a body-less block scalar, so its header cannot
-be located reliably. For a truly empty scalar the chomping is also degenerate; a
-blank-only body (where `|` and `|+` *do* differ) is a narrow, accepted false
-negative.
 
 ## Examples
 

--- a/docs/rules/block-scalar-chomping.md
+++ b/docs/rules/block-scalar-chomping.md
@@ -1,0 +1,108 @@
+# block-scalar-chomping
+
+## What this rule does
+
+Requires every literal (`|`) or folded (`>`) block scalar to carry an explicit
+**chomping indicator** &mdash; `-` (strip) or `+` (keep):
+
+```yaml
+script: |-
+  echo "hello"
+```
+
+A bare `|`/`>`, or a header with only an indentation indicator such as `|2`, is
+flagged because its chomping is still the implicit default. The rule is **off by
+default**.
+
+## Why this matters
+
+A block scalar header may end with a chomping indicator that fixes how the
+scalar's *trailing* line breaks are handled (YAML 1.2.2
+[§8.1.1.2](https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator)):
+
+- `-` &mdash; **strip**: remove every trailing line break.
+- `+` &mdash; **keep**: keep every trailing line break.
+- *(none)* &mdash; **clip**: keep exactly one final line break. This is the
+  default a bare `|`/`>` selects.
+
+The clip default is implicit and easy to forget, so whether a block scalar ends
+with a newline (or how many) silently depends on a detail that is not written
+down. That trailing newline frequently matters &mdash; an embedded shell script,
+a certificate, a key, or a templated config can behave differently with or
+without it. Spelling the indicator out documents the author's intent at the point
+it is decided.
+
+An indentation indicator on its own (`|2`) is **not** a chomping indicator, so it
+is still flagged: the chomping remains the implicit clip default.
+
+Note that YAML has **no explicit clip indicator** &mdash; only `-` and `+` exist.
+This rule therefore asks you to choose deliberately between strip and keep rather
+than rely on the silent clip default; it cannot be satisfied by "making clip
+explicit", because there is no such spelling.
+
+Sources: YAML 1.2.2 §8.1.1.2 (block chomping indicator).
+
+## Configuration
+
+`block-scalar-chomping` is a ryl-only rule (yamllint has no equivalent), so it is
+configured **only in TOML** &mdash; `[rules.block-scalar-chomping]` in
+`.ryl.toml`/`ryl.toml` or `[tool.ryl.rules.block-scalar-chomping]` in
+`pyproject.toml`. It is rejected in yamllint-compatible YAML config (including `-d`
+data) so the YAML namespace stays reserved for any future yamllint rule.
+
+```toml
+[rules.block-scalar-chomping]
+level = "error"
+```
+
+The rule has no options: when enabled it requires an explicit `-`/`+` on every
+literal/folded block scalar.
+
+A block scalar whose value is only line breaks &mdash; a truly empty `key: |`, or
+a header sitting above blank lines &mdash; is not checked: the parser does not
+expose a stable header position for a body-less block scalar, so its header cannot
+be located reliably. For a truly empty scalar the chomping is also degenerate; a
+blank-only body (where `|` and `|+` *do* differ) is a narrow, accepted false
+negative.
+
+## Examples
+
+### :x: Reported
+
+```yaml
+clip: |
+  one line
+folded: >
+  some prose
+indent_only: |2
+  body
+```
+
+```text
+1:7   error  missing explicit chomping indicator ("-" or "+")  (block-scalar-chomping)
+3:9   error  missing explicit chomping indicator ("-" or "+")  (block-scalar-chomping)
+5:14  error  missing explicit chomping indicator ("-" or "+")  (block-scalar-chomping)
+```
+
+### :white_check_mark: Allowed
+
+```yaml
+strip: |-
+  no trailing newline
+keep: >+
+  every trailing newline kept
+```
+
+## Automatic fixing
+
+This rule does not auto-fix. YAML has no explicit clip indicator, so a bare
+`|`/`>` cannot be annotated without switching it to strip (`-`) or keep (`+`)
+&mdash; which changes the scalar's trailing newlines and therefore its resolved
+value. Choosing between strip and keep is the author's intent, so no single
+rewrite is universally safe.
+
+## Related rules
+
+- [`indentation`](indentation.md) &mdash; its `check-multi-line-strings` option
+  governs the *indentation* of block scalar content; this rule governs the
+  *chomping indicator* in the header.

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.14.0"
+  "version": "0.15.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.14.0"
+version = "0.15.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"
@@ -38,7 +38,7 @@ Repository = "https://github.com/owenlamont/ryl"
 Issues = "https://github.com/owenlamont/ryl/issues"
 
 [dependency-groups]
-docs = ["zensical==0.0.42"]
+docs = ["zensical>=0.0.42"]
 
 [tool.maturin]
 bindings = "bin"

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -468,6 +468,7 @@
       "description": "A built-in lint rule name.",
       "enum": [
         "anchors",
+        "block-scalar-chomping",
         "braces",
         "brackets",
         "colons",
@@ -1629,6 +1630,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RuleEntryForTomlAnchorsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "block-scalar-chomping": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleEntryForNoOptions"
             },
             {
               "type": "null"

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -230,6 +230,8 @@ pub enum FixRuleName {
 pub enum RuleName {
     #[serde(rename = "anchors")]
     Anchors,
+    #[serde(rename = "block-scalar-chomping")]
+    BlockScalarChomping,
     #[serde(rename = "braces")]
     Braces,
     #[serde(rename = "brackets")]
@@ -287,6 +289,7 @@ impl RuleName {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Anchors => "anchors",
+            Self::BlockScalarChomping => "block-scalar-chomping",
             Self::Braces => "braces",
             Self::Brackets => "brackets",
             Self::Colons => "colons",
@@ -324,6 +327,8 @@ pub struct RulesTable<
     A = AnchorsOptions,
 > {
     pub anchors: Option<RuleEntry<A>>,
+    #[serde(rename = "block-scalar-chomping")]
+    pub block_scalar_chomping: Option<RuleEntry<NoOptions>>,
     pub braces: Option<RuleEntry<BraceLikeOptions>>,
     pub brackets: Option<RuleEntry<BraceLikeOptions>>,
     pub colons: Option<RuleEntry<ColonsOptions>>,

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -202,6 +202,11 @@ fn rules_table_to_value<Q: Serialize, K: Serialize, A: Serialize>(
 ) -> toml::Value {
     let mut table = toml::map::Map::new();
     insert_serialized(&mut table, "anchors", rules.anchors.as_ref());
+    insert_serialized(
+        &mut table,
+        "block-scalar-chomping",
+        rules.block_scalar_chomping.as_ref(),
+    );
     insert_serialized(&mut table, "braces", rules.braces.as_ref());
     insert_serialized(&mut table, "brackets", rules.brackets.as_ref());
     insert_serialized(&mut table, "colons", rules.colons.as_ref());

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 use crate::config::{RuleLevel, YamlLintConfig};
 use crate::decoder;
 use crate::rules::{
-    anchors, braces, brackets, colons, commas, comments, comments_indentation,
-    document_end, document_start, empty_lines, empty_values, float_values, hyphens,
-    indentation, key_duplicates, key_ordering, line_length, merge_keys,
-    new_line_at_end_of_file, new_lines, octal_values, quoted_strings, tags,
+    anchors, block_scalar_chomping, braces, brackets, colons, commas, comments,
+    comments_indentation, document_end, document_start, empty_lines, empty_values,
+    float_values, hyphens, indentation, key_duplicates, key_ordering, line_length,
+    merge_keys, new_line_at_end_of_file, new_lines, octal_values, quoted_strings, tags,
     trailing_spaces, truthy, unicode_line_breaks,
 };
 
@@ -297,6 +297,16 @@ fn collect_block_diagnostics(
         base_dir,
         merge_keys,
         no_config
+    );
+    lint_rule!(
+        diagnostics,
+        cfg,
+        content,
+        path,
+        base_dir,
+        block_scalar_chomping,
+        no_config,
+        message
     );
 }
 

--- a/src/rules/block_scalar_chomping.rs
+++ b/src/rules/block_scalar_chomping.rs
@@ -27,16 +27,13 @@
 //! `\r` is a line break here, whereas the whitespace byte-scanning rules count
 //! `\n` only (see `unicode-line-breaks`).
 //!
-//! Empty / blank-only block scalars (the resolved value is only line breaks, e.g.
-//! a trailing `key: |`, or a header above blank lines) are not checked: granit
-//! places their token on the header at end-of-stream but on the *following* line
-//! otherwise, so there is no content line to anchor a reliable header lookup. The
-//! skip is a deliberate trade-off — for a truly empty scalar the chomping is also
-//! degenerate, but a blank-only body does differ (`key: |` clips to `""` while
-//! `key: |+` keeps `"\n"`), so that narrow case is an accepted false negative.
-//! yamllint has no equivalent rule, so nothing is lost against it.
+//! Empty / blank-only block scalars need one extra case: granit places their token
+//! on the header at end-of-stream but on the following node otherwise. A token
+//! whose start column is the marker therefore uses its own line; every other
+//! token searches strictly above its start line, just like a non-empty scalar.
 //!
-//! Sources: YAML 1.2.2 §8.1.1.2 (block chomping indicator).
+//! Sources: YAML 1.2.2 §8.1.1.2 (block chomping indicator);
+//! <https://www.yaml.info/learn/quote#chomp> (resolved-value examples).
 
 use granit_parser::{ScalarStyle, Scanner, StrInput, TokenType};
 
@@ -62,20 +59,16 @@ pub fn check(buffer: &str) -> Vec<Violation> {
         let TokenType::Scalar(style, value) = token.1 else {
             continue;
         };
-        // Skip non-block scalars and empty / blank-only block scalars: a value of
-        // only line breaks means there is no content line for granit to anchor the
-        // token to, so the header cannot be located reliably (granit puts the token
-        // on the header at end-of-stream but on the *following* line otherwise).
-        // See the module-level note; this also makes the blank-only body a
-        // deliberate, accepted false negative.
-        if !matches!(style, ScalarStyle::Literal | ScalarStyle::Folded)
-            || value.chars().all(|ch| matches!(ch, '\n' | '\r'))
-        {
+        if !matches!(style, ScalarStyle::Literal | ScalarStyle::Folded) {
             continue;
         }
 
-        let (header_line, header_text, marker_idx) =
-            header_marker(&lines, token.0.start.line());
+        let (header_line, header_text, marker_idx) = header_marker(
+            &lines,
+            token.0.start.line(),
+            token.0.start.col(),
+            value.chars().all(|ch| matches!(ch, '\n' | '\r')),
+        );
         // `marker_idx` is the byte offset of the single-byte `|`/`>` (a char
         // boundary), and the reported column counts characters, not bytes, so a
         // multibyte key shifts the column correctly (issue #232).
@@ -129,23 +122,37 @@ fn granit_lines(buffer: &str) -> Vec<&str> {
     lines
 }
 
-/// Locate the header of the block scalar whose first content line is
-/// `content_line` (1-based, as granit numbers lines): the nearest line *strictly
-/// above* it that ends in a `|`/`>` marker. Only blank lines ever sit between a
-/// header and its first content, so a scanner-confirmed non-empty block scalar
-/// always has its marker-bearing header above it. Because [`granit_lines`] splits
-/// on the same break set granit counts, `content_line` indexes the table directly
-/// and stays in bounds. Returns the header's 1-based line number, comment-stripped
-/// text, and the byte index of the marker within that text.
+/// Locate the header of the block scalar whose token starts at `token_line` and
+/// `token_column` (1-based line and 0-based character column, as granit reports
+/// them).
+/// Non-empty tokens start on their first content line, while an empty token at
+/// end-of-stream starts on its own marker; empty tokens before another node start
+/// on that following node. Checking for the exact marker position first
+/// distinguishes the end-of-stream case, then the nearest marker-bearing line
+/// strictly above is the header in every other case.
 fn header_marker<'a>(
     lines: &[&'a str],
-    content_line: usize,
+    token_line: usize,
+    token_column: usize,
+    blank_only: bool,
 ) -> (usize, &'a str, usize) {
-    (1..content_line)
-        .rev()
-        .find_map(|line_no| {
-            let text = strip_trailing_comment_preserving_quotes(lines[line_no - 1]);
-            block_scalar_marker_index(text).map(|idx| (line_no, text, idx))
+    let current = blank_only
+        .then(|| lines.get(token_line - 1))
+        .flatten()
+        .and_then(|line| {
+            let text = strip_trailing_comment_preserving_quotes(line);
+            block_scalar_marker_index(text)
+                .filter(|marker_idx| {
+                    text[..*marker_idx].chars().count() == token_column
+                })
+                .map(|marker_idx| (token_line, text, marker_idx))
+        });
+    current
+        .or_else(|| {
+            (1..token_line).rev().find_map(|line_no| {
+                let text = strip_trailing_comment_preserving_quotes(lines[line_no - 1]);
+                block_scalar_marker_index(text).map(|idx| (line_no, text, idx))
+            })
         })
-        .expect("a non-empty block scalar has a marker-bearing header above it")
+        .expect("a block scalar has a marker-bearing header")
 }

--- a/src/rules/block_scalar_chomping.rs
+++ b/src/rules/block_scalar_chomping.rs
@@ -38,7 +38,7 @@
 use granit_parser::{ScalarStyle, Scanner, StrInput, TokenType};
 
 use crate::rules::support::line_syntax::{
-    block_scalar_marker_index, strip_trailing_comment_preserving_quotes,
+    block_scalar_header_marker_index, strip_trailing_comment_preserving_quotes,
 };
 
 pub const ID: &str = "block-scalar-chomping";
@@ -141,7 +141,7 @@ fn header_marker<'a>(
         .flatten()
         .and_then(|line| {
             let text = strip_trailing_comment_preserving_quotes(line);
-            block_scalar_marker_index(text)
+            block_scalar_header_marker_index(text)
                 .filter(|marker_idx| {
                     text[..*marker_idx].chars().count() == token_column
                 })
@@ -151,7 +151,7 @@ fn header_marker<'a>(
         .or_else(|| {
             (1..token_line).rev().find_map(|line_no| {
                 let text = strip_trailing_comment_preserving_quotes(lines[line_no - 1]);
-                block_scalar_marker_index(text).map(|idx| (line_no, text, idx))
+                block_scalar_header_marker_index(text).map(|idx| (line_no, text, idx))
             })
         })
         .expect("a block scalar has a marker-bearing header")

--- a/src/rules/block_scalar_chomping.rs
+++ b/src/rules/block_scalar_chomping.rs
@@ -1,0 +1,151 @@
+//! `block-scalar-chomping` rule &mdash; requires an explicit chomping indicator
+//! on every block scalar header (issue #257).
+//!
+//! A block scalar header (`|` literal or `>` folded) may carry a *chomping
+//! indicator* that fixes how the scalar's trailing line breaks are handled
+//! (YAML 1.2.2 §8.1.1.2): `-` (strip) removes every trailing break, `+` (keep)
+//! retains them all, and a bare `|`/`>` defaults to *clip* &mdash; keep exactly
+//! one final break. The clip default is implicit and easy to forget, so a stray
+//! or missing trailing newline silently changes the value a consumer reads. This
+//! off-by-default rule makes the author state the intent with `-` or `+`.
+//!
+//! An *indentation* indicator alone (`|2`) is still flagged: it is not a chomping
+//! indicator, so the chomping is still the implicit clip default. YAML has no
+//! explicit clip indicator (only `-` and `+` exist), so a bare `|`/`>` cannot be
+//! annotated without changing its chomping &mdash; there is therefore no safe
+//! `--fix` (see AGENTS.md "Rules Without A Safe `--fix`").
+//!
+//! Detection enumerates genuine block scalars from granit's scanner tokens
+//! (`ScalarStyle::Literal`/`Folded`), so a `|`/`>` inside a quoted scalar, a
+//! comment, or a literal block's own content is never mistaken for a header.
+//! granit reports a non-empty block scalar's token starting at its first *content*
+//! line (the header column is not exposed), and only blank lines ever sit between
+//! a header and its first content, so the header is recovered as the nearest line
+//! *strictly above* the content that ends in a `|`/`>` marker. The source is split
+//! into lines on granit's YAML 1.2 break set (`\r\n`, `\r`, `\n`) so the token's
+//! line number indexes that table directly; like every granit-based rule, a bare
+//! `\r` is a line break here, whereas the whitespace byte-scanning rules count
+//! `\n` only (see `unicode-line-breaks`).
+//!
+//! Empty / blank-only block scalars (the resolved value is only line breaks, e.g.
+//! a trailing `key: |`, or a header above blank lines) are not checked: granit
+//! places their token on the header at end-of-stream but on the *following* line
+//! otherwise, so there is no content line to anchor a reliable header lookup. The
+//! skip is a deliberate trade-off — for a truly empty scalar the chomping is also
+//! degenerate, but a blank-only body does differ (`key: |` clips to `""` while
+//! `key: |+` keeps `"\n"`), so that narrow case is an accepted false negative.
+//! yamllint has no equivalent rule, so nothing is lost against it.
+//!
+//! Sources: YAML 1.2.2 §8.1.1.2 (block chomping indicator).
+
+use granit_parser::{ScalarStyle, Scanner, StrInput, TokenType};
+
+use crate::rules::support::line_syntax::{
+    block_scalar_marker_index, strip_trailing_comment_preserving_quotes,
+};
+
+pub const ID: &str = "block-scalar-chomping";
+pub const MESSAGE: &str = "missing explicit chomping indicator (\"-\" or \"+\")";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub line: usize,
+    pub column: usize,
+}
+
+#[must_use]
+pub fn check(buffer: &str) -> Vec<Violation> {
+    let lines = granit_lines(buffer);
+    let mut violations = Vec::new();
+
+    for token in Scanner::new(StrInput::new(buffer)) {
+        let TokenType::Scalar(style, value) = token.1 else {
+            continue;
+        };
+        // Skip non-block scalars and empty / blank-only block scalars: a value of
+        // only line breaks means there is no content line for granit to anchor the
+        // token to, so the header cannot be located reliably (granit puts the token
+        // on the header at end-of-stream but on the *following* line otherwise).
+        // See the module-level note; this also makes the blank-only body a
+        // deliberate, accepted false negative.
+        if !matches!(style, ScalarStyle::Literal | ScalarStyle::Folded)
+            || value.chars().all(|ch| matches!(ch, '\n' | '\r'))
+        {
+            continue;
+        }
+
+        let (header_line, header_text, marker_idx) =
+            header_marker(&lines, token.0.start.line());
+        // `marker_idx` is the byte offset of the single-byte `|`/`>` (a char
+        // boundary), and the reported column counts characters, not bytes, so a
+        // multibyte key shifts the column correctly (issue #232).
+        let indicators = &header_text[marker_idx + 1..];
+        if indicators.bytes().any(|b| matches!(b, b'-' | b'+')) {
+            continue;
+        }
+        violations.push(Violation {
+            line: header_line,
+            column: header_text[..marker_idx].chars().count() + 1,
+        });
+    }
+
+    violations
+}
+
+/// Split `buffer` into line contents on granit's YAML 1.2 line-break set
+/// (`\r\n`, `\r`, `\n`). Indexing this table by a granit token's 1-based line
+/// number therefore lands on that token's line exactly — including when a bare
+/// `\r` is the break, which granit (like every other granit-based rule) counts as
+/// a line break. A trailing break produces no extra empty entry.
+fn granit_lines(buffer: &str) -> Vec<&str> {
+    let bytes = buffer.as_bytes();
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+    let mut idx = 0usize;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'\n' => {
+                lines.push(&buffer[start..idx]);
+                idx += 1;
+            }
+            b'\r' => {
+                lines.push(&buffer[start..idx]);
+                idx += if bytes.get(idx + 1) == Some(&b'\n') {
+                    2
+                } else {
+                    1
+                };
+            }
+            _ => {
+                idx += 1;
+                continue;
+            }
+        }
+        start = idx;
+    }
+    if start < bytes.len() {
+        lines.push(&buffer[start..]);
+    }
+    lines
+}
+
+/// Locate the header of the block scalar whose first content line is
+/// `content_line` (1-based, as granit numbers lines): the nearest line *strictly
+/// above* it that ends in a `|`/`>` marker. Only blank lines ever sit between a
+/// header and its first content, so a scanner-confirmed non-empty block scalar
+/// always has its marker-bearing header above it. Because [`granit_lines`] splits
+/// on the same break set granit counts, `content_line` indexes the table directly
+/// and stays in bounds. Returns the header's 1-based line number, comment-stripped
+/// text, and the byte index of the marker within that text.
+fn header_marker<'a>(
+    lines: &[&'a str],
+    content_line: usize,
+) -> (usize, &'a str, usize) {
+    (1..content_line)
+        .rev()
+        .find_map(|line_no| {
+            let text = strip_trailing_comment_preserving_quotes(lines[line_no - 1]);
+            block_scalar_marker_index(text).map(|idx| (line_no, text, idx))
+        })
+        .expect("a non-empty block scalar has a marker-bearing header above it")
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,4 +1,5 @@
 pub mod anchors;
+pub mod block_scalar_chomping;
 pub mod braces;
 pub mod brackets;
 pub mod colons;
@@ -28,8 +29,9 @@ pub mod unicode_line_breaks;
 
 /// Every rule id, used by the directive engine to expand a bare `disable`/`enable`
 /// (no `rule:` token) to "all rules". Extend this when adding a rule.
-pub const ALL_RULE_IDS: [&str; 26] = [
+pub const ALL_RULE_IDS: [&str; 27] = [
     anchors::ID,
+    block_scalar_chomping::ID,
     braces::ID,
     brackets::ID,
     colons::ID,
@@ -62,5 +64,9 @@ pub const ALL_RULE_IDS: [&str; 26] = [
 /// out of the YAML schema so the YAML `rules` namespace stays reserved for
 /// yamllint's own definitions (see `AGENTS.md`). Extend this when adding a rule
 /// that yamllint does not have.
-pub const RYL_ONLY_RULE_IDS: [&str; 3] =
-    [merge_keys::ID, tags::ID, unicode_line_breaks::ID];
+pub const RYL_ONLY_RULE_IDS: [&str; 4] = [
+    block_scalar_chomping::ID,
+    merge_keys::ID,
+    tags::ID,
+    unicode_line_breaks::ID,
+];

--- a/src/rules/support/line_syntax.rs
+++ b/src/rules/support/line_syntax.rs
@@ -87,7 +87,15 @@ pub(crate) fn comment_start_preserving_quotes(content: &str) -> Option<usize> {
         match ch {
             '\'' if !in_double => in_single = !in_single,
             '"' if !in_single => in_double = !in_double,
-            '#' if !in_single && !in_double => return Some(idx),
+            '#' if !in_single
+                && !in_double
+                && content[..idx]
+                    .chars()
+                    .next_back()
+                    .is_none_or(char::is_whitespace) =>
+            {
+                return Some(idx);
+            }
             _ => {}
         }
     }

--- a/src/rules/support/line_syntax.rs
+++ b/src/rules/support/line_syntax.rs
@@ -103,30 +103,8 @@ pub(crate) fn comment_start_preserving_quotes(content: &str) -> Option<usize> {
 }
 
 pub(crate) fn block_scalar_marker_index(content: &str) -> Option<usize> {
-    let trimmed = content.trim_end_matches(|ch: char| ch.is_whitespace());
-    let bytes = trimmed.as_bytes();
-
-    let mut tail = bytes.len();
-    let mut saw_digit = false;
-    let mut saw_chomp = false;
-    while tail > 0 {
-        match bytes[tail - 1] {
-            b'-' | b'+' if !saw_chomp => {
-                saw_chomp = true;
-                tail -= 1;
-            }
-            b'1'..=b'9' if !saw_digit => {
-                saw_digit = true;
-                tail -= 1;
-            }
-            _ => break,
-        }
-    }
-
-    if tail == 0 || !matches!(bytes[tail - 1], b'|' | b'>') {
-        return None;
-    }
-    let marker_idx = tail - 1;
+    let marker_idx = block_scalar_header_marker_index(content)?;
+    let bytes = content.as_bytes();
 
     let mut cursor = marker_idx;
     let mut consumed_whitespace = false;
@@ -161,6 +139,33 @@ pub(crate) fn block_scalar_marker_index(content: &str) -> Option<usize> {
         b':' | b'-' | b'?' => Some(marker_idx),
         _ => None,
     }
+}
+
+pub(crate) fn block_scalar_header_marker_index(content: &str) -> Option<usize> {
+    let trimmed = content.trim_end_matches(|ch: char| ch.is_whitespace());
+    let bytes = trimmed.as_bytes();
+
+    let mut tail = bytes.len();
+    let mut saw_digit = false;
+    let mut saw_chomp = false;
+    while tail > 0 {
+        match bytes[tail - 1] {
+            b'-' | b'+' if !saw_chomp => {
+                saw_chomp = true;
+                tail -= 1;
+            }
+            b'1'..=b'9' if !saw_digit => {
+                saw_digit = true;
+                tail -= 1;
+            }
+            _ => break,
+        }
+    }
+
+    if tail == 0 || !matches!(bytes[tail - 1], b'|' | b'>') {
+        return None;
+    }
+    Some(tail - 1)
 }
 
 pub(crate) fn split_lines_preserve_endings(

--- a/src/rules/unicode_line_breaks.rs
+++ b/src/rules/unicode_line_breaks.rs
@@ -35,11 +35,14 @@ pub struct Violation {
 /// Report every raw NEL / LS / PS character with a 1-based line/column.
 ///
 /// Line counting splits on `\n` only (these characters are not YAML 1.2 line
-/// breaks and so never advance the line counter), matching every other ryl rule;
-/// the reported column is therefore the character's position on its `\n`-delimited
-/// line and is always in bounds. ryl does not treat a bare `\r` (classic Mac OS,
-/// pre-2001) as a line break anywhere, so files using that obsolete ending are
-/// unsupported and may report shifted line numbers.
+/// breaks and so never advance the line counter), matching ryl's other
+/// byte-scanning rules and yamllint's `\n`-only line layer; the reported column
+/// is therefore the character's position on its `\n`-delimited line and is always
+/// in bounds. ryl's `\n`-only line model does not treat a bare `\r` (classic Mac
+/// OS, pre-2001) as a line break, so files using that obsolete ending are
+/// unsupported and may report shifted line numbers (granit-based rules see
+/// granit's CR-aware lines, but `\r`-only files are equally unsupported there —
+/// yamllint behaves the same way, and `new-lines` cannot even target `\r`).
 #[must_use]
 pub fn check(buffer: &str) -> Vec<Violation> {
     let mut violations = Vec::new();

--- a/tests/cli_block_scalar_chomping_rule.rs
+++ b/tests/cli_block_scalar_chomping_rule.rs
@@ -1,0 +1,255 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+mod common;
+use common::cli::{command_output, run};
+
+/// `block-scalar-chomping` is a ryl-only rule, so it is configured through TOML
+/// rather than the yamllint-compatible YAML config that `-d` carries.
+fn lint_with_toml_config(content: &str, config: &str) -> (i32, String) {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, content).unwrap();
+    let config_path = dir.path().join(".ryl.toml");
+    fs::write(&config_path, config).unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config_path).arg(&file));
+    (code, command_output(&stdout, &stderr).to_string())
+}
+
+const ENABLE: &str = "[rules]\nblock-scalar-chomping = \"enable\"\n";
+
+#[test]
+fn flags_bare_literal_and_folded_clip_headers() {
+    // A bare `|`/`>` defaults to clip; both are flagged at the marker column,
+    // including a nested mapping value, while explicit `-`/`+` headers are not.
+    let (code, output) = lint_with_toml_config(
+        "literal: |\n  one\nfolded: >\n  two\nnested:\n  inner: |\n    three\nstrip: |-\n  keep me\nkeep: >+\n  fine\n",
+        ENABLE,
+    );
+    assert_eq!(code, 1, "bare clip headers should fail: {output}");
+    for pos in ["1:10", "3:9", "6:10"] {
+        assert!(
+            output.contains(pos),
+            "expected a clip diagnostic at {pos}: {output}"
+        );
+    }
+    assert!(
+        output.contains("missing explicit chomping indicator")
+            && output.contains("block-scalar-chomping"),
+        "message text and bare rule id expected: {output}"
+    );
+    // Exactly the three clip headers fire; the explicit `|-`/`>+` headers on lines
+    // 8 and 10 are not flagged. A count is robust across output formats — a
+    // negative `line:` substring check would collide with the GitHub format's
+    // `col=10` rendering of the line-1/line-6 diagnostics.
+    assert_eq!(
+        output.matches("block-scalar-chomping").count(),
+        3,
+        "exactly the three bare headers should be flagged: {output}"
+    );
+}
+
+#[test]
+fn flags_indentation_only_header() {
+    // `|2` carries an indentation indicator but no chomping indicator, so the
+    // chomping is still the implicit clip default and the header is flagged.
+    let (code, output) = lint_with_toml_config("block: |2\n  body\n", ENABLE);
+    assert_eq!(code, 1, "indentation-only header should fail: {output}");
+    assert!(
+        output.contains("1:8") && output.contains("block-scalar-chomping"),
+        "indentation-only header flagged at the marker: {output}"
+    );
+}
+
+#[test]
+fn ignores_pipe_inside_quoted_scalar() {
+    // The scanner — not a text scan — decides what is a block header, so a `|`
+    // inside a quoted scalar is never treated as one.
+    let (code, output) =
+        lint_with_toml_config("a: \"pipe | not a header\"\nb: 1\n", ENABLE);
+    assert_eq!(code, 0, "a quoted pipe is not a block header: {output}");
+    assert!(
+        !output.contains("block-scalar-chomping"),
+        "quoted pipe must not be flagged: {output}"
+    );
+}
+
+#[test]
+fn ignores_empty_block_scalar() {
+    // An empty block scalar (resolved value is only line breaks) has no stable
+    // header position and degenerate chomping, so it is intentionally skipped.
+    let (code, output) = lint_with_toml_config("a: 1\nempty: |\n", ENABLE);
+    assert_eq!(code, 0, "an empty block scalar is not checked: {output}");
+    assert!(
+        !output.contains("block-scalar-chomping"),
+        "empty block scalar must not be flagged: {output}"
+    );
+}
+
+#[test]
+fn treats_bare_cr_as_a_line_break() {
+    // A bare `\r` between header and content is a YAML 1.2 line break, so this is
+    // a normal one-line header — handled identically to the `\n` form (1:10), like
+    // every other granit-based rule. (Classic-Mac `\r`-only files are otherwise
+    // unsupported; the byte-scanning rules count `\n` only — see unicode-line-breaks.)
+    let (code, output) = lint_with_toml_config("literal: |\r  one\n", ENABLE);
+    assert_eq!(code, 1, "bare-CR-separated header is flagged: {output}");
+    assert!(
+        output.contains("1:10") && output.contains("block-scalar-chomping"),
+        "CR treated as a break: header on line 1, marker col 10: {output}"
+    );
+}
+
+#[test]
+fn counts_bare_cr_when_numbering_the_header_line() {
+    // Two leading bare `\r`s are two line breaks, so the header `z: |` is on line 3
+    // (not line 1) — the CR-aware count matches granit and ryl's other token rules.
+    let (code, output) = lint_with_toml_config("x: 1\ry: 2\rz: |\n  body\n", ENABLE);
+    assert_eq!(
+        code, 1,
+        "header is flagged on its CR-counted line: {output}"
+    );
+    assert!(
+        output.contains("3:4") && output.contains("block-scalar-chomping"),
+        "CR-counted header line 3, marker col 4: {output}"
+    );
+}
+
+#[test]
+fn flags_crlf_header() {
+    // CRLF endings: `\r\n` is one break, so the header is line 1 and the body
+    // line 2 — identical to the LF form (marker at col 6).
+    let (code, output) = lint_with_toml_config("key: |\r\n  hi\r\n", ENABLE);
+    assert_eq!(code, 1, "CRLF header is flagged: {output}");
+    assert!(
+        output.contains("1:6") && output.contains("block-scalar-chomping"),
+        "CRLF header on line 1, marker col 6: {output}"
+    );
+}
+
+#[test]
+fn flags_header_without_trailing_newline() {
+    // A file with no final line break still yields its last line, so a header at
+    // end-of-file is located and flagged.
+    let (code, output) = lint_with_toml_config("key: |\n  hi", ENABLE);
+    assert_eq!(
+        code, 1,
+        "header without a trailing newline is flagged: {output}"
+    );
+    assert!(
+        output.contains("1:6") && output.contains("block-scalar-chomping"),
+        "header on line 1, marker col 6: {output}"
+    );
+}
+
+#[test]
+fn strips_trailing_comment_after_header() {
+    // A comment may follow the header indicators; it is stripped before the
+    // chomping check, so `| # ...` is still flagged at the marker.
+    let (code, output) =
+        lint_with_toml_config("script: | # run it\n  echo hi\n", ENABLE);
+    assert_eq!(code, 1, "commented bare header should fail: {output}");
+    assert!(
+        output.contains("1:9") && output.contains("block-scalar-chomping"),
+        "header before an inline comment flagged at the marker: {output}"
+    );
+}
+
+#[test]
+fn reports_char_based_column_after_multibyte_key() {
+    // `café` is four characters but five bytes; the marker column counts
+    // characters, so the `|` sits at column 7 (a byte offset would give 8).
+    let (code, output) = lint_with_toml_config("café: |\n  body\n", ENABLE);
+    assert_eq!(code, 1, "multibyte-key header should fail: {output}");
+    assert!(
+        output.contains("1:7") && output.contains("block-scalar-chomping"),
+        "char-based marker column past the multibyte key: {output}"
+    );
+}
+
+#[test]
+fn recovers_header_on_its_own_line_above_a_blank_gap() {
+    // The header need not be on the key's line; here it is on its own line and a
+    // blank line separates it from the content. The diagnostic still points at
+    // the `|` on line 2, not the content line.
+    let (code, output) = lint_with_toml_config("key:\n  |\n\n  body\n", ENABLE);
+    assert_eq!(code, 1, "own-line header should fail: {output}");
+    assert!(
+        output.contains("2:3") && output.contains("block-scalar-chomping"),
+        "own-line header flagged above the blank gap: {output}"
+    );
+}
+
+#[test]
+fn rule_is_rejected_in_yaml_config() {
+    // ryl-only: yamllint-compatible YAML config (here via `-d`) must reject it
+    // rather than silently linting or clashing with a future yamllint rule.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "block: |\n  body\n").unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules: {block-scalar-chomping: enable}")
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "a ryl-only rule in YAML config is a usage error: stdout={stdout} stderr={stderr}"
+    );
+    let output = command_output(&stdout, &stderr);
+    assert!(
+        output.contains("block-scalar-chomping"),
+        "error should name the rule: {output}"
+    );
+    assert!(
+        output.to_lowercase().contains("toml"),
+        "error should point to TOML config: {output}"
+    );
+}
+
+#[test]
+fn per_file_ignores_accept_the_rule_name() {
+    // A `[per-file-ignores]` entry naming the rule must be accepted (the rule id
+    // round-trips through `RuleName`), suppressing its diagnostics for that file.
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ignored.yaml");
+    fs::write(&file, "block: |\n  body\n").unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        format!(
+            "[rules]\nblock-scalar-chomping = \"enable\"\n[per-file-ignores]\n'{}' = ['block-scalar-chomping']\n",
+            file.display()
+        ),
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code, 0,
+        "per-file-ignores should suppress the rule: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+    assert!(stderr.trim().is_empty(), "expected no stderr: {stderr}");
+}
+
+#[test]
+fn disabled_by_default() {
+    // The rule is off unless explicitly enabled, so a bare header alone produces
+    // no diagnostic under an unrelated rule's config.
+    let (code, output) = lint_with_toml_config(
+        "block: |\n  body\n",
+        "[rules]\ntrailing-spaces = \"enable\"\n",
+    );
+    assert_eq!(code, 0, "rule is off by default: {output}");
+    assert!(
+        !output.contains("block-scalar-chomping"),
+        "rule must not fire unless enabled: {output}"
+    );
+}

--- a/tests/cli_block_scalar_chomping_rule.rs
+++ b/tests/cli_block_scalar_chomping_rule.rs
@@ -199,6 +199,25 @@ fn preserves_hash_characters_that_do_not_start_comments() {
 }
 
 #[test]
+fn preserves_plain_key_fragments_that_resemble_node_properties() {
+    // `!` and `&` may appear after the first character of a plain scalar. The
+    // scanner confirms these are keys, so header recovery must not reinterpret
+    // their trailing fragments as tag or anchor properties.
+    let (code, output) =
+        lint_with_toml_config("a !foo: |\n  body\na &foo: |\n  body\n", ENABLE);
+    assert_eq!(
+        code, 1,
+        "bare headers after plain keys should fail: {output}"
+    );
+    for pos in ["1:9", "3:9"] {
+        assert!(
+            output.contains(pos),
+            "expected a complete property-like key at {pos}: {output}"
+        );
+    }
+}
+
+#[test]
 fn reports_char_based_column_after_multibyte_key() {
     // `café` is four characters but five bytes; the marker column counts
     // characters, so the `|` sits at column 7 (a byte offset would give 8).

--- a/tests/cli_block_scalar_chomping_rule.rs
+++ b/tests/cli_block_scalar_chomping_rule.rs
@@ -181,6 +181,24 @@ fn strips_trailing_comment_after_header() {
 }
 
 #[test]
+fn preserves_hash_characters_that_do_not_start_comments() {
+    // An unquoted `#` is part of a plain scalar unless separated by whitespace.
+    // Verbatim tag URIs may also contain `#`; header recovery must preserve both
+    // forms instead of truncating the line before the scanner-confirmed marker.
+    let (code, output) = lint_with_toml_config(
+        "a#b: |\n  body\nvalue: !<tag:example.com,2000:app/foo#bar> |\n  body\n",
+        ENABLE,
+    );
+    assert_eq!(code, 1, "bare headers after hashes should fail: {output}");
+    for pos in ["1:6", "3:44"] {
+        assert!(
+            output.contains(pos),
+            "expected a complete hash-bearing header at {pos}: {output}"
+        );
+    }
+}
+
+#[test]
 fn reports_char_based_column_after_multibyte_key() {
     // `café` is four characters but five bytes; the marker column counts
     // characters, so the `|` sits at column 7 (a byte offset would give 8).

--- a/tests/cli_block_scalar_chomping_rule.rs
+++ b/tests/cli_block_scalar_chomping_rule.rs
@@ -79,14 +79,35 @@ fn ignores_pipe_inside_quoted_scalar() {
 }
 
 #[test]
-fn ignores_empty_block_scalar() {
-    // An empty block scalar (resolved value is only line breaks) has no stable
-    // header position and degenerate chomping, so it is intentionally skipped.
-    let (code, output) = lint_with_toml_config("a: 1\nempty: |\n", ENABLE);
-    assert_eq!(code, 0, "an empty block scalar is not checked: {output}");
+fn flags_empty_and_blank_only_block_scalars() {
+    // Granit anchors an end-of-stream empty scalar on its header, but anchors an
+    // empty scalar before another node on that following node. Both forms and a
+    // blank-only body must still report their own headers.
+    let (code, output) =
+        lint_with_toml_config("first: |\nsecond: |\n\nblank: |\n  \ncafé: |", ENABLE);
+    assert_eq!(code, 1, "empty block scalars should fail: {output}");
+    for pos in ["1:8", "2:9", "4:8", "6:7"] {
+        assert!(
+            output.contains(pos),
+            "expected an empty-scalar diagnostic at {pos}: {output}"
+        );
+    }
     assert!(
-        !output.contains("block-scalar-chomping"),
-        "empty block scalar must not be flagged: {output}"
+        output.matches("block-scalar-chomping").count() == 4,
+        "each empty or blank-only scalar should be flagged once: {output}"
+    );
+}
+
+#[test]
+fn does_not_treat_header_like_first_content_as_the_header() {
+    // A literal scalar may begin with content that itself looks like a standalone
+    // block header. The scanner token starts there, but the diagnostic belongs to
+    // the actual header above it.
+    let (code, output) = lint_with_toml_config("key: |\n  |\n", ENABLE);
+    assert_eq!(code, 1, "bare block scalar should fail: {output}");
+    assert!(
+        output.contains("1:6") && !output.contains("2:3"),
+        "the diagnostic should point to the real header: {output}"
     );
 }
 

--- a/tests/cli_markdown_embed.rs
+++ b/tests/cli_markdown_embed.rs
@@ -414,3 +414,20 @@ fn anchors_ambiguous_name_fires_in_fenced_block() {
         "colon-welded anchor name flagged at host 2:4 in the fenced block: {err}"
     );
 }
+
+#[test]
+fn block_scalar_chomping_fires_in_fenced_block() {
+    // The rule runs in embedded YAML (it is not markdown-suppressed); a bare block
+    // header inside a fenced block maps back to its host line and marker column.
+    let cfg = "files = { markdown = [\"*.md\"] }\n[rules]\nblock-scalar-chomping = \"enable\"\n";
+    let body = "intro\n\n```yaml\nscript: |\n  echo hi\n```\n";
+    let (_dir, file) = project(cfg, "doc.md", body);
+
+    let (code, _out, err) = run(Command::new(env!("CARGO_BIN_EXE_ryl")).arg(&file));
+
+    assert_eq!(code, 1, "{err}");
+    assert!(
+        err.contains("4:9") && err.contains("block-scalar-chomping"),
+        "fenced bare block header flagged at host 4:9: {err}"
+    );
+}

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -78,6 +78,7 @@ const RULE_TRIGGERS: &[(&str, &str)] = &[
     // `forbid-ambiguous-anchor-alias-names` dispatch can flag it, so this proves
     // that dispatch fires (not vacuously the undeclared/duplicated/unused checks).
     ("anchors", "a: &foo: 1\nb: *foo:\n"),
+    ("block-scalar-chomping", "a: |\n  hi\n"),
     ("braces", "a: { b: 1 }\n"),
     ("brackets", "a: [ 1 ]\n"),
     ("colons", "a :  b\n"),

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -2,8 +2,8 @@ use std::sync::LazyLock;
 
 use ryl::config::YamlLintConfig;
 use ryl::rules::{
-    merge_keys, new_line_at_end_of_file, new_lines, trailing_spaces,
-    unicode_line_breaks,
+    block_scalar_chomping, merge_keys, new_line_at_end_of_file, new_lines,
+    trailing_spaces, unicode_line_breaks,
 };
 
 #[derive(Debug, Clone)]
@@ -200,6 +200,13 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     for violation in merge_keys::check(content) {
         spans.push(Span {
             rule: merge_keys::ID,
+            line: violation.line,
+            column: violation.column,
+        });
+    }
+    for violation in block_scalar_chomping::check(content) {
+        spans.push(Span {
+            rule: block_scalar_chomping::ID,
             line: violation.line,
             column: violation.column,
         });

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -404,11 +404,16 @@ fn arb_block_scalar_block() -> impl Strategy<Value = Vec<Line>> {
         arb_block_scalar_header(),
         any::<bool>(),
         any::<bool>(),
+        any::<bool>(),
     )
-        .prop_map(|(key, header, header_on_own_line, blank_gap)| {
+        .prop_map(|(key, header, header_on_own_line, blank_gap, blank_only)| {
             let content = Line::Raw {
                 indent: 4,
-                text: "block content".to_string(),
+                text: if blank_only {
+                    String::new()
+                } else {
+                    "block content".to_string()
+                },
             };
             if header_on_own_line {
                 return vec![

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -43,6 +43,13 @@ pub enum Line {
     Blank {
         spaces: u8,
     },
+    /// An indented raw line with no key/colon structure &mdash; used to build the
+    /// header and content lines of a block scalar (e.g. a standalone `  |` header
+    /// on its own line, or an indented content line).
+    Raw {
+        indent: u8,
+        text: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -108,6 +115,10 @@ impl Line {
             Self::DocumentStart => out.push_str("---"),
             Self::DocumentEnd => out.push_str("..."),
             Self::Blank { spaces } => push_spaces(out, *spaces),
+            Self::Raw { indent, text } => {
+                push_spaces(out, *indent);
+                out.push_str(text);
+            }
         }
     }
 }
@@ -365,6 +376,59 @@ fn arb_custom_tag_block() -> impl Strategy<Value = Vec<Line>> {
     })
 }
 
+// Block scalar headers spanning bare clip (`|`/`>`), explicit strip/keep, an
+// indentation-only header (`|2`, which `block-scalar-chomping` still flags), the
+// digit+chomp combination, and a trailing comment after the header.
+fn arb_block_scalar_header() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("|".to_string()),
+        Just(">".to_string()),
+        Just("|-".to_string()),
+        Just(">+".to_string()),
+        Just("|+".to_string()),
+        Just(">-".to_string()),
+        Just("|2".to_string()),
+        Just("|+2".to_string()),
+        Just("| # chomp".to_string()),
+    ]
+}
+
+/// A coherent block scalar the flat line generator never assembles: a key
+/// introducing a literal/folded block plus an indented content line. The header
+/// sits on the key's line, on its own line below the key, or above a blank gap —
+/// the layouts where the header is *not* the content line, which is exactly what
+/// `block-scalar-chomping`'s header recovery must handle.
+fn arb_block_scalar_block() -> impl Strategy<Value = Vec<Line>> {
+    (
+        arb_key(),
+        arb_block_scalar_header(),
+        any::<bool>(),
+        any::<bool>(),
+    )
+        .prop_map(|(key, header, header_on_own_line, blank_gap)| {
+            let content = Line::Raw {
+                indent: 4,
+                text: "block content".to_string(),
+            };
+            if header_on_own_line {
+                return vec![
+                    merge_entry(0, &key, String::new()),
+                    Line::Raw {
+                        indent: 2,
+                        text: header,
+                    },
+                    content,
+                ];
+            }
+            let mut lines = vec![merge_entry(0, &key, header)];
+            if blank_gap {
+                lines.push(Line::Blank { spaces: 0 });
+            }
+            lines.push(content);
+            lines
+        })
+}
+
 fn arb_fragment() -> impl Strategy<Value = Vec<(Line, Newline)>> {
     prop_oneof![
         10 => (arb_line(), arb_newline()).prop_map(|pair| vec![pair]),
@@ -372,6 +436,9 @@ fn arb_fragment() -> impl Strategy<Value = Vec<(Line, Newline)>> {
             lines.into_iter().map(|line| (line, newline)).collect()
         }),
         1 => (arb_custom_tag_block(), arb_newline()).prop_map(|(lines, newline)| {
+            lines.into_iter().map(|line| (line, newline)).collect()
+        }),
+        2 => (arb_block_scalar_block(), arb_newline()).prop_map(|(lines, newline)| {
             lines.into_iter().map(|line| (line, newline)).collect()
         }),
     ]

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -161,6 +161,8 @@ fn arb_key() -> impl Strategy<Value = String> {
         Just("c".to_string()),
         Just("dup".to_string()),
         Just("a#b".to_string()),
+        Just("a !foo".to_string()),
+        Just("a &foo".to_string()),
         Just("café".to_string()),
         Just("Yes".to_string()),
         Just("On".to_string()),

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -160,6 +160,7 @@ fn arb_key() -> impl Strategy<Value = String> {
         Just("b".to_string()),
         Just("c".to_string()),
         Just("dup".to_string()),
+        Just("a#b".to_string()),
         Just("café".to_string()),
         Just("Yes".to_string()),
         Just("On".to_string()),
@@ -390,6 +391,7 @@ fn arb_block_scalar_header() -> impl Strategy<Value = String> {
         Just("|2".to_string()),
         Just("|+2".to_string()),
         Just("| # chomp".to_string()),
+        Just("!<tag:example.com,2000:app/foo#bar> |".to_string()),
     ]
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -237,7 +237,7 @@ docs = [
 [package.metadata]
 
 [package.metadata.requires-dev]
-docs = [{ name = "zensical", specifier = "==0.0.42" }]
+docs = [{ name = "zensical", specifier = ">=0.0.42" }]
 
 [[package]]
 name = "tomli"
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.42"
+version = "0.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -307,18 +307,18 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/dd/04e89ab92aed1ef9e36c76ef095fb587ffcbe4162aa7f3fe6d63aafade4a/zensical-0.0.42.tar.gz", hash = "sha256:cc346b833868a59412fe8d8498a152be90be9f3d8fb87e1f1a1c2e1146cbae1b", size = 3931093, upload-time = "2026-05-15T10:22:45.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d1/ecb1889fd2208b2d577e6ff952d9bee201302eec7966b5b61cc64adfd8f5/zensical-0.0.45.tar.gz", hash = "sha256:315bce4ab0470338dd3588add38fb325f840856c375722e6802bd58a06446266", size = 3935947, upload-time = "2026-06-09T11:23:32.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/19/2ca4e52769307959f7485d4c5da7b24787339787c1cbc371885cef448e50/zensical-0.0.42-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bffd7a34b570fa3ccadf1d23babb0f7c4851c6b626e4fc8ed9f21c2eaae85968", size = 12705326, upload-time = "2026-05-15T10:22:07.905Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/82/0832b0d2c0c2800174141d5519a017105d3dace9194e2c29730e7a676adf/zensical-0.0.42-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ee1a79789f9462ef44a4b6ebbfc8b5bf4b2447607da8bc5b35bc9c4ce4ea2370", size = 12568663, upload-time = "2026-05-15T10:22:11.072Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/87/272b3998322958ca38f09323d2347cb121dfc851477c36962b71319242a5/zensical-0.0.42-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e9a5d508ce8d1b07d8417f0623be476f6b37d445ab4356481a71e613a7979d6", size = 12948460, upload-time = "2026-05-15T10:22:13.792Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/1b/e5f153401f162f48cae2d58e96b95fd39ba5bd1728fb5881a60e502f4e1d/zensical-0.0.42-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9fbc0951a676e48afe7df3a9b2a30958dcf9c426ed2480972d3c04d6de485ba3", size = 12913460, upload-time = "2026-05-15T10:22:16.791Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/4f/5186b4204bdfdf132851b7515a37b9602bfc153fb601db5fb244339bae52/zensical-0.0.42-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f0e96e53f39b9e4b929a25d9df70bd7fa8217166a854e2c8f3185983dd01500", size = 13276704, upload-time = "2026-05-15T10:22:19.819Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/df/b57b5fcc631ac7a4b4c6834d8cf0b88d3fca37c9db42fc6bbf9f097200ed/zensical-0.0.42-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7d586e57436d603e88acd856864f99f0771aef24bf6560b2de238417bd3817c", size = 12987069, upload-time = "2026-05-15T10:22:22.537Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/3a/b326a44a065d98e89b472645ad33037201e3385340c2e6e35627b18ab3fa/zensical-0.0.42-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3c026f023330d67f986a94b68ffd36dc5066882e697e1125c37308d8d684135c", size = 13124195, upload-time = "2026-05-15T10:22:25.543Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/1e/823740a662e357a8826dc8eeb87e06705e64219b2774430bc555f7c53d57/zensical-0.0.42-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e5908bc09cf5c1c50c9504241e37f89955daf3e89ba1b9d71c17972578b24804", size = 13182981, upload-time = "2026-05-15T10:22:28.89Z" },
-    { url = "https://files.pythonhosted.org/packages/80/6d/9fe261267ac36a7d57051d790022408e9043bc925c9ad21971a1e5b6c3e8/zensical-0.0.42-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c0bf96b55f0a44e8716bcb334a16380ed56772b555145da775a7d8ac8678cb6f", size = 13332666, upload-time = "2026-05-15T10:22:32.249Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/57/9b0e4f131a7ad15cf1aca081748ea7336c084fb8e16be202a6bed32f595c/zensical-0.0.42-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:47cd99583738a8ab03fac4080741275c56e741a06dc8edfb541f4c1649a5ae69", size = 13270817, upload-time = "2026-05-15T10:22:35.388Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/fd/bdb85cc444e4146e8970a22e48a903bfed5bf83276ad7d755caa415dda64/zensical-0.0.42-cp310-abi3-win32.whl", hash = "sha256:83090e53fba061967ecb3dff81500b1900f288bae108bf54084a2aeb6648ebd0", size = 12256227, upload-time = "2026-05-15T10:22:38.869Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/b9/09d1f735c8e6d3eb61d176ed5ebcf658b65b126d7d4bbc03a7d366a1e17d/zensical-0.0.42-cp310-abi3-win_amd64.whl", hash = "sha256:2e4304e103f9cd5c637045bbae1ff29de3009ab01b16e99c2fd6d4bbceb7a3ee", size = 12486598, upload-time = "2026-05-15T10:22:42.158Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/6b84115e3bbe6b76ebb1265e8ff2161c0bc88dcd6499eaf29c61a66421e9/zensical-0.0.45-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c4cb2e11132f02ae824e246e016e073458e12e9de1eaf86fd39f01890d41204c", size = 12698844, upload-time = "2026-06-09T11:22:56.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/dc/4ddf05d77c1455c32cb26da71f2a19d355927a45a3db5b26fb258a07ce8f/zensical-0.0.45-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:799a01de2102b5f731744ad31bdbc464d0c07d484e67ba148f6923679afa6ce6", size = 12571590, upload-time = "2026-06-09T11:23:00.192Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/53/60c6cc7b2ce8b1a83eb87bff3f7289447995552fd9a30ca76ffba22ca9d5/zensical-0.0.45-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6201e79ea8a64bd3ced3f05ef4b1529da0e675d67b1395987c0ba942e4e10dc4", size = 12939590, upload-time = "2026-06-09T11:23:02.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/e9217ed75dba323a6f9a4eee28eb40416eff99932cd0ee6c394bf07b9ead/zensical-0.0.45-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:854aaf500e4a3ce64adea1faa7a1820c7cf9a4f66be1043e4e9ba727fe9cf2b5", size = 12911669, upload-time = "2026-06-09T11:23:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/6fc9fe2334bb4460a8a8d732e23a30d2ddc2ecf63c2eb3487d9e7405e70d/zensical-0.0.45-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a80c57fd50fc60415914388286ac10a7d8b6f70b8ca7235597d09fb12c3171b0", size = 13267643, upload-time = "2026-06-09T11:23:07.915Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f9/5696114af4ede5f1bd01e641a4ff24ee8ca49810bfaa28e5be12d930c0ef/zensical-0.0.45-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c3510f69e08b6ed8bb9596fc9393e4687f90394aa0ef2d6118b1375ad97be5", size = 12972147, upload-time = "2026-06-09T11:23:12.069Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9e/5c6acde480c43f8c993b13260925df8db31d51ab8a9977618e9efdd98d45/zensical-0.0.45-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01c484bb2ee85e98e21e24b397ff52ffc31101f7485935eee5d3afa6cca6cc08", size = 13117360, upload-time = "2026-06-09T11:23:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/31/ea21f102049b35a8fe5218c5331857a15eeb60deb1bb21823a4c0701e274/zensical-0.0.45-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:3654b708830303759e866a58a60c483cd2a1c56a44acdaae5bbb341a3f40ebce", size = 13185593, upload-time = "2026-06-09T11:23:18.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/97/6ded39fe27fa8a292d17d9af713b018e4919315233b60fa4b4b0aca737a6/zensical-0.0.45-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c4da1c37eca1474b487def0ef40d7ac2aff31a9d7a029cb7479ef7c354437361", size = 13326882, upload-time = "2026-06-09T11:23:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/79/80/075975032a9e20f319c0134f8ca659d295ee4908f15ab212702a2728247f/zensical-0.0.45-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f8a1966c186feebd3b795f9d420000bfd582e16eefdd9bc7a286d878faabae52", size = 13253961, upload-time = "2026-06-09T11:23:23.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6a/0eab0eb311af6a07cde15ca58d5d720cbfa02cd509e4c7fb5fa20cda0b46/zensical-0.0.45-cp310-abi3-win32.whl", hash = "sha256:a1dd63a5efb8d0e5f2fadf862f02771a279dc5cbe9a982700194650065758f01", size = 12257083, upload-time = "2026-06-09T11:23:26.769Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/cd/b117e749c60b1d1e16b8450db1355f69f38376f783b8c6c8815202988933/zensical-0.0.45-cp310-abi3-win_amd64.whl", hash = "sha256:1f2c0e69839ce4274bde34d18139d3b0d96bbf02b245ada46243590c9eedebc1", size = 12498335, upload-time = "2026-06-09T11:23:29.702Z" },
 ]


### PR DESCRIPTION
## Summary

- add the opt-in, TOML-only `block-scalar-chomping` rule from #257
- require an explicit strip (`-`) or keep (`+`) indicator on every literal or folded block scalar, including indentation-only, empty, and blank-only scalars
- register the rule across lint dispatch, configuration/schema serialization, directives, per-file ignores, Markdown embedding, docs, and examples
- extend property generation and CLI coverage for scanner/header-position edge cases, mixed newline styles, Unicode columns, and misleading header-like content

## Why

A bare `|` or `>` silently selects YAML's clip chomping behavior. Requiring an explicit indicator makes the intended trailing-newline behavior visible and avoids accidental value changes.

During review, empty and blank-only scalars were found to be skipped even though #257 requires every block scalar to be checked. Header recovery now handles granit's different token positions for those scalars while avoiding false header matches when the first content line itself looks like `|` or `>`.

## User impact

The rule is disabled by default and is configured only through TOML because yamllint has no equivalent rule. It has no safe automatic fix because YAML has no explicit clip indicator; choosing strip or keep changes the resolved value.

## Validation

- `prek run --all-files`
- `./scripts/coverage-missing.sh` (`Coverage OK: no uncovered regions.`)
- `PROPTEST_CASES=512000 cargo test --release --test property_check`
- `uv run scripts/source_size.py --compare-to main`

Closes #257
Part of #261
