### PR TITLE
Add `hyphens: dash-on-own-line` option (#260)

### DIFF
--- a/.ryl.toml.example
+++ b/.ryl.toml.example
@@ -97,6 +97,7 @@ forbid-inf = true
 [rules.hyphens]
 level = "warning"
 max-spaces-after = 1
+dash-on-own-line = false
 
 [rules.indentation]
 level = "warning"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,9 @@ the unsafe-trigger subset in that rule's module-level doc comment instead.
   representation and, in tagged or string-typed consumers, its semantic value.
 - `hyphens` — Collapsing trailing spaces after `-` in a block sequence
   changes the indent of any nested block mapping/sequence that follows on
-  subsequent lines and so can change the parsed structure.
+  subsequent lines and so can change the parsed structure; the `dash-on-own-line`
+  option is likewise no-fix, since breaking the `-` onto its own line re-indents
+  the mapping body.
 - `indentation` — Re-indenting alters the block-structure boundaries the
   YAML grammar uses to delimit mappings, sequences, and scalars; any
   non-trivial fix risks changing the parsed value.

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -193,6 +193,27 @@ options:
 With the option off (the default) ryl matches yamllint exactly. Being ryl-only, the
 option is configured in TOML and rejected in yamllint-compatible YAML config.
 
+### Dash on its own line before a block mapping
+
+yamllint's `hyphens` rule only limits the spaces after a `-`. ryl adds a ryl-only,
+off-by-default [`hyphens: dash-on-own-line`](../rules/hyphens.md) option that requires a
+block-sequence entry's `-` to be on its own line when the entry is a block mapping
+&mdash; the spec-style "sequence of mappings" layout requested in
+[adrienverge/yamllint#527](https://github.com/adrienverge/yamllint/issues/527), which
+the maintainer welcomed but yamllint has not implemented:
+
+```yaml
+items:
+  - name: web    # flagged under the option: mapping starts on the dash line
+    port: 80
+  -
+    name: db     # accepted: dash alone, mapping body indented below
+    port: 90
+```
+
+With the option off (the default) ryl matches yamllint exactly. Being ryl-only, the
+option is configured in TOML and rejected in yamllint-compatible YAML config.
+
 ## Side-by-side example
 
 === "yamllint (.yamllint)"

--- a/docs/rules/hyphens.md
+++ b/docs/rules/hyphens.md
@@ -18,11 +18,16 @@ block sequences.
 [rules.hyphens]
 level = "error"
 max-spaces-after = 1
+dash-on-own-line = false
 ```
 
 | Option | Default | Description |
 | :--- | :--- | :--- |
 | `max-spaces-after` | `1` | Maximum spaces between the `-` and the item value. |
+| `dash-on-own-line` | `false` | Require the `-` on its own line when the entry is a block mapping (ryl-only; TOML config only). |
+
+`dash-on-own-line` is a ryl-only extension with no yamllint counterpart, so it is
+configured in TOML config only and rejected in yamllint-compatible YAML config.
 
 ## Examples
 
@@ -50,9 +55,33 @@ list:
   -   second
 ```
 
+### :x: Reported (with `dash-on-own-line: true`)
+
+The mapping starts on the dash's line, so the `-` is not on its own line:
+
+```yaml
+items:
+  - name: web
+    port: 80
+```
+
+### :white_check_mark: Allowed (with `dash-on-own-line: true`)
+
+The `-` stands alone and the mapping body is indented below it (a dash carrying
+only an anchor/tag or a comment is also accepted, since the keys remain below):
+
+```yaml
+items:
+  -
+    name: web
+    port: 80
+```
+
 ## Automatic fixing
 
-This rule does not auto-fix; trim the extra spaces manually.
+This rule does not auto-fix. Trim the extra spaces (`max-spaces-after`) or break the
+mapping onto the line below the `-` (`dash-on-own-line`) manually: re-indenting the
+mapping body is a structural change ryl will not make automatically.
 
 ## Related rules
 

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -348,20 +348,6 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
-    "RuleEntryForHyphensOptions": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/RuleSwitch"
-        },
-        {
-          "$ref": "#/$defs/RuleOptionsForHyphensOptions"
-        }
-      ],
-      "description": "Common rule entry shape used by TOML config."
-    },
     "RuleEntryForIndentationOptions": {
       "anyOf": [
         {
@@ -470,6 +456,20 @@
         },
         {
           "$ref": "#/$defs/RuleOptionsForTomlAnchorsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForTomlHyphensOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/RuleSwitch"
+        },
+        {
+          "$ref": "#/$defs/RuleOptionsForTomlHyphensOptions"
         }
       ],
       "description": "Common rule entry shape used by TOML config."
@@ -1057,50 +1057,6 @@
       },
       "type": "object"
     },
-    "RuleOptionsForHyphensOptions": {
-      "additionalProperties": false,
-      "description": "Common rule fields plus rule-specific options.",
-      "properties": {
-        "ignore": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "ignore-from-file": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "level": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RuleLevel"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "max-spaces-after": {
-          "format": "int64",
-          "type": [
-            "integer",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
     "RuleOptionsForIndentationOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1518,6 +1474,56 @@
       },
       "type": "object"
     },
+    "RuleOptionsForTomlHyphensOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "dash-on-own-line": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max-spaces-after": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "RuleOptionsForTomlKeyDuplicatesOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1862,7 +1868,7 @@
         "hyphens": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RuleEntryForHyphensOptions"
+              "$ref": "#/$defs/RuleEntryForTomlHyphensOptions"
             },
             {
               "type": "null"

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -43,6 +43,7 @@ pub struct TomlConfig {
             TomlKeyDuplicatesOptions,
             TomlAnchorsOptions,
             CommentsIndentationOptions,
+            TomlHyphensOptions,
         >,
     >,
     #[serde(flatten, default)]
@@ -369,6 +370,7 @@ pub struct RulesTable<
     K = KeyDuplicatesOptions,
     A = AnchorsOptions,
     C = NoOptions,
+    H = HyphensOptions,
 > {
     pub anchors: Option<RuleEntry<A>>,
     #[serde(rename = "block-scalar-chomping")]
@@ -390,7 +392,7 @@ pub struct RulesTable<
     pub empty_values: Option<RuleEntry<EmptyValuesOptions>>,
     #[serde(rename = "float-values")]
     pub float_values: Option<RuleEntry<FloatValuesOptions>>,
-    pub hyphens: Option<RuleEntry<HyphensOptions>>,
+    pub hyphens: Option<RuleEntry<H>>,
     pub indentation: Option<RuleEntry<IndentationOptions>>,
     #[serde(rename = "key-duplicates")]
     pub key_duplicates: Option<RuleEntry<K>>,
@@ -557,6 +559,17 @@ pub struct FloatValuesOptions {
 pub struct HyphensOptions {
     #[serde(rename = "max-spaces-after")]
     pub max_spaces_after: Option<i64>,
+}
+
+/// TOML-only `hyphens` options: the yamllint-compatible `max-spaces-after` plus ryl's
+/// `dash-on-own-line`, which has no YAML-config equivalent.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TomlHyphensOptions {
+    #[serde(rename = "max-spaces-after")]
+    pub max_spaces_after: Option<i64>,
+    #[serde(rename = "dash-on-own-line")]
+    pub dash_on_own_line: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
@@ -984,10 +997,10 @@ pub fn validate_yaml_config(config: &YamlConfig) -> Result<(), String> {
     )
 }
 
-fn validate_common_config<Q: validation::QuotedStringsOptionSet, K, A, C>(
+fn validate_common_config<Q: validation::QuotedStringsOptionSet, K, A, C, H>(
     ignore: Option<&StringOrVec>,
     ignore_from_file: Option<&StringOrVec>,
-    rules: Option<&RulesTable<Q, K, A, C>>,
+    rules: Option<&RulesTable<Q, K, A, C, H>>,
 ) -> Result<(), String> {
     if ignore.is_some() && ignore_from_file.is_some() {
         return Err(

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -199,8 +199,9 @@ fn normalized_rules_from_table<
     K: Serialize,
     A: Serialize,
     C: Serialize,
+    H: Serialize,
 >(
-    rules: &RulesTable<Q, K, A, C>,
+    rules: &RulesTable<Q, K, A, C, H>,
 ) -> std::collections::BTreeMap<String, YamlOwned> {
     rules_table_to_value(rules)
         .as_table()
@@ -225,8 +226,14 @@ fn insert_serialized<T: Serialize>(
     }
 }
 
-fn rules_table_to_value<Q: Serialize, K: Serialize, A: Serialize, C: Serialize>(
-    rules: &RulesTable<Q, K, A, C>,
+fn rules_table_to_value<
+    Q: Serialize,
+    K: Serialize,
+    A: Serialize,
+    C: Serialize,
+    H: Serialize,
+>(
+    rules: &RulesTable<Q, K, A, C, H>,
 ) -> toml::Value {
     let mut table = toml::map::Map::new();
     insert_serialized(&mut table, "anchors", rules.anchors.as_ref());

--- a/src/config_schema/validation.rs
+++ b/src/config_schema/validation.rs
@@ -84,7 +84,7 @@ impl QuotedStringsOptionSet for TomlQuotedStringsOptions {
     }
 }
 
-impl<Q: QuotedStringsOptionSet, K, A, C> RulesTable<Q, K, A, C> {
+impl<Q: QuotedStringsOptionSet, K, A, C, H> RulesTable<Q, K, A, C, H> {
     pub(super) fn validate(&self) -> Result<(), String> {
         validate_key_ordering_rule(self.key_ordering.as_ref())?;
         validate_quoted_strings_rule(self.quoted_strings.as_ref())?;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -258,7 +258,7 @@ fn collect_block_diagnostics(
 ) {
     lint_rule!(diagnostics, cfg, content, path, base_dir, key_duplicates);
     lint_rule!(diagnostics, cfg, content, path, base_dir, key_ordering);
-    lint_rule!(diagnostics, cfg, content, path, base_dir, hyphens, message);
+    lint_rule!(diagnostics, cfg, content, path, base_dir, hyphens);
     lint_rule!(
         diagnostics,
         cfg,

--- a/src/rules/hyphens.rs
+++ b/src/rules/hyphens.rs
@@ -1,17 +1,43 @@
 //! `hyphens`: at most `max-spaces-after` spaces after a block-sequence `-` (default
-//! 1). Mirrors yamllint's `hyphens`. No safe `--fix`: collapsing the spaces shifts the
-//! indent of any nested block that follows on later lines, which can change the parsed
-//! structure.
+//! 1). Mirrors yamllint's `hyphens`.
+//!
+//! Sources: yamllint `hyphens`; YAML 1.2.2 block-sequence grammar; the
+//! `dash-on-own-line` option originates in adrienverge/yamllint#527 (spec-style
+//! "sequence of mappings" layout), which the maintainer welcomed but yamllint has not
+//! implemented.
+//!
+//! The ryl-only, TOML-only `dash-on-own-line` option (default off) additionally
+//! requires a block-sequence entry's `-` to sit on its own line when the entry is a
+//! block mapping, so a mapping body is indented *below* the dash rather than starting
+//! on it. It flags only an entry whose first mapping key shares the dash's line
+//! (`- name: web`); the body-below form (`-` then `  name: web`) is accepted, as is a
+//! dash line carrying only node properties (`- &a !tag` with keys below) or a comment.
+//! The signal is parser-derived, not a char scan: granit's scanner emits `BlockEntry`
+//! then, for a block-mapping entry, `BlockMappingStart`; when both land on the same
+//! line the mapping opened on the dash line. Non-mapping entries (scalars, aliases,
+//! nested sequences, flow values) emit a different value token and a block mapping that
+//! is a *mapping* value (no preceding `BlockEntry`) is never reported.
+//!
+//! No safe `--fix`: collapsing the spaces shifts the indent of any nested block that
+//! follows (`max-spaces-after`), and breaking the dash onto its own line re-indents the
+//! mapping body (`dash-on-own-line`) — both can change the parsed structure.
+
+use granit_parser::{Scanner, StrInput, TokenType};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::split_lines_preserve_endings;
+use crate::rules::support::punctuation::{build_line_starts, line_and_column};
+use crate::rules::support::span_utils::CharPos;
 
 pub const ID: &str = "hyphens";
 pub const MESSAGE: &str = "too many spaces after hyphen";
+pub const MESSAGE_DASH_ON_OWN_LINE: &str =
+    "block mapping should start on a new line after the hyphen";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Config {
     max_spaces_after: i64,
+    dash_on_own_line: bool,
 }
 
 impl Config {
@@ -25,12 +51,22 @@ impl Config {
                 "max-spaces-after",
                 Self::DEFAULT_MAX,
             ),
+            dash_on_own_line: cfg.rule_option_bool(ID, "dash-on-own-line", false),
         }
     }
 
     #[must_use]
     pub const fn new_for_tests(max_spaces_after: i64) -> Self {
-        Self { max_spaces_after }
+        Self {
+            max_spaces_after,
+            dash_on_own_line: false,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_dash_on_own_line(mut self, value: bool) -> Self {
+        self.dash_on_own_line = value;
+        self
     }
 
     #[must_use]
@@ -39,14 +75,26 @@ impl Config {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Violation {
     pub line: usize,
     pub column: usize,
+    pub message: String,
 }
 
 #[must_use]
 pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
+    let mut violations = collect_max_spaces(buffer, cfg.max_spaces_after);
+    if cfg.dash_on_own_line {
+        violations.extend(collect_dash_on_own_line(buffer));
+        // Two independent passes append out of document order; restore it (no later
+        // per-rule sort exists in `lint`, and yamllint reports a file in line/col order).
+        violations.sort_by_key(|a| (a.line, a.column));
+    }
+    violations
+}
+
+fn collect_max_spaces(buffer: &str, max_spaces_after: i64) -> Vec<Violation> {
     let mut violations = Vec::new();
 
     for (idx, line, _ending) in split_lines_preserve_endings(buffer) {
@@ -98,12 +146,59 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
 
         let spaces_count = i64::try_from(spaces_after).unwrap_or(i64::MAX);
 
-        if spaces_count > cfg.max_spaces_after {
+        if spaces_count > max_spaces_after {
             let column = indent_chars + 1 + spaces_after;
             violations.push(Violation {
                 line: idx + 1,
                 column,
+                message: MESSAGE.to_string(),
             });
+        }
+    }
+
+    violations
+}
+
+/// Flag every block-sequence entry whose block mapping opens on the dash's line.
+///
+/// granit's scanner emits `BlockEntry` (the `-`), optional node properties
+/// (`Anchor`/`Tag`/`Comment`), then the entry's value token. A `BlockMappingStart` on
+/// the same line as its `BlockEntry` means the mapping began on the dash line; any
+/// other value token (scalar, alias, nested `BlockSequenceStart`, flow `*Start`) is a
+/// non-mapping entry and clears the pending dash. Positions go through ryl's CR-aware
+/// `line_and_column` so a bare `\r` keeps the reported span in bounds. The scanner is a
+/// lexer, so unparsable input simply yields the tokens it can — no panic.
+fn collect_dash_on_own_line(buffer: &str) -> Vec<Violation> {
+    let char_indices: Vec<(usize, char)> = buffer.char_indices().collect();
+    let line_starts = build_line_starts(&char_indices);
+    let mut violations = Vec::new();
+    let mut dash_line: Option<usize> = None;
+
+    for token in Scanner::new(StrInput::new(buffer)) {
+        match token.1 {
+            TokenType::BlockEntry => {
+                let (line, _) =
+                    line_and_column(&line_starts, CharPos::new(token.0.start.index()));
+                dash_line = Some(line);
+            }
+            // Node properties decorate the entry's value without ending the dash.
+            TokenType::Anchor(_) | TokenType::Tag(..) | TokenType::Comment(_) => {}
+            TokenType::BlockMappingStart => {
+                if let Some(dash) = dash_line.take() {
+                    let (line, column) = line_and_column(
+                        &line_starts,
+                        CharPos::new(token.0.start.index()),
+                    );
+                    if line == dash {
+                        violations.push(Violation {
+                            line,
+                            column,
+                            message: MESSAGE_DASH_ON_OWN_LINE.to_string(),
+                        });
+                    }
+                }
+            }
+            _ => dash_line = None,
         }
     }
 

--- a/tests/cli_hyphens_rule.rs
+++ b/tests/cli_hyphens_rule.rs
@@ -79,6 +79,69 @@ fn rule_ignore_skips_file() {
 }
 
 #[test]
+fn dash_on_own_line_flags_inline_mapping_via_toml() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("inline.yaml");
+    fs::write(&file, "items:\n  - name: web\n    port: 80\n").unwrap();
+    let config = dir.path().join("config.toml");
+    fs::write(&config, "[rules.hyphens]\ndash-on-own-line = true\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+
+    assert_eq!(code, 1, "expected failure: stdout={stdout} stderr={stderr}");
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("block mapping should start on a new line after the hyphen"),
+        "missing dash-on-own-line message: {output}"
+    );
+    // Bare `line:col` (the mapping key) and bare rule id appear in both output formats.
+    assert!(output.contains("2:5"), "expected span at the key: {output}");
+    assert!(output.contains("hyphens"), "rule id missing: {output}");
+}
+
+#[test]
+fn dash_on_own_line_accepts_dash_alone_via_toml() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("own-line.yaml");
+    // Dash alone with the mapping body indented below is the layout the option wants.
+    fs::write(&file, "items:\n  -\n    name: web\n    port: 80\n").unwrap();
+    let config = dir.path().join("config.toml");
+    fs::write(&config, "[rules.hyphens]\ndash-on-own-line = true\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) =
+        run(Command::new(exe).arg("-c").arg(&config).arg(&file));
+
+    assert_eq!(code, 0, "expected success: stdout={stdout} stderr={stderr}");
+    assert!(stdout.trim().is_empty(), "expected no stdout: {stdout}");
+}
+
+#[test]
+fn dash_on_own_line_rejected_in_yaml_config() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("doc.yaml");
+    fs::write(&file, "items:\n  - name: web\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("-d")
+        .arg("rules:\n  hyphens:\n    dash-on-own-line: true\n")
+        .arg(&file));
+
+    assert_eq!(
+        code, 2,
+        "ryl-only option must be rejected in YAML config: stdout={stdout} stderr={stderr}"
+    );
+    let output = if stderr.is_empty() { stdout } else { stderr };
+    assert!(
+        output.contains("hyphens"),
+        "expected config rejection mentioning hyphens: {output}"
+    );
+}
+
+#[test]
 fn custom_max_allows_extra_spacing() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("custom.yaml");

--- a/tests/config_hyphens.rs
+++ b/tests/config_hyphens.rs
@@ -1,5 +1,5 @@
 use ryl::config::YamlLintConfig;
-use ryl::rules::hyphens::Config;
+use ryl::rules::hyphens::{self, Config};
 
 #[test]
 fn rejects_unknown_option() {
@@ -34,6 +34,27 @@ fn resolve_reads_configured_value() {
             .expect("parse config");
     let resolved = Config::resolve(&cfg);
     assert_eq!(resolved.max_spaces_after(), 4);
+}
+
+#[test]
+fn resolve_reads_dash_on_own_line_from_toml() {
+    let cfg =
+        YamlLintConfig::from_toml_str("[rules.hyphens]\ndash-on-own-line = true\n")
+            .expect("parse TOML config");
+    let resolved = Config::resolve(&cfg);
+    // No bool getter is exposed; assert the resolved config drives the check.
+    let diagnostics = hyphens::check("items:\n  - name: web\n", &resolved);
+    assert_eq!(diagnostics.len(), 1, "option should enable the check");
+}
+
+#[test]
+fn dash_on_own_line_rejected_in_yaml_config() {
+    let err = YamlLintConfig::from_yaml_str(
+        "rules:\n  hyphens:\n    dash-on-own-line: true\n",
+    )
+    .unwrap_err();
+    assert!(err.contains("failed to parse config data:"), "{err}");
+    assert!(err.contains("rules.hyphens"), "{err}");
 }
 
 #[test]

--- a/tests/property_check.rs
+++ b/tests/property_check.rs
@@ -11,7 +11,7 @@ use ryl::lint::lint_str;
 
 use harness::{
     check_spans_in_bounds, collect_spans, comments_indentation_open_config,
-    trigger_all_config,
+    hyphens_dash_on_own_line_config, trigger_all_config,
 };
 use strategy::arb_document;
 
@@ -91,6 +91,25 @@ proptest! {
                 strict.contains(violation),
                 "allow-any-open-indent reported {violation:?} the default did not, \
                  for {content:?}"
+            );
+        }
+    }
+
+    /// `hyphens: dash-on-own-line` is purely additive: enabling it preserves every
+    /// `max-spaces-after` violation the default reports and only *adds* dash-on-own-line
+    /// violations. Exercises the scanner-driven detection over generated sequences of
+    /// mappings and pins that contract (the inverse of the relaxing option above).
+    #[test]
+    fn dash_on_own_line_only_adds_hyphens_violations(document in arb_document()) {
+        use ryl::rules::hyphens::{Config, check};
+        let content = document.render();
+        let base = check(&content, &Config::new_for_tests(1));
+        let enhanced =
+            check(&content, &Config::new_for_tests(1).with_dash_on_own_line(true));
+        for violation in &base {
+            prop_assert!(
+                enhanced.contains(violation),
+                "dash-on-own-line dropped base violation {violation:?} for {content:?}"
             );
         }
     }
@@ -180,6 +199,23 @@ fn open_indent_config_relaxes_a_generated_shape() {
         !strict.is_empty() && relaxed.is_empty(),
         "open-indent config must accept an open-level comment the default flags: \
          strict={strict:?} relaxed={relaxed:?}"
+    );
+}
+
+#[test]
+fn dash_on_own_line_config_flags_a_generated_shape() {
+    // Mirrors the open-indent guard: a sequence-of-mappings shape `arb_document` emits
+    // (a `- key: val` entry) must be *flagged* by the harness's dash-on-own-line config
+    // but ignored by the default, so the second `collect_spans` dispatch (and the
+    // monotonicity property) is not exercised vacuously.
+    use ryl::rules::hyphens::{Config, check};
+    let content = "items:\n  - name: web\n    port: 80\n";
+    let base = check(content, &Config::resolve(trigger_all_config()));
+    let enhanced = check(content, &Config::resolve(hyphens_dash_on_own_line_config()));
+    assert!(
+        base.is_empty() && !enhanced.is_empty(),
+        "dash-on-own-line config must flag a sequence-of-mappings the default ignores: \
+         base={base:?} enhanced={enhanced:?}"
     );
 }
 

--- a/tests/property_check/harness.rs
+++ b/tests/property_check/harness.rs
@@ -131,6 +131,21 @@ pub fn comments_indentation_open_config() -> &'static YamlLintConfig {
     &CONFIG
 }
 
+// `dash-on-own-line` is ryl-only (TOML), so the dash-on-own-line path of `hyphens` is
+// fuzzed through this config in addition to the default YAML one above.
+const HYPHENS_DASH_ON_OWN_LINE_TOML: &str = "[rules.hyphens]
+dash-on-own-line = true
+";
+
+#[must_use]
+pub fn hyphens_dash_on_own_line_config() -> &'static YamlLintConfig {
+    static CONFIG: LazyLock<YamlLintConfig> = LazyLock::new(|| {
+        YamlLintConfig::from_toml_str(HYPHENS_DASH_ON_OWN_LINE_TOML)
+            .expect("property-check hyphens dash-on-own-line config must parse")
+    });
+    &CONFIG
+}
+
 macro_rules! collect_standard {
     ($spans:ident, $cfg:expr, $content:expr, $module:path) => {{
         use $module as rule;
@@ -173,6 +188,12 @@ pub fn collect_spans(content: &str, cfg: &YamlLintConfig) -> Vec<Span> {
     collect_standard!(spans, cfg, content, ryl::rules::empty_values);
     collect_standard!(spans, cfg, content, ryl::rules::float_values);
     collect_standard!(spans, cfg, content, ryl::rules::hyphens);
+    collect_standard!(
+        spans,
+        hyphens_dash_on_own_line_config(),
+        content,
+        ryl::rules::hyphens
+    );
     collect_standard!(spans, cfg, content, ryl::rules::indentation);
     collect_standard!(spans, cfg, content, ryl::rules::key_duplicates);
     collect_standard!(

--- a/tests/property_check/strategy.rs
+++ b/tests/property_check/strategy.rs
@@ -373,6 +373,75 @@ fn arb_merge_block() -> impl Strategy<Value = Vec<Line>> {
         })
 }
 
+/// A coherent block sequence-of-mappings the flat line generator never assembles by
+/// chance: a parent key introducing a block sequence whose entries span the layouts
+/// `hyphens: dash-on-own-line` must classify — dash+first-key on one line (the flagged
+/// shape), dash-alone with the body indented below, an anchor/tag or comment on the
+/// dash line (keys still below, accepted), a nested sequence whose inner mapping opens
+/// on the inner dash line, and a flow/scalar value (never flagged). Drives the
+/// scanner-driven detection in `collect_spans`'s dash-on-own-line dispatch over
+/// multibyte keys and mixed newlines so the dual dispatch is not fuzzed vacuously.
+fn arb_seq_of_mappings_block() -> impl Strategy<Value = Vec<Line>> {
+    (arb_key(), 0u8..=6u8).prop_map(|(key, shape)| {
+        let mut lines = vec![merge_entry(0, "items", String::new())];
+        match shape {
+            0 => {
+                lines.push(Line::Raw {
+                    indent: 2,
+                    text: format!("- {key}: web"),
+                });
+                lines.push(Line::Raw {
+                    indent: 4,
+                    text: "port: 80".to_string(),
+                });
+            }
+            1 => {
+                lines.push(Line::Raw {
+                    indent: 2,
+                    text: "-".to_string(),
+                });
+                lines.push(Line::Raw {
+                    indent: 4,
+                    text: format!("{key}: web"),
+                });
+            }
+            2 => {
+                lines.push(Line::Raw {
+                    indent: 2,
+                    text: "- &a !x".to_string(),
+                });
+                lines.push(Line::Raw {
+                    indent: 4,
+                    text: format!("{key}: web"),
+                });
+            }
+            3 => {
+                lines.push(Line::Raw {
+                    indent: 2,
+                    text: "- # c".to_string(),
+                });
+                lines.push(Line::Raw {
+                    indent: 4,
+                    text: format!("{key}: web"),
+                });
+            }
+            4 => lines.push(Line::Raw {
+                indent: 2,
+                text: format!("- - {key}: 1"),
+            }),
+            5 => lines.push(Line::Raw {
+                indent: 2,
+                text: format!("- {{{key}: 1}}"),
+            }),
+            _ => lines.push(Line::Raw {
+                indent: 2,
+                text: "- scalar".to_string(),
+            }),
+        }
+        lines
+    })
+}
+
 fn arb_custom_tag_block() -> impl Strategy<Value = Vec<Line>> {
     prop_oneof![Just("!e!keep"), Just("!e!other")].prop_map(|tag| {
         vec![
@@ -452,6 +521,9 @@ fn arb_fragment() -> impl Strategy<Value = Vec<(Line, Newline)>> {
             lines.into_iter().map(|line| (line, newline)).collect()
         }),
         2 => (arb_block_scalar_block(), arb_newline()).prop_map(|(lines, newline)| {
+            lines.into_iter().map(|line| (line, newline)).collect()
+        }),
+        2 => (arb_seq_of_mappings_block(), arb_newline()).prop_map(|(lines, newline)| {
             lines.into_iter().map(|line| (line, newline)).collect()
         }),
     ]

--- a/tests/rule_hyphens.rs
+++ b/tests/rule_hyphens.rs
@@ -1,4 +1,20 @@
-use ryl::rules::hyphens::{self, Config, Violation};
+use ryl::rules::hyphens::{self, Config, MESSAGE, MESSAGE_DASH_ON_OWN_LINE, Violation};
+
+fn too_many_spaces(line: usize, column: usize) -> Violation {
+    Violation {
+        line,
+        column,
+        message: MESSAGE.to_string(),
+    }
+}
+
+fn dash_on_own_line(line: usize, column: usize) -> Violation {
+    Violation {
+        line,
+        column,
+        message: MESSAGE_DASH_ON_OWN_LINE.to_string(),
+    }
+}
 
 #[test]
 fn allows_single_space_after_hyphen() {
@@ -14,21 +30,21 @@ fn allows_single_space_after_hyphen() {
 fn reports_too_many_spaces_in_root_sequence() {
     let cfg = Config::new_for_tests(1);
     let diagnostics = hyphens::check("-  item\n", &cfg);
-    assert_eq!(diagnostics, vec![Violation { line: 1, column: 3 }]);
+    assert_eq!(diagnostics, vec![too_many_spaces(1, 3)]);
 }
 
 #[test]
 fn reports_too_many_spaces_with_indentation() {
     let cfg = Config::new_for_tests(1);
     let diagnostics = hyphens::check("  -  item\n", &cfg);
-    assert_eq!(diagnostics, vec![Violation { line: 1, column: 5 }]);
+    assert_eq!(diagnostics, vec![too_many_spaces(1, 5)]);
 }
 
 #[test]
 fn respects_configured_max_spaces() {
     let cfg = Config::new_for_tests(3);
     let diagnostics = hyphens::check("-    item\n", &cfg);
-    assert_eq!(diagnostics, vec![Violation { line: 1, column: 5 }]);
+    assert_eq!(diagnostics, vec![too_many_spaces(1, 5)]);
 
     let ok = hyphens::check("-   item\n", &cfg);
     assert!(ok.is_empty(), "unexpected diagnostics: {ok:?}");
@@ -62,4 +78,128 @@ fn ignores_entries_without_inline_values() {
         diagnostics.is_empty(),
         "unexpected diagnostics: {diagnostics:?}"
     );
+}
+
+// `dash-on-own-line` is off by default, so the spec-style requirement never fires
+// unless explicitly enabled.
+#[test]
+fn dash_on_own_line_off_by_default() {
+    let cfg = Config::new_for_tests(1);
+    let diagnostics = hyphens::check("items:\n  - name: web\n    port: 80\n", &cfg);
+    assert!(
+        diagnostics.is_empty(),
+        "default config must not require dash-on-own-line: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn dash_on_own_line_flags_mapping_on_dash_line() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("items:\n  - name: web\n    port: 80\n", &cfg);
+    // Reported at the first key (`name`), the token that must move to the next line.
+    assert_eq!(diagnostics, vec![dash_on_own_line(2, 5)]);
+}
+
+#[test]
+fn dash_on_own_line_accepts_body_below_dash() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics =
+        hyphens::check("items:\n  -\n    name: web\n    port: 80\n", &cfg);
+    assert!(
+        diagnostics.is_empty(),
+        "dash alone with body below must be accepted: {diagnostics:?}"
+    );
+}
+
+// A dash line carrying only node properties keeps the mapping keys below it, so the
+// spec-style layout is satisfied and nothing is flagged.
+#[test]
+fn dash_on_own_line_accepts_anchor_or_tag_before_body() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("items:\n  - &a !x\n    name: web\n", &cfg);
+    assert!(
+        diagnostics.is_empty(),
+        "anchor/tag on the dash line with keys below must be accepted: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn dash_on_own_line_accepts_comment_after_dash() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("items:\n  - # c\n    name: web\n", &cfg);
+    assert!(
+        diagnostics.is_empty(),
+        "a comment after the dash with keys below must be accepted: {diagnostics:?}"
+    );
+}
+
+// Only block mappings trigger the option: scalars, aliases, nested block sequences,
+// and flow collections on the dash line are all left alone.
+#[test]
+fn dash_on_own_line_ignores_non_mapping_entries() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    for input in [
+        "items:\n  - scalar\n",       // scalar entry
+        "items:\n  - *anchor\n",      // alias entry
+        "items:\n  - [1, 2]\n",       // flow sequence value
+        "items:\n  - {x: 1}\n",       // flow mapping value
+        "items:\n  - - x\n    - y\n", // nested block sequence
+    ] {
+        let diagnostics = hyphens::check(input, &cfg);
+        assert!(
+            diagnostics.is_empty(),
+            "non-mapping entry must not be flagged for {input:?}: {diagnostics:?}"
+        );
+    }
+}
+
+// A block mapping that is a *mapping value* (no preceding `-`) is never a sequence
+// entry, so the option must not flag it.
+#[test]
+fn dash_on_own_line_ignores_mapping_value() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("foo:\n  bar: 1\n", &cfg);
+    assert!(
+        diagnostics.is_empty(),
+        "a block mapping value must not be flagged: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn dash_on_own_line_flags_each_top_level_entry() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("- name: web\n  port: 80\n- name: db\n", &cfg);
+    assert_eq!(
+        diagnostics,
+        vec![dash_on_own_line(1, 3), dash_on_own_line(3, 3)]
+    );
+}
+
+// The inner sequence's mapping opens on the inner dash line, so the nested entry is
+// flagged while the outer (sequence) entry is not.
+#[test]
+fn dash_on_own_line_flags_nested_sequence_of_mappings() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("- - a: 1\n", &cfg);
+    assert_eq!(diagnostics, vec![dash_on_own_line(1, 5)]);
+}
+
+// Both passes contribute on one line; the combined result stays in document order.
+#[test]
+fn dash_on_own_line_and_max_spaces_sort_in_document_order() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("x:\n  -   name: web\n", &cfg);
+    assert_eq!(
+        diagnostics,
+        vec![too_many_spaces(2, 6), dash_on_own_line(2, 7)]
+    );
+}
+
+// Char-aligned columns on a multibyte dash line (issue #232): the key column counts
+// characters, not bytes.
+#[test]
+fn dash_on_own_line_reports_char_columns_on_multibyte_line() {
+    let cfg = Config::new_for_tests(1).with_dash_on_own_line(true);
+    let diagnostics = hyphens::check("café:\n  - café: web\n", &cfg);
+    assert_eq!(diagnostics, vec![dash_on_own_line(2, 5)]);
 }


### PR DESCRIPTION
## Summary

Closes #260 (last Tier-2 item of epic #261).

Adds a ryl-only, TOML-only, **off-by-default** `dash-on-own-line` option to the
`hyphens` rule. When enabled it requires a block-sequence entry's `-` to be on its own
line when the entry is a block mapping — the spec-style "sequence of mappings" layout
requested in [adrienverge/yamllint#527](https://github.com/adrienverge/yamllint/issues/527)
(welcomed by the maintainer, never implemented upstream).

```yaml
# flagged under the option (mapping starts on the dash line)
items:
  - name: web
    port: 80

# accepted (dash alone, mapping body indented below)
items:
  -
    name: web
    port: 80
```

## Design — parser-derived, not a char scan

Detection reads granit's **scanner** tokens: `BlockEntry` marks the dash line, and the
entry's value node follows. A `BlockMappingStart` on the same line as its `BlockEntry`
means the mapping opened on the dash line ⇒ flagged. `Anchor`/`Tag`/`Comment` tokens are
transparent decorations; any other value token (scalar, alias, nested `BlockSequenceStart`,
flow `*Start`) is a non-mapping entry and clears the pending dash. This means the
following are all correctly handled without heuristics:

- scalars, aliases, nested sequences, flow values → not flagged
- `- &a !tag` / `- # comment` with keys below → accepted (key-on-dash-line semantics)
- a block mapping that is a *mapping value* (no preceding `-`) → never flagged
- nested sequences-of-mappings, multi-doc, CRLF, multibyte keys → handled

The diagnostic points at the mapping's first key (the token that must move to the next
line). Positions go through the CR-aware, char-based `line_and_column` helper, so spans
stay in bounds on multibyte / bare-CR input.

## No safe `--fix`

Detection-only, consistent with `hyphens`'s existing no-fix status: breaking the `-` onto
its own line re-indents the mapping body, a structural change ryl won't make
automatically.

## Config

ryl-only ⇒ TOML config only (`[rules.hyphens] dash-on-own-line = true`), rejected in
yamllint-compatible YAML config via a new `TomlHyphensOptions` type (mirrors
`anchors: forbid-ambiguous-anchor-alias-names` / `comments-indentation: allow-any-open-indent`).

## Tests

- `tests/rule_hyphens.rs` — unit cases for every layout (flagged / dash-alone / anchor-tag /
  comment / scalar / alias / flow / nested / mapping-value / multibyte / combined-with-max-spaces ordering).
- `tests/cli_hyphens_rule.rs` — TOML-enabled CLI runs + YAML-rejection.
- `tests/config_hyphens.rs` — resolve + YAML rejection.
- `tests/property_check` — new `arb_seq_of_mappings_block` generator covering all layouts,
  a dual-dispatch through the option, a monotonicity guard (the option only *adds*
  violations), and a deterministic non-vacuity guard.

prek clean; coverage zero-missed; `PROPTEST_CASES=512000` property_check green.

No version bump — #257–#260 are all unreleased; the release rolls after #260 lands.
