### PR TITLE
Add `per-line-ignores` config mechanism (#258)

### DIFF
--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -161,6 +161,16 @@ an error (and `--fix`/`--diff` skip with a notice) telling you to convert the fi
 LF or CRLF. The YAML *inside* an LF/CRLF Markdown host (itself free of bare `\r`) is
 linted CR-aware like any other.
 
+### Per-line ignores
+
+ryl adds a [`per-line-ignores`](../per-line-ignores.md) config table with no
+yamllint counterpart: it suppresses chosen rules on lines (and/or files) matching a
+regex/glob, the config-level complement to inline `# ryl disable-line`. yamllint
+offers only inline directives and per-file path ignores, so a recurring exception
+(every `#cloud-config`, every `# renovate:` marker) must be annotated in each file
+or handled per-rule. Being ryl-only, it lives in TOML config and is rejected in
+yamllint-compatible YAML config.
+
 ## Side-by-side example
 
 === "yamllint (.yamllint)"

--- a/docs/per-line-ignores.md
+++ b/docs/per-line-ignores.md
@@ -1,0 +1,85 @@
+# Per-line ignores
+
+## Suppressing rules from configuration
+
+[Inline directives](directives.md) switch rules off at a specific spot in a
+file. `per-line-ignores` does the same thing from configuration: it suppresses
+chosen rules on every line matching a pattern, across all files, without editing
+them. It is the tool for recurring exceptions &mdash; tool-directive comments and
+machine-managed markers that legitimately break a rule everywhere they appear.
+
+Two common cases:
+
+- `#cloud-config` directives must keep their exact spelling, so they trip
+  [`comments`](rules/comments.md) (`require-starting-space`).
+- `# renovate:` markers can be long and cannot be wrapped, so they trip
+  [`line-length`](rules/line-length.md).
+
+`per-line-ignores` is **ryl-only** and configured in TOML only (yamllint has no
+equivalent); it is rejected in yamllint-compatible YAML config.
+
+## Configuration
+
+Each `[[per-line-ignores]]` entry suppresses its `rules` on a line when the
+entry's conditions match:
+
+```toml
+[rules.comments]
+[rules.line-length]
+max = 80
+
+[[per-line-ignores]]
+regex = '^#cloud-config$'   # match against the whole source line
+rules = ["comments"]
+
+[[per-line-ignores]]
+regex = '#\s*renovate:'
+rules = ["line-length"]
+```
+
+| Field | Required | Description |
+| :--- | :--- | :--- |
+| `regex` | one of `regex`/`path` | Regex matched against the whole physical source line (unanchored &mdash; add `^`/`$` yourself). |
+| `path` | one of `regex`/`path` | Glob matched against the file path (same glob semantics as [`per-file-ignores`](config-presets.md), including a leading `!` to negate &mdash; apply to files *not* matching). |
+| `rules` | yes | Rule IDs to suppress, or `["ALL"]` for every rule. |
+
+Present conditions are combined with logical **AND**: an entry with both `regex` and
+`path` suppresses its rules only on matching lines of matching files. An omitted field is
+unconstrained &mdash; no `path` means every file; no `regex` means every line of the
+matched files. At least one of `regex`/`path` is required, so an entry can never
+disable a rule globally (use the rule's own config to turn it off).
+
+Use single-quoted TOML strings for patterns so backslashes need no escaping.
+
+### Examples
+
+```toml
+# Let machine-generated marker lines break any rule
+[[per-line-ignores]]
+regex = 'GENERATED — do not edit'
+rules = ["ALL"]
+
+# Allow Go-template braces, but only in template files
+[[per-line-ignores]]
+path = "*.tpl.yaml"
+regex = '\{\{.*\}\}'
+rules = ["braces"]
+```
+
+## Behaviour
+
+- **Matching** is unanchored, so `^#cloud-config` only matches a comment at the
+  start of a line, while `renovate:` matches anywhere on it.
+- **`--fix`** never rewrites a suppressed line: an edit a fixer would make to a
+  line whose rule is suppressed here is reverted, exactly as for an inline
+  `# ryl disable-line`.
+- **Embedded [YAML in Markdown](markdown.md)**: `path` matches the host Markdown
+  file, while `regex` matches the embedded YAML line (after any list/blockquote
+  prefix is stripped), so the same pattern works for standalone and embedded YAML.
+- **Syntax errors are never suppressed** &mdash; `per-line-ignores` only mutes the
+  named rules, never a parse failure.
+
+## Related
+
+- [Inline directives](directives.md) &mdash; per-file, in-line suppression with
+  `# ryl disable` / `disable-line`.

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -1,5 +1,12 @@
 {
   "$defs": {
+    "AllRulesSelector": {
+      "description": "The `ALL` keyword accepted in a `per-line-ignores` `rules` list.",
+      "enum": [
+        "ALL"
+      ],
+      "type": "string"
+    },
     "FilesTable": {
       "additionalProperties": false,
       "description": "File-to-source-kind glob mapping (ryl-only; TOML). Each kind selects which\nfiles are linted as that kind. A file matching more than one kind is an error.",
@@ -150,6 +157,45 @@
         "platform"
       ],
       "type": "string"
+    },
+    "PerLineIgnore": {
+      "additionalProperties": false,
+      "description": "A single `per-line-ignores` entry. Suppresses `rules` on source lines matching\n`regex` (the whole physical line, unanchored) within files matching `path` (a\nglob). All present fields must match (logical AND); at least one of `regex`/`path`\nis required (validated in `validate_toml_config`), so an entry can't disable a rule\nglobally.",
+      "properties": {
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "regex": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rules": {
+          "items": {
+            "$ref": "#/$defs/PerLineRule"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "rules"
+      ],
+      "type": "object"
+    },
+    "PerLineRule": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AllRulesSelector"
+        },
+        {
+          "$ref": "#/$defs/RuleName"
+        }
+      ],
+      "description": "A `per-line-ignores` rule selector: a built-in rule name, or `ALL` to suppress\nevery rule on a matching line. Untagged so `\"ALL\"` and rule names share one list."
     },
     "QuoteType": {
       "enum": [
@@ -2029,6 +2075,16 @@
       "description": "Per-file rule ignores.",
       "type": [
         "object",
+        "null"
+      ]
+    },
+    "per-line-ignores": {
+      "description": "Per-line rule ignores: suppress rules on lines/files matching a pattern.",
+      "items": {
+        "$ref": "#/$defs/PerLineIgnore"
+      },
+      "type": [
+        "array",
         "null"
       ]
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,16 +4,18 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::directives::PerLineRuleApply;
 use crate::yaml_dom::{ScalarOwned, YamlOwned};
 use globset::{Glob, GlobMatcher, escape as glob_escape};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use regex::Regex;
 
 use crate::config_schema::{
     FixRuleName as TomlFixRuleName, FixableRuleSelector as TomlFixableRuleSelector,
-    NormalizedConfig, NormalizedFixConfig, NormalizedMarkdown, TomlConfig,
-    normalize_toml_config, normalized_config_to_toml_value, parse_toml_config_str,
-    parse_yaml_config, validate_toml_config, yaml_rule_filter_patterns,
-    yaml_rule_level,
+    NormalizedConfig, NormalizedFixConfig, NormalizedMarkdown, NormalizedPerLineIgnore,
+    TomlConfig, normalize_toml_config, normalized_config_to_toml_value,
+    parse_toml_config_str, parse_yaml_config, validate_toml_config,
+    yaml_rule_filter_patterns, yaml_rule_level,
 };
 use crate::{conf, decoder};
 
@@ -136,6 +138,10 @@ pub struct YamlLintConfig {
     ignore_matcher: Option<Gitignore>,
     per_file_ignores: BTreeMap<String, Vec<String>>,
     per_file_ignore_matchers: Vec<PerFileIgnore>,
+    /// Resolved `per-line-ignores` spec, kept (alongside the compiled matchers) so the
+    /// runtime config can serialize back to TOML for `--migrate-configs`.
+    per_line_ignores: Vec<NormalizedPerLineIgnore>,
+    per_line_ignore_matchers: Vec<PerLineIgnoreMatcher>,
     rule_names: Vec<String>,
     rules: std::collections::BTreeMap<String, RuleConfig>,
     yaml_file_patterns: Vec<String>,
@@ -179,9 +185,7 @@ struct PerFileIgnore {
 
 impl PerFileIgnore {
     fn new(pattern: &str, rules: Vec<String>, base_dir: &Path) -> Result<Self, String> {
-        let (negated, pattern) = pattern
-            .strip_prefix('!')
-            .map_or((false, pattern), |stripped| (true, stripped));
+        let (negated, pattern) = split_negation(pattern);
         let absolute_pattern = absolute_glob_pattern(pattern, base_dir);
         let basename_matcher = Glob::new(pattern)
             .map_err(|err| {
@@ -202,22 +206,43 @@ impl PerFileIgnore {
     }
 
     fn matches(&self, path: &Path, base_dir: &Path) -> bool {
-        let filename_matches = path.file_name().is_some_and(|file_name| {
-            self.basename_matcher.is_match(Path::new(file_name))
-        });
-        let absolute_path = if path.is_absolute() {
-            Cow::Borrowed(path)
-        } else {
-            Cow::Owned(base_dir.join(path))
-        };
-        let path_matches = self.absolute_matcher.is_match(absolute_path.as_ref());
-
-        if self.negated {
-            !filename_matches && !path_matches
-        } else {
-            filename_matches || path_matches
-        }
+        let matched = glob_path_matches(
+            &self.basename_matcher,
+            &self.absolute_matcher,
+            path,
+            base_dir,
+        );
+        // Negation inverts the whole match: `!(filename || absolute)`.
+        matched != self.negated
     }
+}
+
+/// Split a leading `!` negation marker off a glob pattern, returning `(negated, rest)`.
+/// Shared by the per-file and per-line ignore matchers so both honour `!` identically.
+fn split_negation(pattern: &str) -> (bool, &str) {
+    pattern
+        .strip_prefix('!')
+        .map_or((false, pattern), |rest| (true, rest))
+}
+
+/// Whether `path` matches either glob: its basename against `basename`, or its
+/// (base-dir-resolved) absolute form against `absolute`. Shared by the per-file and
+/// per-line ignore matchers so both interpret a path glob identically.
+fn glob_path_matches(
+    basename: &GlobMatcher,
+    absolute: &GlobMatcher,
+    path: &Path,
+    base_dir: &Path,
+) -> bool {
+    let filename_matches = path
+        .file_name()
+        .is_some_and(|file_name| basename.is_match(Path::new(file_name)));
+    let absolute_path = if path.is_absolute() {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(base_dir.join(path))
+    };
+    filename_matches || absolute.is_match(absolute_path.as_ref())
 }
 
 fn absolute_glob_pattern(pattern: &str, base_dir: &Path) -> String {
@@ -233,6 +258,99 @@ fn absolute_glob_pattern(pattern: &str, base_dir: &Path) -> String {
         pattern_with_base.push_str(pattern);
         pattern_with_base
     }
+}
+
+/// The rules a `per-line-ignores` entry suppresses, resolved to `&'static str` ids;
+/// `None` means every rule (the `ALL` selector). This mirrors
+/// `directives::insert_rules`'s `None`-means-all convention, so the directives builder
+/// expands `ALL` in one place rather than here.
+fn resolve_per_line_rules(rules: &[String]) -> Option<Vec<&'static str>> {
+    if rules.iter().any(|rule| rule == "ALL") {
+        return None;
+    }
+    Some(
+        rules
+            .iter()
+            .map(|rule| {
+                crate::rules::ALL_RULE_IDS
+                    .iter()
+                    .copied()
+                    .find(|id| *id == rule)
+                    .expect("per-line-ignores rule names are validated rule ids")
+            })
+            .collect(),
+    )
+}
+
+/// Compiled `per-line-ignores` entry: an optional path glob (the basename + absolute
+/// matcher pair, as per-file-ignores), an optional line regex, and the rules to
+/// suppress (`None` = all). No path glob applies to every file; line matching happens
+/// in the directives builder. At least one of path/regex is guaranteed by validation.
+#[derive(Debug, Clone)]
+struct PerLineIgnoreMatcher {
+    path_glob: Option<(GlobMatcher, GlobMatcher)>,
+    /// Whether the path glob was `!`-negated (matches files *not* matching it), as
+    /// per-file-ignores. Only meaningful when `path_glob` is `Some`.
+    path_negated: bool,
+    regex: Option<Regex>,
+    rules: Option<Vec<&'static str>>,
+}
+
+impl PerLineIgnoreMatcher {
+    /// Build a compiled matcher. Infallible: config validation
+    /// (`validate_per_line_ignores`) has already proven every regex/glob compiles, so
+    /// the only failure path is unreachable and is documented with `expect`.
+    fn new(entry: &NormalizedPerLineIgnore, base_dir: &Path) -> Self {
+        let (path_negated, path_glob) = match entry.path.as_deref() {
+            Some(raw) => {
+                let (negated, pattern) = split_negation(raw);
+                let basename = Glob::new(pattern)
+                    .expect("per-line-ignores `path` compiles after config validation")
+                    .compile_matcher();
+                let absolute = Glob::new(&absolute_glob_pattern(pattern, base_dir))
+                    .expect(
+                        "absolute per-line ignore pattern compiles after validation",
+                    )
+                    .compile_matcher();
+                (negated, Some((basename, absolute)))
+            }
+            None => (false, None),
+        };
+        let regex = entry.regex.as_deref().map(|pattern| {
+            Regex::new(pattern)
+                .expect("per-line-ignores `regex` compiles after config validation")
+        });
+        Self {
+            path_glob,
+            path_negated,
+            regex,
+            rules: resolve_per_line_rules(&entry.rules),
+        }
+    }
+
+    /// Whether this entry applies to `path` (true when it has no path constraint).
+    fn path_matches(&self, path: &Path, base_dir: &Path) -> bool {
+        self.path_glob.as_ref().is_none_or(|(basename, absolute)| {
+            glob_path_matches(basename, absolute, path, base_dir) != self.path_negated
+        })
+    }
+
+    fn as_apply(&self) -> PerLineRuleApply<'_> {
+        PerLineRuleApply {
+            regex: self.regex.as_ref(),
+            rules: self.rules.as_deref(),
+        }
+    }
+}
+
+fn build_per_line_ignores(
+    entries: &[NormalizedPerLineIgnore],
+    base_dir: &Path,
+) -> Vec<PerLineIgnoreMatcher> {
+    entries
+        .iter()
+        .map(|entry| PerLineIgnoreMatcher::new(entry, base_dir))
+        .collect()
 }
 
 impl RuleConfig {
@@ -376,6 +494,8 @@ impl Default for YamlLintConfig {
             ignore_matcher: None,
             per_file_ignores: BTreeMap::new(),
             per_file_ignore_matchers: Vec::new(),
+            per_line_ignores: Vec::new(),
+            per_line_ignore_matchers: Vec::new(),
             rule_names: Vec::new(),
             rules: std::collections::BTreeMap::new(),
             yaml_file_patterns: DEFAULT_YAML_FILE_PATTERNS
@@ -409,7 +529,11 @@ impl YamlLintConfig {
         Self::from_yaml_str_with_env(s, None, None)
     }
 
-    /// Build a config from standalone TOML configuration text.
+    /// Build a config from standalone TOML configuration text, without filesystem
+    /// access (like [`Self::from_yaml_str`]). Parsing is separated from discovery: this
+    /// does not run [`Self::finalize`], so path-based matchers (`per-file-ignores`,
+    /// `per-line-ignores`, per-rule `ignore`) are not built here &mdash; the lint-ready
+    /// config comes from `discover_config`, which owns I/O and finalization.
     ///
     /// # Errors
     /// Returns an error when the TOML is empty or cannot be parsed into a valid
@@ -550,6 +674,10 @@ impl YamlLintConfig {
     /// cannot accidentally match the synthetic label.
     pub fn disable_path_based_rule_ignores(&mut self) {
         self.per_file_ignore_matchers.clear();
+        // A per-line entry with a path constraint can't match a synthetic label, so
+        // drop it; pure-regex entries are content-based and still apply to stdin.
+        self.per_line_ignore_matchers
+            .retain(|matcher| matcher.path_glob.is_none());
         for rule in self.rules.values_mut() {
             if let Some(filter) = rule.filter.as_mut() {
                 filter.matcher = None;
@@ -567,6 +695,22 @@ impl YamlLintConfig {
                 .iter()
                 .filter(|entry| entry.matches(path, base_dir))
                 .any(|entry| entry.rules.iter().any(|candidate| candidate == rule))
+    }
+
+    /// The `per-line-ignores` entries applying to `path` (path glob matches, or none),
+    /// as virtual-disable-line applies for the directives builder. Empty when none are
+    /// configured, so directive-less linting pays nothing.
+    #[must_use]
+    pub(crate) fn per_line_applies(
+        &self,
+        path: &Path,
+        base_dir: &Path,
+    ) -> Vec<PerLineRuleApply<'_>> {
+        self.per_line_ignore_matchers
+            .iter()
+            .filter(|matcher| matcher.path_matches(path, base_dir))
+            .map(PerLineIgnoreMatcher::as_apply)
+            .collect()
     }
 
     #[must_use]
@@ -739,6 +883,7 @@ impl YamlLintConfig {
             self.yaml_file_patterns = other.yaml_file_patterns;
         }
         self.per_file_ignores = other.per_file_ignores;
+        self.per_line_ignores = other.per_line_ignores;
         self.locale = self.locale.take().or(other.locale);
     }
 
@@ -774,6 +919,10 @@ impl YamlLintConfig {
 
         if !normalized.per_file_ignores.is_empty() {
             self.per_file_ignores = normalized.per_file_ignores;
+        }
+
+        if !normalized.per_line_ignores.is_empty() {
+            self.per_line_ignores = normalized.per_line_ignores;
         }
 
         if let Some(locale) = normalized.locale {
@@ -826,6 +975,8 @@ impl YamlLintConfig {
         self.ignore_matcher = matcher;
         self.per_file_ignore_matchers =
             build_per_file_ignores(&self.per_file_ignores, base_dir)?;
+        self.per_line_ignore_matchers =
+            build_per_line_ignores(&self.per_line_ignores, base_dir);
 
         self.build_file_kind_matchers(base_dir);
 
@@ -1097,6 +1248,7 @@ fn normalized_config_from_runtime(config: &YamlLintConfig) -> NormalizedConfig {
         ignore_from_files: (!config.ignore_from_files.is_empty())
             .then(|| config.ignore_from_files.clone()),
         per_file_ignores: config.per_file_ignores.clone(),
+        per_line_ignores: config.per_line_ignores.clone(),
         yaml_file_patterns: Some(config.yaml_file_patterns.clone()),
         markdown_file_patterns: (!config.markdown_file_patterns.is_empty())
             .then(|| config.markdown_file_patterns.clone()),

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -33,6 +33,9 @@ pub struct TomlConfig {
     /// Per-file rule ignores.
     #[serde(rename = "per-file-ignores")]
     pub per_file_ignores: Option<BTreeMap<String, Vec<RuleName>>>,
+    /// Per-line rule ignores: suppress rules on lines/files matching a pattern.
+    #[serde(rename = "per-line-ignores")]
+    pub per_line_ignores: Option<Vec<PerLineIgnore>>,
     /// Rule configuration table.
     pub rules: Option<
         RulesTable<
@@ -317,6 +320,45 @@ impl RuleName {
             Self::UnicodeLineBreaks => "unicode-line-breaks",
         }
     }
+}
+
+/// A `per-line-ignores` rule selector: a built-in rule name, or `ALL` to suppress
+/// every rule on a matching line. Untagged so `"ALL"` and rule names share one list.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum PerLineRule {
+    All(AllRulesSelector),
+    Named(RuleName),
+}
+
+/// The `ALL` keyword accepted in a `per-line-ignores` `rules` list.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
+pub enum AllRulesSelector {
+    #[serde(rename = "ALL")]
+    All,
+}
+
+impl PerLineRule {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::All(AllRulesSelector::All) => "ALL",
+            Self::Named(rule) => rule.as_str(),
+        }
+    }
+}
+
+/// A single `per-line-ignores` entry. Suppresses `rules` on source lines matching
+/// `regex` (the whole physical line, unanchored) within files matching `path` (a
+/// glob). All present fields must match (logical AND); at least one of `regex`/`path`
+/// is required (validated in `validate_toml_config`), so an entry can't disable a rule
+/// globally.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PerLineIgnore {
+    pub regex: Option<String>,
+    pub path: Option<String>,
+    pub rules: Vec<PerLineRule>,
 }
 
 /// Built-in rule table for TOML config.
@@ -907,6 +949,10 @@ pub fn validate_toml_config(config: &TomlConfig) -> Result<(), String> {
         );
     }
 
+    if let Some(entries) = config.per_line_ignores.as_deref() {
+        validation::validate_per_line_ignores(entries)?;
+    }
+
     validate_common_config(
         config.ignore.as_ref(),
         config.ignore_from_file.as_ref(),
@@ -957,6 +1003,7 @@ pub struct NormalizedConfig {
     pub ignore_patterns: Option<Vec<String>>,
     pub ignore_from_files: Option<Vec<String>>,
     pub per_file_ignores: BTreeMap<String, Vec<String>>,
+    pub per_line_ignores: Vec<NormalizedPerLineIgnore>,
     pub yaml_file_patterns: Option<Vec<String>>,
     pub markdown_file_patterns: Option<Vec<String>>,
     pub markdown: Option<NormalizedMarkdown>,
@@ -969,6 +1016,15 @@ pub struct NormalizedConfig {
 pub struct NormalizedMarkdown {
     pub front_matter: Option<bool>,
     pub fenced_blocks: Option<bool>,
+}
+
+/// Post-parse form of one `per-line-ignores` entry. `rules` holds rule ids, or the
+/// single literal `"ALL"`; the regex/glob are compiled later in `config.rs`.
+#[derive(Debug, Clone, Default)]
+pub struct NormalizedPerLineIgnore {
+    pub regex: Option<String>,
+    pub path: Option<String>,
+    pub rules: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1025,6 +1081,13 @@ pub(crate) fn parse_yaml_config(doc: &YamlOwned) -> Result<ParsedYamlConfig, Str
     if doc.as_mapping_get("fix").is_some() {
         return Err(
             "invalid config: fix is only supported in TOML configuration".to_string(),
+        );
+    }
+
+    if doc.as_mapping_get("per-line-ignores").is_some() {
+        return Err(
+            "invalid config: per-line-ignores is only supported in TOML configuration"
+                .to_string(),
         );
     }
 

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -3,7 +3,8 @@ use serde::Serialize;
 
 use super::{
     FixTable, MarkdownTable, NormalizedConfig, NormalizedFixConfig, NormalizedMarkdown,
-    RuleName, RulesTable, StringOrVec, TomlConfig, YamlConfig,
+    NormalizedPerLineIgnore, PerLineIgnore, RuleName, RulesTable, StringOrVec,
+    TomlConfig, YamlConfig,
 };
 
 pub(crate) fn string_or_vec_items(value: &StringOrVec) -> Vec<String> {
@@ -43,6 +44,23 @@ fn normalize_per_file_ignores(
                 pattern.clone(),
                 rules.iter().map(|rule| rule.as_str().to_string()).collect(),
             )
+        })
+        .collect()
+}
+
+fn normalize_per_line_ignores(
+    ignores: &[PerLineIgnore],
+) -> Vec<NormalizedPerLineIgnore> {
+    ignores
+        .iter()
+        .map(|entry| NormalizedPerLineIgnore {
+            regex: entry.regex.clone(),
+            path: entry.path.clone(),
+            rules: entry
+                .rules
+                .iter()
+                .map(|rule| rule.as_str().to_string())
+                .collect(),
         })
         .collect()
 }
@@ -132,6 +150,10 @@ pub fn normalize_toml_config(config: &TomlConfig) -> NormalizedConfig {
             .per_file_ignores
             .as_ref()
             .map_or_else(std::collections::BTreeMap::new, normalize_per_file_ignores),
+        per_line_ignores: config
+            .per_line_ignores
+            .as_deref()
+            .map_or_else(Vec::new, normalize_per_line_ignores),
         yaml_file_patterns: config.files.as_ref().and_then(|files| files.yaml.clone()),
         markdown_file_patterns: config
             .files
@@ -159,6 +181,7 @@ pub fn normalize_yaml_config(config: &YamlConfig) -> NormalizedConfig {
         ignore_patterns: config.ignore.as_ref().map(string_or_vec_items),
         ignore_from_files: config.ignore_from_file.as_ref().map(string_or_vec_items),
         per_file_ignores: std::collections::BTreeMap::new(),
+        per_line_ignores: Vec::new(),
         yaml_file_patterns: config.yaml_files.clone(),
         markdown_file_patterns: None,
         markdown: None,
@@ -274,6 +297,11 @@ pub fn toml_config_to_value(config: &TomlConfig) -> toml::Value {
         "per-file-ignores",
         config.per_file_ignores.as_ref(),
     );
+    insert_serialized(
+        &mut table,
+        "per-line-ignores",
+        config.per_line_ignores.as_ref(),
+    );
     if let Some(rules) = config.rules.as_ref() {
         table.insert("rules".to_string(), rules_table_to_value(rules));
     }
@@ -354,6 +382,13 @@ pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value
         );
     }
 
+    if !config.per_line_ignores.is_empty() {
+        table.insert(
+            "per-line-ignores".to_string(),
+            normalized_per_line_ignores_to_toml_value(&config.per_line_ignores),
+        );
+    }
+
     if !config.rules.is_empty() {
         table.insert(
             "rules".to_string(),
@@ -404,6 +439,30 @@ fn normalized_per_file_ignores_to_toml_value(
                             .collect(),
                     ),
                 )
+            })
+            .collect(),
+    )
+}
+
+fn normalized_per_line_ignores_to_toml_value(
+    per_line_ignores: &[NormalizedPerLineIgnore],
+) -> toml::Value {
+    toml::Value::Array(
+        per_line_ignores
+            .iter()
+            .map(|entry| {
+                let mut table = toml::map::Map::new();
+                if let Some(regex) = entry.regex.as_ref() {
+                    table.insert(
+                        "regex".to_string(),
+                        toml::Value::String(regex.clone()),
+                    );
+                }
+                if let Some(path) = entry.path.as_ref() {
+                    table.insert("path".to_string(), toml::Value::String(path.clone()));
+                }
+                insert_string_array(&mut table, "rules", &entry.rules);
+                toml::Value::Table(table)
             })
             .collect(),
     )

--- a/src/config_schema/validation.rs
+++ b/src/config_schema/validation.rs
@@ -1,10 +1,54 @@
+use globset::Glob;
 use regex::Regex;
 
 use super::{
-    KeyOrderingOptions, QuotedStringsOptions, QuotedStringsRequired,
+    KeyOrderingOptions, PerLineIgnore, QuotedStringsOptions, QuotedStringsRequired,
     QuotedStringsRequiredMode, RuleEntry, RuleOptions, RulesTable,
     TomlQuotedStringsOptions,
 };
+
+/// Validate `per-line-ignores` entries: each needs at least one of `regex`/`path`
+/// and a non-empty `rules` list, and each `regex`/`path` must be a valid pattern. Rule
+/// names are already type-checked by deserialization. Validating the patterns here
+/// (the single fallible step) lets the runtime matcher build infallibly.
+///
+/// # Errors
+/// Returns an error describing the first invalid entry.
+pub fn validate_per_line_ignores(entries: &[PerLineIgnore]) -> Result<(), String> {
+    for entry in entries {
+        if entry.regex.is_none() && entry.path.is_none() {
+            return Err(
+                "invalid config: each per-line-ignores entry needs at least one of \
+                 `regex` or `path`"
+                    .to_string(),
+            );
+        }
+        if entry.rules.is_empty() {
+            return Err(
+                "invalid config: per-line-ignores entry has an empty `rules` list"
+                    .to_string(),
+            );
+        }
+        if let Some(pattern) = entry.regex.as_deref() {
+            Regex::new(pattern).map_err(|err| {
+                format!(
+                    "invalid config: per-line-ignores `regex` '{pattern}' is invalid: {err}"
+                )
+            })?;
+        }
+        if let Some(pattern) = entry.path.as_deref() {
+            // Validate the same glob the matcher compiles: a leading `!` is a negation
+            // marker (per-file-ignores parity), stripped before compilation.
+            let glob = pattern.strip_prefix('!').unwrap_or(pattern);
+            Glob::new(glob).map_err(|err| {
+                format!(
+                    "invalid config: per-line-ignores `path` '{pattern}' is invalid: {err}"
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
 
 pub trait QuotedStringsOptionSet {
     fn required(&self) -> Option<&QuotedStringsRequired>;

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -18,7 +18,7 @@ use regex::Regex;
 use crate::rules::ALL_RULE_IDS;
 use crate::rules::support::comments_scan::collect_comments;
 use crate::rules::support::line_syntax::{
-    split_lines_inclusive, split_lines_preserve_endings,
+    line_contents, split_lines_inclusive, split_lines_preserve_endings,
 };
 
 // The patterns match granit's comment payload, which is the text after the leading
@@ -95,12 +95,27 @@ fn resolve_rule(token: &str) -> Option<&'static str> {
 }
 
 /// Directive state for one buffer: block `disable`/`enable` snapshots plus the set of
+/// A resolved `per-line-ignores` entry to layer onto a buffer's directives: suppress
+/// `rules` on every line whose content matches `regex` (all lines if `regex` is None).
+/// `rules` follows [`insert_rules`]' convention &mdash; `None` means every rule (the
+/// `ALL` selector). `config` builds these per file (after path-glob filtering); the
+/// regex matches the line content excluding its break, so the user's `$` anchors to
+/// the line.
+pub struct PerLineRuleApply<'a> {
+    pub regex: Option<&'a Regex>,
+    pub rules: Option<&'a [&'static str]>,
+}
+
 /// rules each line disables via `disable-line`.
 #[derive(Default)]
 pub struct Directives {
     /// `(line, rules disabled from that line onward)`, in ascending line order.
     block_snapshots: Vec<(usize, HashSet<&'static str>)>,
     line_disabled: HashMap<usize, HashSet<&'static str>>,
+    /// Rules disabled on *every* line, from a `per-line-ignores` entry with a matching
+    /// `path` but no `regex`. Recorded once here (not materialized per line) so a
+    /// file-wide suppression on a large file costs O(rules), not O(lines × rules).
+    file_wide: HashSet<&'static str>,
 }
 
 impl Directives {
@@ -152,15 +167,57 @@ impl Directives {
         directives
     }
 
+    /// Parse inline directives, then layer config-driven `per-line-ignores` on top — a
+    /// virtual `disable-line`, so lint filtering ([`Self::is_disabled`]) and `--fix`
+    /// reconcile ([`Self::reconcile`]) treat config and inline suppression identically.
+    /// A `regex` entry suppresses its rules only on matching lines (line numbers come
+    /// from [`line_contents`], which splits on the same YAML 1.2 break set as granit, so
+    /// a match on line *n* lands on a diagnostic at line *n*). A no-`regex` entry is
+    /// file-wide and recorded once in `file_wide` rather than per line.
+    #[must_use]
+    pub fn parse_with_per_line(
+        buffer: &str,
+        per_line: &[PerLineRuleApply<'_>],
+    ) -> Self {
+        let mut directives = Self::parse(buffer);
+        if per_line.is_empty() {
+            return directives;
+        }
+        let mut has_regex_entry = false;
+        for entry in per_line {
+            if entry.regex.is_none() {
+                insert_rules(&mut directives.file_wide, entry.rules);
+            } else {
+                has_regex_entry = true;
+            }
+        }
+        // Only scan lines when a regex entry needs per-line matching.
+        if has_regex_entry {
+            for (index, content) in line_contents(buffer).into_iter().enumerate() {
+                for entry in per_line {
+                    if entry.regex.is_some_and(|regex| regex.is_match(content)) {
+                        insert_rules(
+                            directives.line_disabled.entry(index + 1).or_default(),
+                            entry.rules,
+                        );
+                    }
+                }
+            }
+        }
+        directives
+    }
+
     /// Whether `rule` is disabled on `line` (1-based) by a block or `disable-line`
     /// directive.
     #[must_use]
     pub fn is_disabled(&self, rule: &str, line: usize) -> bool {
-        self.block_snapshots
-            .iter()
-            .rev()
-            .find(|(at, _)| *at <= line)
-            .is_some_and(|(_, set)| set.contains(rule))
+        self.file_wide.contains(rule)
+            || self
+                .block_snapshots
+                .iter()
+                .rev()
+                .find(|(at, _)| *at <= line)
+                .is_some_and(|(_, set)| set.contains(rule))
             || self
                 .line_disabled
                 .get(&line)
@@ -170,7 +227,8 @@ impl Directives {
     /// Whether `rule` is disabled anywhere, used to skip reconciliation in `--fix`.
     #[must_use]
     pub fn disables_any(&self, rule: &str) -> bool {
-        self.line_disabled.values().any(|set| set.contains(rule))
+        self.file_wide.contains(rule)
+            || self.line_disabled.values().any(|set| set.contains(rule))
             || self
                 .block_snapshots
                 .iter()

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -4,7 +4,7 @@ use similar::TextDiff;
 
 use crate::config::{SourceKind, YamlLintConfig};
 use crate::decoder;
-use crate::directives::Directives;
+use crate::directives::{Directives, PerLineRuleApply};
 use crate::markdown_embed::{MarkdownSources, extract_regions};
 use crate::rules::support::line_syntax::buffer_newline;
 use crate::rules::{
@@ -555,12 +555,14 @@ pub fn apply_safe_fixes_filtered(
     {
         return input.to_string();
     }
+    let per_line = cfg.per_line_applies(path, base_dir);
     let ctx = FixContext {
         cfg,
         path,
         base_dir,
         skip,
-        directives: Directives::parse(input),
+        directives: Directives::parse_with_per_line(input, &per_line),
+        per_line,
     };
     let mut content = input.to_string();
     content = ctx.apply(content, NEW_LINES_FIX, |buffer| {
@@ -614,10 +616,14 @@ struct FixContext<'a> {
     path: &'a Path,
     base_dir: &'a Path,
     skip: &'a [&'a str],
-    /// Parsed once from the original input. `disables_any` is stable across fixes
-    /// (no fixer adds or removes a directive comment), so the per-rule guard can be
-    /// read from here without re-parsing for every rule.
+    /// Parsed once from the original input (inline directives plus the `per_line`
+    /// virtual disable-lines). `disables_any` is stable across fixes (no fixer adds or
+    /// removes a directive comment), so the per-rule guard can be read from here
+    /// without re-parsing for every rule.
     directives: Directives,
+    /// Config `per-line-ignores` applying to this file; re-applied on each guarded
+    /// re-parse since a structural fixer can shift which line a regex matches.
+    per_line: Vec<PerLineRuleApply<'a>>,
 }
 
 impl FixContext<'_> {
@@ -646,11 +652,19 @@ impl FixContext<'_> {
         // change because structural fixers shift line numbers (and the comments with
         // them). The guard is read from the once-parsed `self.directives`; only a
         // guarded rule pays for the per-pass re-parse.
-        let guarded = self.directives.disables_any(rule.rule);
+        // Reconcile when an inline directive disables this rule, OR when any per-line
+        // entry targets it: a content regex can newly match a line a *fixer* produces
+        // (unlike an inline comment, which a fixer can't create), so the per-pass
+        // re-parse must run even if no original line matched yet.
+        let guarded = self.directives.disables_any(rule.rule)
+            || self
+                .per_line
+                .iter()
+                .any(|entry| entry.rules.is_none_or(|ids| ids.contains(&rule.rule)));
         let mut current = content;
         let mut directives = Directives::default();
         if guarded {
-            directives = Directives::parse(&current);
+            directives = Directives::parse_with_per_line(&current, &self.per_line);
         }
         for _ in 0..RULE_FIX_MAX_ITERATIONS {
             let Some(next) = fix(&current) else { break };
@@ -664,7 +678,7 @@ impl FixContext<'_> {
             }
             current = next;
             if guarded {
-                directives = Directives::parse(&current);
+                directives = Directives::parse_with_per_line(&current, &self.per_line);
             }
         }
         current

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -331,7 +331,9 @@ pub fn lint_str(
     collect_value_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
     collect_block_diagnostics(&mut diagnostics, content, cfg, path, base_dir);
 
-    let directives = crate::directives::Directives::parse(content);
+    let per_line = cfg.per_line_applies(path, base_dir);
+    let directives =
+        crate::directives::Directives::parse_with_per_line(content, &per_line);
     diagnostics.retain(|problem| {
         !problem
             .rule

--- a/tests/cli_per_line_ignores.rs
+++ b/tests/cli_per_line_ignores.rs
@@ -1,0 +1,407 @@
+//! CLI coverage for the ryl-only `per-line-ignores` TOML config table: a regex/glob
+//! that suppresses chosen rules on matching lines, implemented as virtual
+//! `disable-line` directives so lint, `--fix`, and embedded markdown all honour it.
+//! Assertions are format-agnostic (bare `line:col` + bare rule id) per the repo's
+//! CI-output convention.
+
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use tempfile::tempdir;
+
+mod common;
+use common::cli::{command_output, run};
+
+fn run_lint(config: &str, file_name: &str, body: &str) -> (i32, String) {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".ryl.toml");
+    fs::write(&config_path, config).unwrap();
+    let file = dir.path().join(file_name);
+    fs::write(&file, body).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config_path).arg(&file));
+    (code, command_output(&stdout, &stderr).to_string())
+}
+
+#[test]
+fn regex_suppresses_rule_only_on_matching_lines() {
+    // `#cloud-config` keeps its exact spelling (no starting space), so without an
+    // exemption `comments` flags it; a second `#bad` comment must still fire.
+    let config = "[rules.comments]\n\n[[per-line-ignores]]\n\
+                  regex = '^#cloud-config$'\nrules = [\"comments\"]\n";
+    let (code, out) = run_lint(config, "doc.yaml", "#cloud-config\nkey: value  #bad\n");
+    assert_eq!(code, 1, "second comment should still fire: {out}");
+    assert!(
+        out.contains("2:14") && out.contains("comments"),
+        "line 2 comment should be reported: {out}"
+    );
+    assert!(
+        !out.contains("1:2"),
+        "the #cloud-config line must be suppressed: {out}"
+    );
+}
+
+#[test]
+fn path_and_regex_are_anded_to_scope_an_entry() {
+    let dir = tempdir().unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.comments]\n\n[[per-line-ignores]]\npath = \"*.tpl.yaml\"\n\
+         regex = '^#cloud-config$'\nrules = [\"comments\"]\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("a.tpl.yaml"), "#cloud-config\n").unwrap();
+    fs::write(dir.path().join("b.yaml"), "#cloud-config\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(dir.path()));
+    let out = command_output(&stdout, &stderr);
+    assert_eq!(code, 1, "only the non-template file should fire: {out}");
+    assert!(
+        out.contains("b.yaml") && out.contains("comments"),
+        "b.yaml is outside the path glob, so comments fires: {out}"
+    );
+    assert!(
+        !out.contains("a.tpl.yaml"),
+        "a.tpl.yaml matches path+regex, so it is suppressed: {out}"
+    );
+}
+
+#[test]
+fn negated_path_glob_applies_outside_the_pattern() {
+    // `!src/**` negates like per-file-ignores: the entry applies to files NOT under
+    // src/, so the outside file is suppressed and the inside file still fires.
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules.comments]\n\n[[per-line-ignores]]\npath = \"!src/**\"\n\
+         regex = '^#cloud-config$'\nrules = [\"comments\"]\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("outside.yaml"), "#cloud-config\n").unwrap();
+    fs::write(src.join("inside.yaml"), "#cloud-config\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(dir.path().join(".ryl.toml"))
+        .arg(dir.path()));
+    let out = command_output(&stdout, &stderr);
+    assert_eq!(code, 1, "the in-src file should still fire: {out}");
+    assert!(
+        out.contains("inside.yaml") && out.contains("comments"),
+        "src/inside.yaml is excluded by the negated glob, so comments fires: {out}"
+    );
+    assert!(
+        !out.contains("outside.yaml"),
+        "outside.yaml matches the negated glob, so it is suppressed: {out}"
+    );
+}
+
+#[test]
+fn path_only_entry_suppresses_a_rule_file_wide() {
+    // No regex → the entry applies to every line of a matching file (recorded once as a
+    // file-wide disable, not materialized per line). Multiple comment violations across
+    // lines are all suppressed; a non-matching file still fires.
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules.comments]\n\n[[per-line-ignores]]\npath = \"gen-*.yaml\"\n\
+         rules = [\"comments\"]\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("gen-a.yaml"), "#one\nkey: value  #two\n").unwrap();
+    fs::write(dir.path().join("normal.yaml"), "#three\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(dir.path().join(".ryl.toml"))
+        .arg(dir.path()));
+    let out = command_output(&stdout, &stderr);
+    assert_eq!(code, 1, "the non-matching file should still fire: {out}");
+    assert!(
+        out.contains("normal.yaml") && out.contains("comments"),
+        "normal.yaml is outside the path glob, so comments fires: {out}"
+    );
+    assert!(
+        !out.contains("gen-a.yaml"),
+        "every comment in gen-a.yaml is suppressed file-wide: {out}"
+    );
+}
+
+#[test]
+fn all_selector_suppresses_every_rule_on_the_line() {
+    let config = "[rules.comments]\n[rules.line-length]\nmax = 10\n\n\
+                  [[per-line-ignores]]\nregex = 'GENERATED'\nrules = [\"ALL\"]\n";
+    // Line 1 trips both comments and line-length but is fully exempt; line 2 stays.
+    let body = "k: value  #GENERATED filler over the limit\nother: value-too-long\n";
+    let (code, out) = run_lint(config, "doc.yaml", body);
+    assert_eq!(code, 1, "line 2 should still fire: {out}");
+    assert!(
+        out.contains("2:11") && out.contains("line-length"),
+        "line 2 line-length should be reported: {out}"
+    );
+    // Line 1 would trip line-length (1:11) and comments (1:12); ALL must suppress both.
+    // Assert the full `line:col` (not a bare `1:`, which collides with the GitHub
+    // format's `col=11::` rendering of the line-2 diagnostic).
+    assert!(
+        !out.contains("1:11") && !out.contains("1:12"),
+        "every rule on the GENERATED line must be suppressed: {out}"
+    );
+}
+
+#[test]
+fn fix_leaves_suppressed_lines_byte_identical() {
+    let dir = tempdir().unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.comments]\n\n[[per-line-ignores]]\nregex = '^#cloud-config$'\n\
+         rules = [\"comments\"]\n",
+    )
+    .unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "#cloud-config\nkey: value  #bad\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (_code, _stdout, _stderr) = run(Command::new(exe)
+        .arg("--fix")
+        .arg("-c")
+        .arg(&config)
+        .arg(&file));
+    let fixed = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        fixed, "#cloud-config\nkey: value  # bad\n",
+        "the suppressed comment is untouched while the other is fixed"
+    );
+}
+
+#[test]
+fn fix_still_applies_when_a_per_line_entry_matches_no_current_line() {
+    // The entry targets a fixable rule but its regex matches nothing in the input, so
+    // reconciliation is engaged (a fixer could create a matching line) yet reverts
+    // nothing — the trailing spaces are still fixed. Exercises the per-line `guarded`
+    // path where no original line matched.
+    let dir = tempdir().unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.trailing-spaces]\n\n[[per-line-ignores]]\nregex = 'NEVER_MATCHES'\n\
+         rules = [\"trailing-spaces\"]\n",
+    )
+    .unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "key: value   \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let _ = run(Command::new(exe)
+        .arg("--fix")
+        .arg("-c")
+        .arg(&config)
+        .arg(&file));
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "key: value\n",
+        "a non-matching per-line entry must not block fixing the rule elsewhere"
+    );
+}
+
+#[test]
+fn regex_matches_embedded_yaml_while_path_matches_host_markdown() {
+    let dir = tempdir().unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.comments]\n\n[files]\nmarkdown = [\"*.md\"]\n\n\
+         [[per-line-ignores]]\npath = \"*.md\"\nregex = '^#cloud-config$'\n\
+         rules = [\"comments\"]\n",
+    )
+    .unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(
+        &file,
+        "# Title\n\n```yaml\n#cloud-config\nkey: value\n```\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    assert_eq!(
+        code,
+        0,
+        "regex matches the embedded YAML line, path matches the host .md: {}",
+        command_output(&stdout, &stderr)
+    );
+}
+
+#[test]
+fn pure_regex_entry_applies_to_unlabeled_stdin() {
+    // Without --stdin-filename ryl drops path-based filtering, but a content-regex
+    // entry has no path and must still apply.
+    let dir = tempdir().unwrap();
+    let config = dir.path().join(".ryl.toml");
+    fs::write(
+        &config,
+        "[rules.comments]\n\n[[per-line-ignores]]\nregex = '^#cloud-config$'\n\
+         rules = [\"comments\"]\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let mut child = Command::new(exe)
+        .current_dir(dir.path())
+        .arg("-c")
+        .arg(&config)
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"#cloud-config\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code().unwrap_or(-1),
+        0,
+        "content-regex entry should suppress the stdin diagnostic"
+    );
+}
+
+#[test]
+fn invalid_regex_is_a_config_error() {
+    let (code, out) = run_lint(
+        "[rules.comments]\n[[per-line-ignores]]\nregex = '('\nrules = [\"comments\"]\n",
+        "doc.yaml",
+        "k: v\n",
+    );
+    assert_eq!(code, 2, "invalid regex must be rejected: {out}");
+    assert!(out.contains("per-line-ignores `regex`"), "{out}");
+}
+
+#[test]
+fn invalid_path_glob_is_a_config_error() {
+    let (code, out) = run_lint(
+        "[rules.comments]\n[[per-line-ignores]]\npath = '['\nrules = [\"comments\"]\n",
+        "doc.yaml",
+        "k: v\n",
+    );
+    assert_eq!(code, 2, "invalid glob must be rejected: {out}");
+    assert!(out.contains("per-line-ignores `path`"), "{out}");
+}
+
+#[test]
+fn entry_without_regex_or_path_is_a_config_error() {
+    let (code, out) = run_lint(
+        "[rules.comments]\n[[per-line-ignores]]\nrules = [\"comments\"]\n",
+        "doc.yaml",
+        "k: v\n",
+    );
+    assert_eq!(code, 2, "an unscoped entry must be rejected: {out}");
+    assert!(out.contains("at least one of"), "{out}");
+}
+
+#[test]
+fn empty_rules_list_is_a_config_error() {
+    let (code, out) = run_lint(
+        "[rules.comments]\n[[per-line-ignores]]\nregex = 'x'\nrules = []\n",
+        "doc.yaml",
+        "k: v\n",
+    );
+    assert_eq!(code, 2, "an empty rules list must be rejected: {out}");
+    assert!(out.contains("empty `rules`"), "{out}");
+}
+
+#[test]
+fn unknown_rule_name_is_a_config_error() {
+    let (code, out) = run_lint(
+        "[rules.comments]\n[[per-line-ignores]]\nregex = 'x'\nrules = [\"nope\"]\n",
+        "doc.yaml",
+        "k: v\n",
+    );
+    assert_eq!(code, 2, "an unknown rule name must be rejected: {out}");
+}
+
+#[test]
+fn path_glob_matches_a_relative_cli_path() {
+    // Invoked with a relative path so `path_matches` joins it onto the base dir
+    // (the non-absolute branch), mirroring per-file-ignores' relative matching.
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules.comments]\n\n[[per-line-ignores]]\npath = \"*.yaml\"\n\
+         regex = '^#cloud-config$'\nrules = [\"comments\"]\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("rel.yaml"), "#cloud-config\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .current_dir(dir.path())
+        .arg("-c")
+        .arg(".ryl.toml")
+        .arg("rel.yaml"));
+    assert_eq!(
+        code,
+        0,
+        "relative path should match the glob and suppress comments: {}",
+        command_output(&stdout, &stderr)
+    );
+}
+
+#[test]
+fn effective_config_round_trips_per_line_ignores_to_toml() {
+    // `to_toml_string` must preserve per-line-ignores so the rendered effective config
+    // is not lossy. A regex-only and a path-only entry exercise both optional fields.
+    let cfg = ryl::config::YamlLintConfig::from_toml_str(
+        "[rules.comments]\n\n[[per-line-ignores]]\nregex = '#x'\nrules = [\"comments\"]\n\n\
+         [[per-line-ignores]]\npath = \"*.yaml\"\nrules = [\"comments\"]\n",
+    )
+    .unwrap();
+    let rendered = cfg.to_toml_string();
+    assert!(
+        rendered.contains("per-line-ignores")
+            && rendered.contains("regex")
+            && rendered.contains("#x")
+            && rendered.contains("path")
+            && rendered.contains("*.yaml")
+            && rendered.contains("comments"),
+        "rendered TOML should keep both per-line-ignores entries: {rendered}"
+    );
+}
+
+#[test]
+fn per_line_ignores_is_rejected_in_yaml_config() {
+    let dir = tempdir().unwrap();
+    let config = dir.path().join(".ryl.yaml");
+    fs::write(
+        &config,
+        "rules:\n  comments: {}\nper-line-ignores:\n  - regex: x\n    rules: [comments]\n",
+    )
+    .unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "k: v\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+    let out = command_output(&stdout, &stderr);
+    assert_eq!(code, 2, "per-line-ignores is TOML-only: {out}");
+    assert!(
+        out.contains("per-line-ignores is only supported in TOML"),
+        "{out}"
+    );
+}

--- a/tests/property_config.rs
+++ b/tests/property_config.rs
@@ -16,7 +16,9 @@
 //!   future *validation gap*: were one introduced, a generated config would carry a
 //!   bad value into `resolve()` and panic the property.
 //! - TOML configs are pushed through `parse -> validate -> normalize`, the
-//!   TOML-specific surface.
+//!   TOML-specific surface. This includes generated `[[per-line-ignores]]` entries
+//!   (TOML-only), with hostile regex/glob/rules values to exercise
+//!   `validate_per_line_ignores`.
 //!
 //! Deterministic siblings pin the empty-config, invalid-regex, billion-laughs, and
 //! valid-config cases so the random invariant cannot pass vacuously if the generator
@@ -116,6 +118,31 @@ fn billion_laughs_config_errors_without_panicking() {
         YamlLintConfig::from_yaml_str(&yaml).is_err(),
         "alias expansion must be capped and reported, not exhaust memory"
     );
+}
+
+#[test]
+fn per_line_ignores_config_is_handled_without_panicking() {
+    // Valid entry (regex + path + rules incl. ALL): parses, validates, normalizes.
+    parse_toml_without_panicking(
+        "[rules]\ncomments = \"enable\"\n\n[[per-line-ignores]]\nregex = \"^ok$\"\n\
+         path = \"*.yaml\"\nrules = [\"comments\", \"ALL\"]\n",
+    );
+    // Invalid entries must be rejected by validation (not panic): a bad regex, a bad
+    // glob, neither regex nor path, and an empty rules list.
+    for bad in [
+        "[[per-line-ignores]]\nregex = \"(\"\nrules = [\"comments\"]\n",
+        "[[per-line-ignores]]\npath = \"[\"\nrules = [\"comments\"]\n",
+        "[[per-line-ignores]]\nrules = [\"comments\"]\n",
+        "[[per-line-ignores]]\nregex = \"^ok$\"\nrules = []\n",
+    ] {
+        let typed = parse_toml_config_str(bad, false)
+            .expect("parses into the typed model")
+            .expect("standalone config is present");
+        assert!(
+            validate_toml_config(&typed).is_err(),
+            "invalid per-line-ignores entry must be rejected: {bad}"
+        );
+    }
 }
 
 #[test]

--- a/tests/property_config/strategy.rs
+++ b/tests/property_config/strategy.rs
@@ -38,11 +38,23 @@ pub struct RuleCfg {
     pub setting: Setting,
 }
 
+/// A generated `[[per-line-ignores]]` entry (TOML-only). `regex`/`path` are drawn from
+/// pools that mix valid with hostile (invalid regex/glob, empty), and `rules` may be
+/// empty or omit both regex and path, so every `validate_per_line_ignores` branch is
+/// reached and must error-or-succeed, never panic.
+#[derive(Debug, Clone)]
+pub struct PerLineModel {
+    pub regex: Option<&'static str>,
+    pub path: Option<&'static str>,
+    pub rules: Vec<&'static str>,
+}
+
 #[derive(Debug, Clone)]
 pub struct ConfigModel {
     pub rules: Vec<RuleCfg>,
     pub ignore: Option<Vec<&'static str>>,
     pub locale: Option<&'static str>,
+    pub per_line_ignores: Vec<PerLineModel>,
 }
 
 /// Regex strings spanning valid, invalid, and pathological-but-valid (the last to
@@ -51,6 +63,13 @@ const REGEX_POOL: &[&str] = &["^ok$", "(", "[", "(a+)+$", ".*", "[0-9]+"];
 const LEVELS: &[&str] = &["error", "warning", "bogus"];
 const LOCALES: &[&str] = &["en_US.UTF-8", "C", "garbage", "xx_XX"];
 const INTS: &[i64] = &[-1, 0, 1, 2, 80, 9999];
+/// Globs for `per-line-ignores` `path`, mixing valid (incl. `!` negation) with the
+/// invalid `[` so the glob-validation error branch is exercised.
+const PER_LINE_PATHS: &[&str] = &["*.yaml", "vendor/**", "!src/**", "[", ""];
+/// Real rule ids plus the `ALL` selector; an empty draw exercises the empty-`rules`
+/// validation error. Names stay valid so generation reaches `validate_per_line_ignores`
+/// rather than bouncing off `PerLineRule` deserialization.
+const PER_LINE_RULES: &[&str] = &["comments", "line-length", "trailing-spaces", "ALL"];
 
 /// What kind of value an option accepts; `arb` yields both well-typed and
 /// deliberately ill-typed values so validation is stressed.
@@ -156,6 +175,15 @@ fn arb_optval_for(
     kind.arb().prop_map(move |value| (key, value))
 }
 
+fn arb_per_line() -> impl Strategy<Value = PerLineModel> {
+    (
+        prop::option::of(prop::sample::select(REGEX_POOL)),
+        prop::option::of(prop::sample::select(PER_LINE_PATHS)),
+        prop::collection::vec(prop::sample::select(PER_LINE_RULES), 0..3),
+    )
+        .prop_map(|(regex, path, rules)| PerLineModel { regex, path, rules })
+}
+
 pub fn arb_config() -> impl Strategy<Value = ConfigModel> {
     (
         prop::collection::vec(arb_rule(), 0..6),
@@ -164,8 +192,9 @@ pub fn arb_config() -> impl Strategy<Value = ConfigModel> {
             0..3,
         )),
         prop::option::of(prop::sample::select(LOCALES)),
+        prop::collection::vec(arb_per_line(), 0..3),
     )
-        .prop_map(|(rules, ignore, locale)| ConfigModel {
+        .prop_map(|(rules, ignore, locale, per_line_ignores)| ConfigModel {
             // Drop duplicate rule ids: rendering the same id twice produces a
             // duplicate `[rules.<id>]` table (a hard TOML error) or a duplicate YAML
             // key, which would bounce a chunk of generated configs off the parser
@@ -173,6 +202,7 @@ pub fn arb_config() -> impl Strategy<Value = ConfigModel> {
             rules: dedup_rules(rules),
             ignore: ignore.map(|patterns| patterns.into_iter().collect()),
             locale,
+            per_line_ignores,
         })
 }
 
@@ -264,6 +294,20 @@ pub fn render_toml(model: &ConfigModel) -> String {
                 out.push_str(&format!("{key} = {}\n", render_optval_toml(value)));
             }
         }
+    }
+    // `per-line-ignores` is a top-level array of tables, TOML-only (the YAML path
+    // rejects it), so it is rendered here but not in `render_yaml`.
+    for entry in &model.per_line_ignores {
+        out.push_str("[[per-line-ignores]]\n");
+        if let Some(regex) = entry.regex {
+            out.push_str(&format!("regex = \"{regex}\"\n"));
+        }
+        if let Some(path) = entry.path {
+            out.push_str(&format!("path = \"{path}\"\n"));
+        }
+        let inner: Vec<String> =
+            entry.rules.iter().map(|r| format!("\"{r}\"")).collect();
+        out.push_str(&format!("rules = [{}]\n", inner.join(", ")));
     }
     out
 }

--- a/zensical.toml
+++ b/zensical.toml
@@ -22,6 +22,7 @@ nav = [
   { "Configuration" = [
     { "Presets" = "config-presets.md" },
     { "Inline directives" = "directives.md" },
+    { "Per-line ignores" = "per-line-ignores.md" },
     { "YAML in Markdown" = "markdown.md" },
   ]},
   { "YAML version compatibility" = "yaml-version.md" },


### PR DESCRIPTION
Closes #258.

## What

Adds a ryl-only TOML `[[per-line-ignores]]` table that suppresses chosen rules on source lines (and/or files) matching a pattern — the config-level complement to inline `# ryl disable-line`.

```toml
[[per-line-ignores]]
regex = '#\s*renovate:'   # optional: unanchored regex vs the whole physical source line
path  = "*.tpl.yaml"       # optional: glob vs the file path (per-file-ignores semantics, incl. ! negation)
rules = ["line-length"]     # required: rule ids, or ["ALL"]
```

- Present fields are ANDed; at least one of `regex`/`path` is required (a global rule-disable is rejected).
- **TOML-only** (rejected in yamllint-compatible YAML config), consistent with `per-file-ignores`.
- Modelled on golangci-lint's `exclude-rules` (`source` + `linters`). Supersedes the original narrow `comments.ignore-regex` scope of #258.

## How

Implemented as **config-driven virtual `disable-line` directives**: for the file being linted, entries whose `path` glob doesn't match are dropped, then each surviving entry's `rules` are added to `Directives.line_disabled` for every line matching `regex` (all lines if no `regex`). `Directives::is_disabled` (lint filtering) and `Directives::reconcile` (`--fix` edit-reversion) then apply unchanged — no parallel suppression engine.

- **Embedded Markdown**: `path` matches the host `.md`; `regex` matches the embedded YAML region line (region-local, like inline directives) — falls out of the per-region `lint_str` call.
- **`--fix`**: never rewrites a suppressed line; reconcile engages whenever a per-line entry targets the rule (a fixer could create a newly-matching line).
- Validation: bad regex/glob, neither-regex-nor-path, empty rules, unknown rule → config errors.

## Review

- Local `/code-review` (high) + a local Codex pass. Codex's one finding (`!` path negation parity) is fixed; engine, validation, markdown mapping, `--fix` reconcile, stdin, CRLF/multibyte all confirmed sound.
- prek green; full suite passes; coverage script reports zero missed lines/regions.
- Docs: new `docs/per-line-ignores.md` + nav + "How ryl differs from yamllint" entry; `ryl.toml.schema.json` regenerated.

Epic #261 updated: #258 detached (a suppression mechanism, not a rule); #257 ticked as shipped.