### PR TITLE
Add cargo audit prek hook + CI install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92
+        with:
+          tool: cargo-audit
+
       - name: Run prek hooks (lint and static checks)
         env:
           SKIP: no-commit-to-branch,nextest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,10 @@ rather than shipping silently. Work this checklist (*Automated Tests* expands st
 - This repo runs on Mac, Linux, and Windows. Don't make assumptions about the shell
   you're running on without checking first (it could be a Posix shell like Bash or
   Windows Powershell).
-- `prek`, `rg`, `rumdl`, `typos`, `yamllint`, and `zizmor` should be installed as global
-  tools (if they don't appear to be installed raise that with the user).
+- `prek`, `rg`, `rumdl`, `typos`, `yamllint`, `zizmor`, and `cargo-audit` should be
+  installed as global tools (if they don't appear to be installed raise that with the
+  user). `cargo-audit` backs the `cargo audit --deny warnings` prek hook; install it with
+  `cargo install cargo-audit --locked`.
 - `gh` will be available in most, but not all environments to inspect GitHub.
 - For PR feedback, use `gh pr view <n> --json comments,reviews` for summary threads and
   `gh api repos/<owner>/<repo>/pulls/<n>/comments` for inline review details (avoid

--- a/prek.toml
+++ b/prek.toml
@@ -99,8 +99,15 @@ hooks = [
     language = "system",
     entry = "uv audit --preview-features audit",
     always_run = true,
-    pass_filenames = false,
-    types = ["python", "toml"]
+    pass_filenames = false
+  },
+  {
+    id = "cargo-audit",
+    name = "cargo audit",
+    language = "system",
+    entry = "cargo audit --deny warnings",
+    always_run = true,
+    pass_filenames = false
   }
 ]
 


### PR DESCRIPTION
Closes #294.

Adds a `cargo audit --deny warnings` check so RustSec advisories against ryl's
dependencies fail fast, mirroring the existing `uv audit` prek hook on the Python side.

## Changes

- **`prek.toml`** — new `local`/`system` hook `cargo-audit` running
  `cargo audit --deny warnings`, alongside the existing `uv audit` hook
  (`always_run = true`, `pass_filenames = false`). Since CI runs
  `prek run --all-files`, this one hook covers **both local and CI** — no separate
  audit job needed. Also drops the inert `types` key from both audit hooks
  (`always_run` makes them run regardless of matched files).
- **`.github/workflows/ci.yml`** — installs `cargo-audit` via `taiki-e/install-action`
  (same pinned SHA as the existing cargo-nextest/cargo-llvm-cov steps), before the
  "Run prek hooks" step so the `system` hook resolves. taiki-e fetches a **prebuilt
  binary** from rustsec/rustsec GitHub Releases — no source compile, so no CI
  compile-time/caching concern.
- **`AGENTS.md`** — documents `cargo-audit` as a required global tool.

## Verification

- Pre-flight `cargo audit --deny warnings` against the current `Cargo.lock`: **clean**
  (276 dependencies scanned, exit 0, zero advisories/warnings) — so no
  `.cargo/audit.toml` ignore file is needed.
- `prek run --all-files`: fully green, including the new `cargo audit` hook.

## Accepted caveats (same as `uv audit`)

`always_run = true` means the hook runs on every commit and needs network to refresh
the RustSec advisory DB (cached at `~/.cargo/advisory-db` when offline); a
newly-published advisory can fail CI with no code change — expected, the fix is to
bump or ignore the dep.