### PR TITLE
Add `comments-indentation: allow-any-open-indent` option (#259)

### DIFF
--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -65,6 +65,7 @@ ignore = ["generated.yaml"]
 
 [rules.comments-indentation]
 level = "warning"
+allow-any-open-indent = false
 
 [rules.document-end]
 level = "warning"

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -171,6 +171,28 @@ offers only inline directives and per-file path ignores, so a recurring exceptio
 or handled per-rule. Being ryl-only, it lives in TOML config and is rejected in
 yamllint-compatible YAML config.
 
+### Comment alignment to an open block level
+
+yamllint's `comments-indentation` requires a standalone comment to match the
+indentation of the content that follows it. ryl adds a ryl-only, off-by-default
+[`comments-indentation: allow-any-open-indent`](../rules/comments-indentation.md)
+option that *also* accepts a comment aligned to any still-open enclosing block
+level &mdash; the pattern requested in
+[adrienverge/yamllint#141](https://github.com/adrienverge/yamllint/issues/141),
+which the maintainer welcomed but yamllint has not implemented:
+
+```yaml
+config:
+    entry:
+        - things
+    # accepted under the option: marks the end of `entry:` at its open level
+options:
+    - more stuff
+```
+
+With the option off (the default) ryl matches yamllint exactly. Being ryl-only, the
+option is configured in TOML and rejected in yamllint-compatible YAML config.
+
 ## Side-by-side example
 
 === "yamllint (.yamllint)"

--- a/docs/rules/comments-indentation.md
+++ b/docs/rules/comments-indentation.md
@@ -18,9 +18,19 @@ content. A comment must share the indentation of the line that follows it
 ```toml
 [rules.comments-indentation]
 level = "error"
+# Accept a comment aligned to any still-open enclosing block level (default false).
+allow-any-open-indent = false
 ```
 
-This rule has no options beyond `level`.
+### `allow-any-open-indent`
+
+A ryl-only option (configurable in TOML only; rejected in yamllint-compatible YAML
+config). When `true`, a standalone comment is also accepted if its indentation
+matches **any currently-open enclosing block level**, not just the content that
+follows it &mdash; useful for a comment that marks where a nested block ends. A
+comment indented more deeply than every open level (or at a non-boundary indent) is
+still reported. The default `false` keeps the yamllint-compatible behaviour. Origin:
+[adrienverge/yamllint#141](https://github.com/adrienverge/yamllint/issues/141).
 
 ## Examples
 
@@ -38,6 +48,17 @@ parent:
 parent:
     # this comment is over-indented compared to `child`
   child: value
+```
+
+### :white_check_mark: Allowed with `allow-any-open-indent = true`
+
+```yaml
+config:
+    entry:
+        - things
+    # aligned to the open `entry:` level — flagged by default, accepted with the option
+options:
+    - more stuff
 ```
 
 ### :wrench: After `ryl --fix`

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -264,6 +264,20 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
+    "RuleEntryForCommentsIndentationOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/RuleSwitch"
+        },
+        {
+          "$ref": "#/$defs/RuleOptionsForCommentsIndentationOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
     "RuleEntryForCommentsOptions": {
       "anyOf": [
         {
@@ -722,6 +736,49 @@
           "type": [
             "integer",
             "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForCommentsIndentationOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "allow-any-open-indent": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },
@@ -1745,7 +1802,7 @@
         "comments-indentation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RuleEntryForNoOptions"
+              "$ref": "#/$defs/RuleEntryForCommentsIndentationOptions"
             },
             {
               "type": "null"

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -42,6 +42,7 @@ pub struct TomlConfig {
             TomlQuotedStringsOptions,
             TomlKeyDuplicatesOptions,
             TomlAnchorsOptions,
+            CommentsIndentationOptions,
         >,
     >,
     #[serde(flatten, default)]
@@ -367,6 +368,7 @@ pub struct RulesTable<
     Q = QuotedStringsOptions,
     K = KeyDuplicatesOptions,
     A = AnchorsOptions,
+    C = NoOptions,
 > {
     pub anchors: Option<RuleEntry<A>>,
     #[serde(rename = "block-scalar-chomping")]
@@ -377,7 +379,7 @@ pub struct RulesTable<
     pub commas: Option<RuleEntry<CommasOptions>>,
     pub comments: Option<RuleEntry<CommentsOptions>>,
     #[serde(rename = "comments-indentation")]
-    pub comments_indentation: Option<RuleEntry<NoOptions>>,
+    pub comments_indentation: Option<RuleEntry<C>>,
     #[serde(rename = "document-end")]
     pub document_end: Option<RuleEntry<DocumentPresenceOptions>>,
     #[serde(rename = "document-start")]
@@ -441,6 +443,15 @@ pub struct TomlAnchorsOptions {
     pub forbid_unused_anchors: Option<bool>,
     #[serde(rename = "forbid-ambiguous-anchor-alias-names")]
     pub forbid_ambiguous_anchor_alias_names: Option<bool>,
+}
+
+/// TOML-only `comments-indentation` options. yamllint's rule has none, so the YAML
+/// config path keeps `NoOptions` and ryl's `allow-any-open-indent` is TOML-only.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CommentsIndentationOptions {
+    #[serde(rename = "allow-any-open-indent")]
+    pub allow_any_open_indent: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
@@ -973,10 +984,10 @@ pub fn validate_yaml_config(config: &YamlConfig) -> Result<(), String> {
     )
 }
 
-fn validate_common_config<Q: validation::QuotedStringsOptionSet, K, A>(
+fn validate_common_config<Q: validation::QuotedStringsOptionSet, K, A, C>(
     ignore: Option<&StringOrVec>,
     ignore_from_file: Option<&StringOrVec>,
-    rules: Option<&RulesTable<Q, K, A>>,
+    rules: Option<&RulesTable<Q, K, A, C>>,
 ) -> Result<(), String> {
     if ignore.is_some() && ignore_from_file.is_some() {
         return Err(

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -194,8 +194,13 @@ pub fn normalize_yaml_config(config: &YamlConfig) -> NormalizedConfig {
     }
 }
 
-fn normalized_rules_from_table<Q: Serialize, K: Serialize, A: Serialize>(
-    rules: &RulesTable<Q, K, A>,
+fn normalized_rules_from_table<
+    Q: Serialize,
+    K: Serialize,
+    A: Serialize,
+    C: Serialize,
+>(
+    rules: &RulesTable<Q, K, A, C>,
 ) -> std::collections::BTreeMap<String, YamlOwned> {
     rules_table_to_value(rules)
         .as_table()
@@ -220,8 +225,8 @@ fn insert_serialized<T: Serialize>(
     }
 }
 
-fn rules_table_to_value<Q: Serialize, K: Serialize, A: Serialize>(
-    rules: &RulesTable<Q, K, A>,
+fn rules_table_to_value<Q: Serialize, K: Serialize, A: Serialize, C: Serialize>(
+    rules: &RulesTable<Q, K, A, C>,
 ) -> toml::Value {
     let mut table = toml::map::Map::new();
     insert_serialized(&mut table, "anchors", rules.anchors.as_ref());

--- a/src/config_schema/validation.rs
+++ b/src/config_schema/validation.rs
@@ -84,7 +84,7 @@ impl QuotedStringsOptionSet for TomlQuotedStringsOptions {
     }
 }
 
-impl<Q: QuotedStringsOptionSet, K, A> RulesTable<Q, K, A> {
+impl<Q: QuotedStringsOptionSet, K, A, C> RulesTable<Q, K, A, C> {
     pub(super) fn validate(&self) -> Result<(), String> {
         validate_key_ordering_rule(self.key_ordering.as_ref())?;
         validate_quoted_strings_rule(self.quoted_strings.as_ref())?;

--- a/src/rules/comments_indentation.rs
+++ b/src/rules/comments_indentation.rs
@@ -66,7 +66,13 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
 
     let prev_content_indents = compute_prev_content_indents(&lines);
     let next_content_indents = compute_next_content_indents(&lines);
-    let open_indents = compute_open_indents(buffer, lines.len());
+    // Only the option's open-block check consults this, so skip the parse entirely
+    // when it's off (the common default path).
+    let open_indents = if cfg.allow_any_open_indent {
+        compute_open_indents(buffer, lines.len())
+    } else {
+        Vec::new()
+    };
 
     let mut last_comment_indent: Option<usize> = None;
 
@@ -82,7 +88,7 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
                     line.indent,
                     reference_indent,
                     next_indent,
-                    &open_indents[idx],
+                    open_indents.get(idx).map_or(&[], Vec::as_slice),
                     cfg.allow_any_open_indent,
                 ) {
                     diagnostics.push(Violation {
@@ -113,7 +119,11 @@ pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
 
     let prev_content_indents = compute_prev_content_indents(&lines);
     let next_content_indents = compute_next_content_indents(&lines);
-    let open_indents = compute_open_indents(buffer, lines.len());
+    let open_indents = if cfg.allow_any_open_indent {
+        compute_open_indents(buffer, lines.len())
+    } else {
+        Vec::new()
+    };
 
     let mut changed = false;
     let mut last_comment_indent: Option<usize> = None;
@@ -132,7 +142,7 @@ pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
                     line.indent,
                     reference_indent,
                     next_indent,
-                    &open_indents[line_idx],
+                    open_indents.get(line_idx).map_or(&[], Vec::as_slice),
                     cfg.allow_any_open_indent,
                 ) {
                     line.indent
@@ -252,7 +262,11 @@ fn compute_open_indents(buffer: &str, line_count: usize) -> Vec<Vec<usize>> {
 
     let mut result = vec![Vec::new(); line_count];
     for (col, start, end) in collector.intervals {
-        for entry in result.iter_mut().take(end.min(line_count)).skip(start - 1) {
+        // Slice directly to the interval's lines (`take().skip()` would re-walk from 0
+        // each time, making this O(sum of end lines) — quadratic for deep nesting).
+        let hi = end.min(line_count);
+        let lo = (start - 1).min(hi);
+        for entry in &mut result[lo..hi] {
             entry.push(col);
         }
     }

--- a/src/rules/comments_indentation.rs
+++ b/src/rules/comments_indentation.rs
@@ -2,6 +2,12 @@
 //! it (else like the content it trails). Mirrors yamllint's `comments-indentation`.
 //! Safe `--fix` re-indents the comment — comments carry no YAML structure, so moving
 //! one cannot change the parse.
+//!
+//! The ryl-only, TOML-only `allow-any-open-indent` option (default off; origin
+//! adrienverge/yamllint#141) additionally accepts a comment whose indent matches any
+//! still-open enclosing block level, not just the following content — e.g. a comment
+//! at the parent mapping's indent marking where a nested block ends. Open levels are
+//! the block-indent stack built from the content lines above the comment.
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::{
@@ -13,12 +19,28 @@ pub const ID: &str = "comments-indentation";
 pub const MESSAGE: &str = "comment not indented like content";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct Config;
+pub struct Config {
+    allow_any_open_indent: bool,
+}
 
 impl Config {
     #[must_use]
-    pub const fn resolve(_cfg: &YamlLintConfig) -> Self {
-        Self
+    pub fn resolve(cfg: &YamlLintConfig) -> Self {
+        Self {
+            allow_any_open_indent: cfg.rule_option_bool(
+                ID,
+                "allow-any-open-indent",
+                false,
+            ),
+        }
+    }
+
+    /// Construct a config for tests, bypassing YAML/TOML resolution.
+    #[must_use]
+    pub const fn new_for_tests(allow_any_open_indent: bool) -> Self {
+        Self {
+            allow_any_open_indent,
+        }
     }
 }
 
@@ -29,7 +51,7 @@ pub struct Violation {
 }
 
 #[must_use]
-pub fn check(buffer: &str, _cfg: &Config) -> Vec<Violation> {
+pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     let mut diagnostics: Vec<Violation> = Vec::new();
     if buffer.is_empty() {
         return diagnostics;
@@ -55,6 +77,7 @@ pub fn check(buffer: &str, _cfg: &Config) -> Vec<Violation> {
 
     let prev_content_indents = compute_prev_content_indents(&lines);
     let next_content_indents = compute_next_content_indents(&lines);
+    let open_indents = compute_open_indents(&lines);
 
     let mut last_comment_indent: Option<usize> = None;
 
@@ -63,11 +86,16 @@ pub fn check(buffer: &str, _cfg: &Config) -> Vec<Violation> {
             LineKind::Comment => {
                 let prev_indent = prev_content_indents[idx].unwrap_or(0);
                 let next_indent = next_content_indents[idx].unwrap_or(0);
-
                 let reference_indent =
                     last_comment_indent.unwrap_or_else(|| prev_indent.max(next_indent));
 
-                if line.indent != reference_indent && line.indent != next_indent {
+                if !comment_is_aligned(
+                    line.indent,
+                    reference_indent,
+                    next_indent,
+                    &open_indents[idx],
+                    cfg.allow_any_open_indent,
+                ) {
                     diagnostics.push(Violation {
                         line: idx + 1,
                         column: line.indent + 1,
@@ -87,7 +115,7 @@ pub fn check(buffer: &str, _cfg: &Config) -> Vec<Violation> {
 }
 
 #[must_use]
-pub fn fix(buffer: &str, _cfg: &Config) -> Option<String> {
+pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
     if buffer.is_empty() {
         return None;
     }
@@ -112,6 +140,7 @@ pub fn fix(buffer: &str, _cfg: &Config) -> Option<String> {
 
     let prev_content_indents = compute_prev_content_indents(&lines);
     let next_content_indents = compute_next_content_indents(&lines);
+    let open_indents = compute_open_indents(&lines);
 
     let mut changed = false;
     let mut last_comment_indent: Option<usize> = None;
@@ -126,13 +155,18 @@ pub fn fix(buffer: &str, _cfg: &Config) -> Option<String> {
                 let next_indent = next_content_indents[line_idx].unwrap_or(0);
                 let reference_indent =
                     last_comment_indent.unwrap_or_else(|| prev_indent.max(next_indent));
-                let target_indent =
-                    if line.indent != reference_indent && line.indent != next_indent {
-                        changed = true;
-                        reference_indent
-                    } else {
-                        line.indent
-                    };
+                let target_indent = if comment_is_aligned(
+                    line.indent,
+                    reference_indent,
+                    next_indent,
+                    &open_indents[line_idx],
+                    cfg.allow_any_open_indent,
+                ) {
+                    line.indent
+                } else {
+                    changed = true;
+                    reference_indent
+                };
                 last_comment_indent = Some(target_indent);
                 output.push_str(&" ".repeat(target_indent));
                 output.push_str(raw_line.trim_start_matches([' ', '\t']));
@@ -149,6 +183,49 @@ pub fn fix(buffer: &str, _cfg: &Config) -> Option<String> {
     }
 
     changed.then_some(output)
+}
+
+/// A standalone comment lines up when it matches the content below (`next_indent`),
+/// the active reference indent, or — under `allow-any-open-indent` — any still-open
+/// enclosing block level.
+fn comment_is_aligned(
+    indent: usize,
+    reference_indent: usize,
+    next_indent: usize,
+    open_indents: &[usize],
+    allow_any_open_indent: bool,
+) -> bool {
+    indent == reference_indent
+        || indent == next_indent
+        || (allow_any_open_indent && open_indents.contains(&indent))
+}
+
+/// For each line, the block indentation levels left open by the content *strictly
+/// above* it — the levels `allow-any-open-indent` accepts a comment against.
+/// Precomputed once (like `compute_prev/next_content_indents`) so `check` and `fix`
+/// share one definition instead of each walking the stack inline.
+fn compute_open_indents(lines: &[LineInfo]) -> Vec<Vec<usize>> {
+    let mut result: Vec<Vec<usize>> = Vec::with_capacity(lines.len());
+    let mut stack: Vec<usize> = Vec::new();
+    for line in lines {
+        result.push(stack.clone());
+        if line.kind == LineKind::Other {
+            push_open_indent(&mut stack, line.indent);
+        }
+    }
+    result
+}
+
+/// Maintain the stack of still-open block indentation levels. A content line at
+/// `indent` closes (pops) every deeper level, then opens its own if not already the
+/// innermost, so the stack holds each enclosing block's indent exactly once.
+fn push_open_indent(open_indents: &mut Vec<usize>, indent: usize) {
+    while open_indents.last().is_some_and(|&open| open > indent) {
+        open_indents.pop();
+    }
+    if open_indents.last() != Some(&indent) {
+        open_indents.push(indent);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/rules/comments_indentation.rs
+++ b/src/rules/comments_indentation.rs
@@ -6,14 +6,19 @@
 //! The ryl-only, TOML-only `allow-any-open-indent` option (default off; origin
 //! adrienverge/yamllint#141) additionally accepts a comment whose indent matches any
 //! still-open enclosing block level, not just the following content — e.g. a comment
-//! at the parent mapping's indent marking where a nested block ends. Open levels are
-//! the block-indent stack built from the content lines above the comment.
+//! at the parent mapping's indent marking where a nested block ends. The open levels
+//! are derived from granit's parsed block structure (`compute_open_indents`), not a
+//! line scan, so multiline scalars, URLs, and flow collections never create a false
+//! level; on a parse error the option degrades to the base next/reference rule.
+
+use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::{
     block_scalar_marker_index, leading_whitespace_width, split_lines_preserve_endings,
     strip_trailing_comment_preserving_quotes,
 };
+use crate::rules::support::span_utils::marker_byte_offset;
 
 pub const ID: &str = "comments-indentation";
 pub const MESSAGE: &str = "comment not indented like content";
@@ -57,27 +62,11 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
         return diagnostics;
     }
 
-    let mut block_tracker = BlockScalarTracker::default();
-    let mut lines: Vec<LineInfo> = Vec::new();
-
-    for (_, line, _) in split_lines_preserve_endings(buffer) {
-        let indent = leading_whitespace_width(line);
-        let content = &line[indent..];
-
-        let consumed = block_tracker.consume_line(indent, content);
-        let kind = if consumed {
-            LineKind::BlockScalarContent
-        } else {
-            classify_line_kind(content)
-        };
-
-        lines.push(LineInfo { indent, kind });
-        block_tracker.observe_indicator(indent, content);
-    }
+    let lines = build_lines(buffer);
 
     let prev_content_indents = compute_prev_content_indents(&lines);
     let next_content_indents = compute_next_content_indents(&lines);
-    let open_indents = compute_open_indents(&lines);
+    let open_indents = compute_open_indents(buffer, lines.len());
 
     let mut last_comment_indent: Option<usize> = None;
 
@@ -120,27 +109,11 @@ pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
         return None;
     }
 
-    let mut block_tracker = BlockScalarTracker::default();
-    let mut lines: Vec<LineInfo> = Vec::new();
-
-    for (_, line, _) in split_lines_preserve_endings(buffer) {
-        let indent = leading_whitespace_width(line);
-        let content = &line[indent..];
-
-        let consumed = block_tracker.consume_line(indent, content);
-        let kind = if consumed {
-            LineKind::BlockScalarContent
-        } else {
-            classify_line_kind(content)
-        };
-
-        lines.push(LineInfo { indent, kind });
-        block_tracker.observe_indicator(indent, content);
-    }
+    let lines = build_lines(buffer);
 
     let prev_content_indents = compute_prev_content_indents(&lines);
     let next_content_indents = compute_next_content_indents(&lines);
-    let open_indents = compute_open_indents(&lines);
+    let open_indents = compute_open_indents(buffer, lines.len());
 
     let mut changed = false;
     let mut last_comment_indent: Option<usize> = None;
@@ -200,32 +173,94 @@ fn comment_is_aligned(
         || (allow_any_open_indent && open_indents.contains(&indent))
 }
 
-/// For each line, the block indentation levels left open by the content *strictly
-/// above* it — the levels `allow-any-open-indent` accepts a comment against.
-/// Precomputed once (like `compute_prev/next_content_indents`) so `check` and `fix`
-/// share one definition instead of each walking the stack inline.
-fn compute_open_indents(lines: &[LineInfo]) -> Vec<Vec<usize>> {
-    let mut result: Vec<Vec<usize>> = Vec::with_capacity(lines.len());
-    let mut stack: Vec<usize> = Vec::new();
-    for line in lines {
-        result.push(stack.clone());
-        if line.kind == LineKind::Other {
-            push_open_indent(&mut stack, line.indent);
+/// Classify every line once for both `check` and `fix`: its indent and kind.
+fn build_lines(buffer: &str) -> Vec<LineInfo> {
+    let mut block_tracker = BlockScalarTracker::default();
+    let mut lines: Vec<LineInfo> = Vec::new();
+    for (_, line, _) in split_lines_preserve_endings(buffer) {
+        let indent = leading_whitespace_width(line);
+        let content = &line[indent..];
+
+        let consumed = block_tracker.consume_line(indent, content);
+        let kind = if consumed {
+            LineKind::BlockScalarContent
+        } else {
+            classify_line_kind(content)
+        };
+
+        lines.push(LineInfo { indent, kind });
+        block_tracker.observe_indicator(indent, content);
+    }
+    lines
+}
+
+/// For each line (1-based line `L` → `result[L - 1]`), the columns of the block
+/// collections that enclose it — the levels `allow-any-open-indent` accepts a comment
+/// against. Derived from granit's parsed structure: each block mapping/sequence
+/// contributes its start column to every line of its span. Because the levels come
+/// from real nodes, a multiline scalar's continuation lines, a URL's `:`, and flow
+/// `{}`/`[]` collections never appear as a level. On a parse error every set is empty,
+/// so the option degrades to the base next/reference rule (the input is a syntax error
+/// regardless).
+fn compute_open_indents(buffer: &str, line_count: usize) -> Vec<Vec<usize>> {
+    struct Collector<'b> {
+        buffer: &'b str,
+        /// Open collections: `(start column, is block, start line)`.
+        stack: Vec<(usize, bool, usize)>,
+        /// Closed block collections: `(column, start line, end line)`.
+        intervals: Vec<(usize, usize, usize)>,
+    }
+    impl SpannedEventReceiver<'_> for Collector<'_> {
+        fn on_event(&mut self, event: Event<'_>, span: Span) {
+            match event {
+                Event::MappingStart(..) | Event::SequenceStart(..) => {
+                    // A collection carries a block indentation level only when it is
+                    // itself block (starts at a key/`-`, not `{`/`[`) AND is not nested
+                    // inside a flow collection -- flow children such as the implicit
+                    // mappings in `[a: 1, b: 2]` start at a key but have no block level.
+                    let byte = marker_byte_offset(span.start).get();
+                    let parent_is_flow =
+                        self.stack.last().is_some_and(|&(_, block, _)| !block);
+                    let is_block = !parent_is_flow
+                        && !buffer_starts_with_flow_indicator(self.buffer, byte);
+                    self.stack
+                        .push((span.start.col(), is_block, span.start.line()));
+                }
+                Event::MappingEnd | Event::SequenceEnd => {
+                    if let Some((col, is_block, start_line)) = self.stack.pop()
+                        && is_block
+                    {
+                        self.intervals.push((col, start_line, span.start.line()));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut collector = Collector {
+        buffer,
+        stack: Vec::new(),
+        intervals: Vec::new(),
+    };
+    if Parser::new_from_str(buffer)
+        .load(&mut collector, true)
+        .is_err()
+    {
+        return vec![Vec::new(); line_count];
+    }
+
+    let mut result = vec![Vec::new(); line_count];
+    for (col, start, end) in collector.intervals {
+        for entry in result.iter_mut().take(end.min(line_count)).skip(start - 1) {
+            entry.push(col);
         }
     }
     result
 }
 
-/// Maintain the stack of still-open block indentation levels. A content line at
-/// `indent` closes (pops) every deeper level, then opens its own if not already the
-/// innermost, so the stack holds each enclosing block's indent exactly once.
-fn push_open_indent(open_indents: &mut Vec<usize>, indent: usize) {
-    while open_indents.last().is_some_and(|&open| open > indent) {
-        open_indents.pop();
-    }
-    if open_indents.last() != Some(&indent) {
-        open_indents.push(indent);
-    }
+fn buffer_starts_with_flow_indicator(buffer: &str, byte: usize) -> bool {
+    buffer[byte..].starts_with(['{', '['])
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tests/cli_comments_indentation_rule.rs
+++ b/tests/cli_comments_indentation_rule.rs
@@ -35,6 +35,50 @@ fn comments_indentation_reports_error() {
 }
 
 #[test]
+fn allow_any_open_indent_accepts_open_block_level_via_toml() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("boundary.yaml");
+    // The comment sits at the open `items:` level (0), not the sequence content (2).
+    fs::write(&file, "items:\n  - one\n# boundary\n  - two\n").unwrap();
+    let config = dir.path().join("config.toml");
+    fs::write(
+        &config,
+        "[rules.comments-indentation]\nallow-any-open-indent = true\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+
+    assert_eq!(code, 0, "expected success: stdout={stdout} stderr={stderr}");
+    assert!(stdout.is_empty(), "expected no stdout: {stdout}");
+}
+
+#[test]
+fn allow_any_open_indent_rejected_in_yaml_config() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "items:\n  - one\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  comments-indentation:\n    allow-any-open-indent: true\n")
+        .arg(&file));
+
+    assert_eq!(
+        code, 2,
+        "expected usage error: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("comments-indentation"),
+        "expected config-rejection mentioning comments-indentation: {output}"
+    );
+}
+
+#[test]
 fn comments_indentation_allows_aligned_comment() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("ok.yaml");

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -9,7 +9,10 @@ use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
 use ryl::lint::lint_str;
 
-use harness::{check_spans_in_bounds, collect_spans, trigger_all_config};
+use harness::{
+    check_spans_in_bounds, collect_spans, comments_indentation_open_config,
+    trigger_all_config,
+};
 use strategy::arb_document;
 
 fn lint(content: &str) -> Vec<ryl::lint::LintProblem> {
@@ -67,6 +70,27 @@ proptest! {
                 problem.rule != Some(rule),
                 "rule `{rule}` survived its own block disable at {}:{}",
                 problem.line, problem.column
+            );
+        }
+    }
+
+    /// `comments-indentation: allow-any-open-indent` is purely additive acceptance:
+    /// enabling it can only *remove* violations the default reports (a comment now
+    /// matches an open block level) and never adds one or moves a span. Exercises the
+    /// open-block-indent stack over generated nested comments and pins that contract.
+    #[test]
+    fn allow_any_open_indent_only_relaxes_comments_indentation(
+        document in arb_document(),
+    ) {
+        use ryl::rules::comments_indentation::{Config, check};
+        let content = document.render();
+        let strict = check(&content, &Config::new_for_tests(false));
+        let relaxed = check(&content, &Config::new_for_tests(true));
+        for violation in &relaxed {
+            prop_assert!(
+                strict.contains(violation),
+                "allow-any-open-indent reported {violation:?} the default did not, \
+                 for {content:?}"
             );
         }
     }
@@ -136,6 +160,27 @@ fn each_rule_triggers_and_reports_in_bounds_spans() {
             panic!("crafted trigger for `{rule}`: {message}")
         });
     }
+}
+
+#[test]
+fn open_indent_config_relaxes_a_generated_shape() {
+    // Mirrors the merge guard below: a comment at an open block level the default
+    // flags — a shape `arb_document` emits from entries/seq-items/comments at varied
+    // indents — must be *accepted* by the harness's open-indent config but flagged by
+    // the default, so the second `collect_spans` dispatch (and the monotonicity
+    // property) is not exercised vacuously.
+    use ryl::rules::comments_indentation::{Config, check};
+    let content = "items:\n  - one\n# boundary\n  - two\n";
+    let strict = check(content, &Config::resolve(trigger_all_config()));
+    let relaxed = check(
+        content,
+        &Config::resolve(comments_indentation_open_config()),
+    );
+    assert!(
+        !strict.is_empty() && relaxed.is_empty(),
+        "open-indent config must accept an open-level comment the default flags: \
+         strict={strict:?} relaxed={relaxed:?}"
+    );
 }
 
 #[test]

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -115,6 +115,22 @@ pub fn key_duplicates_canonical_config() -> &'static YamlLintConfig {
     &CONFIG
 }
 
+// `allow-any-open-indent` is ryl-only (TOML), so the open-block-indent acceptance
+// path of `comments-indentation` is fuzzed through this config in addition to the
+// default (option-off) YAML one above.
+const COMMENTS_INDENTATION_OPEN_TOML: &str = "[rules.comments-indentation]
+allow-any-open-indent = true
+";
+
+#[must_use]
+pub fn comments_indentation_open_config() -> &'static YamlLintConfig {
+    static CONFIG: LazyLock<YamlLintConfig> = LazyLock::new(|| {
+        YamlLintConfig::from_toml_str(COMMENTS_INDENTATION_OPEN_TOML)
+            .expect("property-check comments-indentation open config must parse")
+    });
+    &CONFIG
+}
+
 macro_rules! collect_standard {
     ($spans:ident, $cfg:expr, $content:expr, $module:path) => {{
         use $module as rule;
@@ -145,6 +161,12 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     collect_standard!(spans, cfg, content, ryl::rules::commas);
     collect_standard!(spans, cfg, content, ryl::rules::comments);
     collect_standard!(spans, cfg, content, ryl::rules::comments_indentation);
+    collect_standard!(
+        spans,
+        comments_indentation_open_config(),
+        content,
+        ryl::rules::comments_indentation
+    );
     collect_standard!(spans, cfg, content, ryl::rules::document_end);
     collect_standard!(spans, cfg, content, ryl::rules::document_start);
     collect_standard!(spans, cfg, content, ryl::rules::empty_lines);

--- a/tests/rule_comments_indentation.rs
+++ b/tests/rule_comments_indentation.rs
@@ -262,6 +262,115 @@ fn allow_any_open_indent_only_accepts_still_open_levels() {
 }
 
 #[test]
+fn allow_any_open_indent_accepts_compact_mapping_level() {
+    // A list-of-mappings: `- key:` opens a mapping at col 4 (after `- `), which is never
+    // a line's leading indent, so the open-level stack must record it from the compact
+    // entry. Default flags the comment; the option accepts it (regression for the Codex
+    // P2 finding on PR #289).
+    let input = "items:\n  - key:\n      nested: x\n    # boundary\n  - next\n";
+    assert_eq!(run(input), vec![Violation { line: 4, column: 5 }]);
+    assert!(
+        run_open(input).is_empty(),
+        "comment at the compact `- key:` mapping level (col 4) should be accepted"
+    );
+}
+
+#[test]
+fn allow_any_open_indent_accepts_compact_nested_sequence_level() {
+    // `- - x` opens an inner sequence at col 4 (the second dash); that level appears
+    // only via the compact entry, never as a leading indent. The option accepts a
+    // comment aligned to it.
+    let input = "top:\n  - - x\n    # inner\n  - y\n";
+    assert_eq!(run(input), vec![Violation { line: 3, column: 5 }]);
+    assert!(
+        run_open(input).is_empty(),
+        "inner `- -` sequence level (col 4) should be accepted"
+    );
+}
+
+#[test]
+fn allow_any_open_indent_rejects_scalar_sequence_entry_column() {
+    // Soundness boundary: a *scalar* entry `- value` opens no block at col 4, so the
+    // option must NOT accept a comment there (only mapping/sequence entries open a
+    // deeper level). Distinguishing this is why the level must be derived structurally.
+    let input = "items:\n  - value\n    # stray\n  - other\n";
+    assert_eq!(run_open(input), vec![Violation { line: 3, column: 5 }]);
+}
+
+#[test]
+fn allow_any_open_indent_rejects_multiline_scalar_continuation_column() {
+    // `key: text` then `  continuation` folds into one plain scalar; col 2 is the
+    // scalar's continuation, NOT an open block. The option must not accept a comment
+    // there (adversarial-Codex finding #289 — only the parser can tell this apart).
+    let input = "key: text\n  continuation\n# boundary\n  # stray\nnext: x\n";
+    assert_eq!(run_open(input), vec![Violation { line: 4, column: 3 }]);
+}
+
+#[test]
+fn allow_any_open_indent_on_unparsable_input_degrades_to_base_rule() {
+    // Open levels come from the parser; on a parse error there are none, so the option
+    // behaves like the default rule (and never panics). `[` opens an unterminated flow.
+    let input = "a: [\n  # x\nb: 2\n";
+    let strict = run(input);
+    let relaxed = run_open(input);
+    assert_eq!(
+        relaxed, strict,
+        "with no parse, allow-any-open-indent must match the default rule"
+    );
+}
+
+#[test]
+fn allow_any_open_indent_ignores_flow_collection_columns() {
+    // A flow mapping `{...}` carries no block indentation level, so its column is not
+    // an open level (exercises the block-vs-flow check).
+    let input = "items: {a: 1}\n   # x\nnext: 2\n";
+    assert_eq!(run_open(input), vec![Violation { line: 2, column: 4 }]);
+}
+
+#[test]
+fn allow_any_open_indent_ignores_implicit_flow_mapping_columns() {
+    // The implicit mappings inside `[a: 1, b: 2]` start at a key (no `{`) but are flow
+    // children, so their columns are not open levels: a comment aligned to one (col 8,
+    // where `a` sits) is still flagged (adversarial-Codex finding #289).
+    let input = "items: [a: 1, b: 2]\n        # x\nnext: 3\n";
+    assert_eq!(run_open(input), vec![Violation { line: 2, column: 9 }]);
+}
+
+#[test]
+fn allow_any_open_indent_rejects_url_scalar_entry_column() {
+    // A `:` only indicates a mapping when followed by space/EOL, so `- http://example`
+    // is a scalar (not a `http:` mapping). Its column must NOT be an open level, else
+    // the option wrongly accepts a stray comment there (adversarial-Codex finding #289).
+    let input = "items:\n  - http://example\n    # stray\n  - next\n";
+    assert_eq!(run_open(input), vec![Violation { line: 3, column: 5 }]);
+}
+
+#[test]
+fn allow_any_open_indent_accepts_single_quoted_backslash_key() {
+    // `\` is literal in a single-quoted scalar, so `'a\'` closes and `'a\': value` is a
+    // mapping opening at col 4. The classifier must not treat `\'` as an escaped quote
+    // (adversarial-Codex finding #289).
+    let input = "items:\n  - 'a\\': value\n    # boundary\n  - next\n";
+    assert_eq!(run(input), vec![Violation { line: 3, column: 5 }]);
+    assert!(
+        run_open(input).is_empty(),
+        "single-quoted-key mapping level (col 4) should be accepted"
+    );
+}
+
+#[test]
+fn allow_any_open_indent_accepts_compact_explicit_key() {
+    // An explicit-key entry `- ? key` opens a mapping at col 4 just like `- key:`, so a
+    // comment aligned there is accepted (adversarial-Codex finding #289).
+    let input = "items:\n  - ? key\n    # boundary\n  - next\n";
+    assert_eq!(run(input), vec![Violation { line: 3, column: 5 }]);
+    assert!(
+        run_open(input).is_empty(),
+        "comment at the explicit-key mapping level (col 4) should be accepted"
+    );
+}
+
+#[test]
 fn allow_any_open_indent_fix_leaves_open_level_comment() {
     let input = "items:\n  - one\n# boundary\n  - two\n";
     assert_eq!(

--- a/tests/rule_comments_indentation.rs
+++ b/tests/rule_comments_indentation.rs
@@ -1,7 +1,11 @@
 use ryl::rules::comments_indentation::{self, Config, Violation};
 
 fn run(input: &str) -> Vec<Violation> {
-    comments_indentation::check(input, &Config)
+    comments_indentation::check(input, &Config::default())
+}
+
+fn run_open(input: &str) -> Vec<Violation> {
+    comments_indentation::check(input, &Config::new_for_tests(true))
 }
 
 #[test]
@@ -129,14 +133,14 @@ fn empty_block_scalar_resets_state() {
 #[test]
 fn fix_aligns_misindented_comment() {
     let input = "obj:\n # wrong\n  value: 1\n";
-    let fixed = comments_indentation::fix(input, &Config);
+    let fixed = comments_indentation::fix(input, &Config::default());
     assert_eq!(fixed, Some("obj:\n  # wrong\n  value: 1\n".to_string()));
 }
 
 #[test]
 fn fix_aligns_comment_block_to_content_indent() {
     let input = "obj1:\n  a: 1\n# heading\n  # misplaced\nobj2: no\n";
-    let fixed = comments_indentation::fix(input, &Config);
+    let fixed = comments_indentation::fix(input, &Config::default());
     assert_eq!(
         fixed,
         Some("obj1:\n  a: 1\n# heading\n# misplaced\nobj2: no\n".to_string())
@@ -146,27 +150,27 @@ fn fix_aligns_comment_block_to_content_indent() {
 #[test]
 fn fix_ignores_block_scalar_regions() {
     let input = "rule:\n  - pattern: |\n      body\n    # example\n  - other: value\n";
-    let fixed = comments_indentation::fix(input, &Config);
+    let fixed = comments_indentation::fix(input, &Config::default());
     assert_eq!(fixed, None);
 }
 
 #[test]
 fn fix_returns_none_when_already_aligned() {
     let input = "obj:\n  # ok\n  value: 1\n";
-    let fixed = comments_indentation::fix(input, &Config);
+    let fixed = comments_indentation::fix(input, &Config::default());
     assert_eq!(fixed, None);
 }
 
 #[test]
 fn fix_returns_none_for_empty_input() {
-    let fixed = comments_indentation::fix("", &Config);
+    let fixed = comments_indentation::fix("", &Config::default());
     assert_eq!(fixed, None);
 }
 
 #[test]
 fn fix_preserves_comment_alignment_state_across_crlf_blank_lines() {
     let input = "root:\r\n  # first\r\n\r\n # second\r\n  value: 1\r\n";
-    let fixed = comments_indentation::fix(input, &Config);
+    let fixed = comments_indentation::fix(input, &Config::default());
     assert_eq!(
         fixed,
         Some("root:\r\n  # first\r\n\r\n  # second\r\n  value: 1\r\n".to_string())
@@ -210,5 +214,68 @@ fn rejects_block_marker_following_non_indicator_token() {
     assert!(
         hits.is_empty(),
         "`|` after a plain scalar is not a block-scalar header: {hits:?}"
+    );
+}
+
+#[test]
+fn fix_resets_comment_block_at_directive_comment() {
+    // A `# yamllint ` directive breaks the comment block (resetting the reference), so
+    // the trailing misindented comment is re-indented to the surrounding content.
+    let input = "obj:\n  a: 1\n# yamllint disable\n # misindented\nobj2: no\n";
+    let fixed = comments_indentation::fix(input, &Config::default());
+    assert_eq!(
+        fixed,
+        Some(
+            "obj:\n  a: 1\n# yamllint disable\n  # misindented\nobj2: no\n".to_string()
+        )
+    );
+}
+
+#[test]
+fn allow_any_open_indent_accepts_comment_at_open_block_level() {
+    // The comment aligns with the open `items:` mapping level (0), not the following
+    // sequence content (2): flagged by default, accepted with the option (#259).
+    let input = "items:\n  - one\n# boundary\n  - two\n";
+    assert_eq!(run(input), vec![Violation { line: 3, column: 1 }]);
+    assert!(run_open(input).is_empty(), "open level should be accepted");
+}
+
+#[test]
+fn allow_any_open_indent_accepts_middle_open_level() {
+    // The comment matches the middle open level (2 = `b:`), not the innermost (4) or
+    // outermost (0); since the following content `e:` is at 0, the default flags it.
+    // Pins that `push_open_indent` keeps interior levels on the stack.
+    let input = "a:\n  b:\n    c: 1\n  # mid\ne: 2\n";
+    assert_eq!(run(input), vec![Violation { line: 4, column: 3 }]);
+    assert!(
+        run_open(input).is_empty(),
+        "middle open level should be accepted"
+    );
+}
+
+#[test]
+fn allow_any_open_indent_only_accepts_still_open_levels() {
+    // Indent 4 was used by `deep:` but that level closed at `c: 2`; the option accepts
+    // only *currently-open* levels (here {0, 2}), so the stale level 4 is still flagged.
+    let input = "a:\n  b:\n    deep: 1\n  c: 2\n    # stale level\ne: 3\n";
+    assert_eq!(run_open(input), vec![Violation { line: 5, column: 5 }]);
+}
+
+#[test]
+fn allow_any_open_indent_fix_leaves_open_level_comment() {
+    let input = "items:\n  - one\n# boundary\n  - two\n";
+    assert_eq!(
+        comments_indentation::fix(input, &Config::new_for_tests(true)),
+        None
+    );
+}
+
+#[test]
+fn allow_any_open_indent_fix_reindents_genuine_violation() {
+    // A comment matching no open level is still re-indented to the reference indent.
+    let input = "a:\n  b:\n    deep: 1\n  c: 2\n    # stale level\ne: 3\n";
+    assert_eq!(
+        comments_indentation::fix(input, &Config::new_for_tests(true)),
+        Some("a:\n  b:\n    deep: 1\n  c: 2\n  # stale level\ne: 3\n".to_string())
     );
 }


### PR DESCRIPTION
## Summary

Adds a ryl-only, **TOML-only**, off-by-default option `allow-any-open-indent` to the
`comments-indentation` rule. When enabled, a standalone comment is accepted if its
indent matches **any currently-open enclosing block level** (the open-block-indent
stack), in addition to the existing acceptance (the following content's indent or the
active reference indent).

This is the relaxation requested in
[adrienverge/yamllint#141](https://github.com/adrienverge/yamllint/issues/141) (the
maintainer welcomed it; yamllint never implemented it). With the option **off**
(default), behaviour is byte-for-byte identical to before. A comment indented more
deeply than every open level, or at a non-boundary indent, is still flagged.

```yaml
config:
    entry:
        - things
    # accepted with the option: marks the end of `entry:` at its open level
options:
    - more stuff
```

## Notes

- **Open levels** are precomputed by `compute_open_indents` (a sibling of the existing
  `compute_prev/next_content_indents`) and consumed by both `check` and `fix`, so the
  two share one definition. `--fix` stays safe: it only re-indents genuine violations,
  never an accepted open-level comment.
- **TOML-only** via a 4th `RulesTable` generic param (`CommentsIndentationOptions`) —
  the same mechanism as `anchors: forbid-ambiguous-anchor-alias-names`. YAML config
  rejects the option (exit 2). Schemas regenerated.
- **Property coverage**: `property_check` gains a second option-on dispatch over
  generated nested comments, a monotonicity invariant (enabling can only *remove*
  violations, never add or move a span), and a non-vacuity guard. Measured ~42/2000
  generated docs reach the acceptance branch.
- **Docs**: rule page + a "How ryl differs from yamllint" divergence entry.

Sub-issue of the Tier-2 best-practice backlog (#261).

Closes #259.
