### PR TITLE
Bump to 0.16.0 and consolidate YAML line-break handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,9 +612,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -918,13 +918,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1013,9 +1012,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "micromap"
@@ -1386,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1409,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1582,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "diffy",
@@ -1785,9 +1784,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -2211,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2224,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2234,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2244,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2257,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -2300,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2567,18 +2566,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.15.0"
+  "version": "0.16.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.15.0"
+version = "0.16.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -6,7 +6,7 @@ use crate::config::{SourceKind, YamlLintConfig};
 use crate::decoder;
 use crate::directives::{Directives, PerLineRuleApply};
 use crate::markdown_embed::{MarkdownSources, extract_regions};
-use crate::rules::support::line_syntax::buffer_newline;
+use crate::rules::support::line_syntax::{buffer_newline, first_line_break};
 use crate::rules::{
     braces, brackets, commas, comments, comments_indentation, document_end,
     document_start, empty_lines, new_line_at_end_of_file, new_lines, quoted_strings,
@@ -716,21 +716,9 @@ fn target_newline(
         .into_owned();
     }
 
-    first_newline(content).unwrap_or("\n").to_string()
-}
-
-fn first_newline(content: &str) -> Option<&'static str> {
-    let bytes = content.as_bytes();
-    let mut idx = 0usize;
-    while idx < bytes.len() {
-        match bytes[idx] {
-            b'\r' if bytes.get(idx + 1) == Some(&b'\n') => return Some("\r\n"),
-            // A bare `\r` is a YAML 1.2 line break, so a `\r`-delimited
-            // file's appended final newline reuses `\r` rather than falling back to LF.
-            b'\r' => return Some("\r"),
-            b'\n' => return Some("\n"),
-            _ => idx += 1,
-        }
-    }
-    None
+    // Reuse the first line's ending so a `\r`-delimited file's appended final newline
+    // stays `\r` rather than falling back to LF.
+    first_line_break(content)
+        .map_or("\n", |(_, nl)| nl)
+        .to_string()
 }

--- a/src/rules/comments_indentation.rs
+++ b/src/rules/comments_indentation.rs
@@ -89,7 +89,6 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
                     reference_indent,
                     next_indent,
                     open_indents.get(idx).map_or(&[], Vec::as_slice),
-                    cfg.allow_any_open_indent,
                 ) {
                     diagnostics.push(Violation {
                         line: idx + 1,
@@ -143,7 +142,6 @@ pub fn fix(buffer: &str, cfg: &Config) -> Option<String> {
                     reference_indent,
                     next_indent,
                     open_indents.get(line_idx).map_or(&[], Vec::as_slice),
-                    cfg.allow_any_open_indent,
                 ) {
                     line.indent
                 } else {
@@ -176,11 +174,10 @@ fn comment_is_aligned(
     reference_indent: usize,
     next_indent: usize,
     open_indents: &[usize],
-    allow_any_open_indent: bool,
 ) -> bool {
     indent == reference_indent
         || indent == next_indent
-        || (allow_any_open_indent && open_indents.contains(&indent))
+        || open_indents.contains(&indent)
 }
 
 /// Classify every line once for both `check` and `fix`: its indent and kind.

--- a/src/rules/new_lines.rs
+++ b/src/rules/new_lines.rs
@@ -9,6 +9,7 @@
 use std::borrow::Cow;
 
 use crate::config::YamlLintConfig;
+use crate::rules::support::line_syntax::{first_line_break, line_break_at};
 
 pub const ID: &str = "new-lines";
 
@@ -64,7 +65,7 @@ pub const fn platform_newline() -> &'static str {
 #[must_use]
 pub fn check(buffer: &str, cfg: Config, platform_newline: &str) -> Option<Violation> {
     let expected = cfg.kind.expected(platform_newline);
-    let (index, actual) = first_line_ending(buffer)?;
+    let (index, actual) = first_line_break(buffer)?;
     if actual == expected.as_ref() {
         return None;
     }
@@ -99,51 +100,23 @@ pub fn fix(buffer: &str, cfg: Config, platform_newline: &str) -> Option<String> 
     let mut changed = false;
 
     while idx < bytes.len() {
-        match bytes[idx] {
-            b'\r' if bytes.get(idx + 1) == Some(&b'\n') => {
-                out.push_str(expected.as_ref());
-                changed |= expected.as_ref() != "\r\n";
-                idx += 2;
-            }
-            b'\r' => {
-                // A bare `\r` is never the configured style, so emitting the
-                // expected ending always changes the buffer.
-                out.push_str(expected.as_ref());
-                changed = true;
-                idx += 1;
-            }
-            b'\n' => {
-                out.push_str(expected.as_ref());
-                changed |= expected.as_ref() != "\n";
-                idx += 1;
-            }
-            _ => {
-                let ch = buffer[idx..]
-                    .chars()
-                    .next()
-                    .expect("idx should always point at a valid character boundary");
-                out.push(ch);
-                idx += ch.len_utf8();
-            }
+        if let Some((len, style)) = line_break_at(bytes, idx) {
+            out.push_str(expected.as_ref());
+            // A bare `\r` is never a configurable style, so `expected != "\r"` always
+            // holds and rewriting it always counts as a change.
+            changed |= expected.as_ref() != style;
+            idx += len;
+        } else {
+            let ch = buffer[idx..]
+                .chars()
+                .next()
+                .expect("idx should always point at a valid character boundary");
+            out.push(ch);
+            idx += ch.len_utf8();
         }
     }
 
     changed.then_some(out)
-}
-
-fn first_line_ending(buffer: &str) -> Option<(usize, &'static str)> {
-    let bytes = buffer.as_bytes();
-    let mut idx = 0;
-    while idx < bytes.len() {
-        match bytes[idx] {
-            b'\n' => return Some((idx, "\n")),
-            b'\r' if bytes.get(idx + 1) == Some(&b'\n') => return Some((idx, "\r\n")),
-            b'\r' => return Some((idx, "\r")),
-            _ => {}
-        }
-        idx += 1;
-    }
-    None
 }
 
 fn display_sequence(input: &str) -> &'static str {

--- a/src/rules/support/line_syntax.rs
+++ b/src/rules/support/line_syntax.rs
@@ -8,10 +8,26 @@ pub(crate) fn leading_whitespace_width(line: &str) -> usize {
         .count()
 }
 
+/// Classify the YAML 1.2 line break starting at byte `idx` as `(break length in bytes,
+/// canonical style)` — `(2, "\r\n")`, `(1, "\r")`, or `(1, "\n")` — or `None` when `idx`
+/// is past the end or not at a break. The single source of truth for the break set:
+/// [`scan_lines`], [`first_line_break`], and `new_lines::fix` all classify through it,
+/// so changing what counts as a break is a one-line edit.
+pub(crate) fn line_break_at(bytes: &[u8], idx: usize) -> Option<(usize, &'static str)> {
+    match bytes.get(idx)? {
+        b'\r' if bytes.get(idx + 1) == Some(&b'\n') => Some((2, "\r\n")),
+        b'\r' => Some((1, "\r")),
+        b'\n' => Some((1, "\n")),
+        _ => None,
+    }
+}
+
 /// The line-ending style to reuse when inserting a line into `buffer` (e.g. a
 /// `document-start`/`-end` marker): `"\r\n"` if it contains any CRLF, else `"\r"`
 /// if it uses a bare `\r` (so a `\r`-delimited file reuses `\r` rather than mixing
-/// in LF), else `"\n"`.
+/// in LF), else `"\n"`. Deliberately *not* built on [`line_break_at`]: it answers a
+/// different question — the buffer's *dominant* style to write, preferring CRLF if any
+/// is present — not the first break left-to-right (that is [`first_line_break`]).
 pub(crate) fn buffer_newline(buffer: &str) -> &'static str {
     if buffer.contains("\r\n") {
         "\r\n"
@@ -20,6 +36,17 @@ pub(crate) fn buffer_newline(buffer: &str) -> &'static str {
     } else {
         "\n"
     }
+}
+
+/// The buffer's *first* YAML 1.2 line break as `(byte index, canonical style)` —
+/// `"\r\n"`, `"\r"`, or `"\n"` — or `None` when it has no break. Distinct from
+/// [`buffer_newline`], which reports the dominant style for *inserting* a line
+/// (preferring CRLF if any is present); this reports the first ending verbatim, for
+/// callers matching against or reusing that specific ending.
+pub(crate) fn first_line_break(buffer: &str) -> Option<(usize, &'static str)> {
+    let bytes = buffer.as_bytes();
+    (0..bytes.len())
+        .find_map(|idx| line_break_at(bytes, idx).map(|(_, style)| (idx, style)))
 }
 
 /// Collect line numbers (1-based) for every `Scalar` event whose `style` and
@@ -181,29 +208,40 @@ pub(crate) fn block_scalar_header_marker_index(content: &str) -> Option<usize> {
 pub(crate) fn split_lines_preserve_endings(
     buffer: &str,
 ) -> impl Iterator<Item = (usize, &str, &str)> {
+    scan_lines(buffer).enumerate().map(
+        move |(line_idx, (start, content_end, next_start))| {
+            (
+                line_idx,
+                &buffer[start..content_end],
+                &buffer[content_end..next_start],
+            )
+        },
+    )
+}
+
+/// Single source of truth for the YAML 1.2 line-break set (`\r\n`, `\r`, `\n`):
+/// yields `(start, content_end, next_start)` byte offsets per line, where
+/// `[start..content_end]` is the break-free content and `[content_end..next_start]`
+/// the matched break (empty for a final unterminated line). Both public splitters
+/// below are thin slicing adapters over this so the break rule lives in one place.
+fn scan_lines(buffer: &str) -> impl Iterator<Item = (usize, usize, usize)> {
+    let bytes = buffer.as_bytes();
     let mut start = 0usize;
-    let mut line_idx = 0usize;
     std::iter::from_fn(move || {
-        if start == buffer.len() {
+        if start == bytes.len() {
             return None;
         }
 
-        let bytes = buffer.as_bytes();
         let mut idx = start;
-        while idx < bytes.len() && !matches!(bytes[idx], b'\n' | b'\r') {
+        while idx < bytes.len() && line_break_at(bytes, idx).is_none() {
             idx += 1;
         }
 
-        let next_start = if idx >= bytes.len() {
-            bytes.len()
-        } else if bytes[idx] == b'\r' && bytes.get(idx + 1) == Some(&b'\n') {
-            idx + 2
-        } else {
-            idx + 1
-        };
+        // `idx == bytes.len()` (final line, no break) ⇒ `line_break_at` is `None` ⇒ the
+        // line ends at `idx` with an empty ending; otherwise skip past the matched break.
+        let next_start = idx + line_break_at(bytes, idx).map_or(0, |(len, _)| len);
 
-        let current = (line_idx, &buffer[start..idx], &buffer[idx..next_start]);
-        line_idx += 1;
+        let current = (start, idx, next_start);
         start = next_start;
         Some(current)
     })
@@ -225,25 +263,5 @@ pub(crate) fn line_contents(buffer: &str) -> Vec<&str> {
 /// reproduces the buffer, so callers can map a line index 1:1 onto a granit
 /// (CR-aware) line number.
 pub(crate) fn split_lines_inclusive(buffer: &str) -> impl Iterator<Item = &str> {
-    let bytes = buffer.as_bytes();
-    let mut start = 0usize;
-    std::iter::from_fn(move || {
-        if start == buffer.len() {
-            return None;
-        }
-        let mut idx = start;
-        while idx < bytes.len() && !matches!(bytes[idx], b'\n' | b'\r') {
-            idx += 1;
-        }
-        let end = if idx >= bytes.len() {
-            bytes.len()
-        } else if bytes[idx] == b'\r' && bytes.get(idx + 1) == Some(&b'\n') {
-            idx + 2
-        } else {
-            idx + 1
-        };
-        let piece = &buffer[start..end];
-        start = end;
-        Some(piece)
-    })
+    scan_lines(buffer).map(move |(start, _, next_start)| &buffer[start..next_start])
 }

--- a/src/rules/unicode_line_breaks.rs
+++ b/src/rules/unicode_line_breaks.rs
@@ -23,6 +23,8 @@
 //! Sources: YAML 1.2.2 changes page; YAML 1.2.2 spec §5.1 (character set), §5.4
 //! (line-break characters), §5.7 (escaped characters).
 
+use crate::rules::support::line_syntax::split_lines_preserve_endings;
+
 pub const ID: &str = "unicode-line-breaks";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,44 +34,26 @@ pub struct Violation {
     pub message: String,
 }
 
-/// Report every raw NEL / LS / PS character with a 1-based line/column. Line counting
-/// advances on `\n`, `\r\n`, and a bare `\r`; the flagged NEL/LS/PS chars are not YAML
-/// 1.2 breaks, so they never advance the counter.
+/// Report every raw NEL / LS / PS character with a 1-based line/column. The flagged
+/// chars are not YAML 1.2 breaks, so they stay inside a line's content — splitting on
+/// the shared CR-aware break set (`\n`, `\r\n`, bare `\r`) gives the line, and the
+/// char offset within that content gives the (character-, not byte-) column.
 #[must_use]
 pub fn check(buffer: &str) -> Vec<Violation> {
-    let mut violations = Vec::new();
-    let mut line = 1usize;
-    let mut column = 1usize;
-    let mut chars = buffer.chars().peekable();
-    while let Some(ch) = chars.next() {
-        match ch {
-            '\n' => {
-                line += 1;
-                column = 1;
-            }
-            '\r' => {
-                if chars.peek() == Some(&'\n') {
-                    chars.next();
-                }
-                line += 1;
-                column = 1;
-            }
-            _ => {
-                if let Some((name, escape)) = classify(ch) {
-                    violations.push(Violation {
-                        line,
-                        column,
-                        message: format!(
-                            "forbidden raw {name} U+{:04X}; escape as \"{escape}\" in a double-quoted scalar",
-                            ch as u32
-                        ),
-                    });
-                }
-                column += 1;
-            }
-        }
-    }
-    violations
+    split_lines_preserve_endings(buffer)
+        .flat_map(|(line_idx, content, _)| {
+            content.chars().enumerate().filter_map(move |(col_idx, ch)| {
+                classify(ch).map(|(name, escape)| Violation {
+                    line: line_idx + 1,
+                    column: col_idx + 1,
+                    message: format!(
+                        "forbidden raw {name} U+{:04X}; escape as \"{escape}\" in a double-quoted scalar",
+                        ch as u32
+                    ),
+                })
+            })
+        })
+        .collect()
 }
 
 fn classify(ch: char) -> Option<(&'static str, &'static str)> {

--- a/tests/cli_unicode_line_breaks_rule.rs
+++ b/tests/cli_unicode_line_breaks_rule.rs
@@ -59,6 +59,28 @@ fn flags_nel_ls_ps_across_contexts_with_char_based_columns() {
 }
 
 #[test]
+fn flags_chars_adjacent_to_cr_and_crlf_breaks() {
+    // The rule must keep NEL/LS/PS on the line they sit on while still advancing the
+    // counter across `\r\n` and bare `\r` — the chars are not YAML 1.2 breaks but the
+    // CRs are. All-comment lines keep the doc valid YAML so the rule spans survive.
+    // LS before a CRLF (1:4), then NEL before a bare CR (2:4); the final `\n` line is
+    // clean.
+    let (code, output) = lint_with_toml_config(
+        "# a\u{2028}\r\n# b\u{85}\r# c\n",
+        "[rules]\nunicode-line-breaks = \"enable\"\n",
+    );
+    assert_eq!(code, 1, "raw breaks adjacent to CRs should fail: {output}");
+    assert!(
+        output.contains("1:4") && output.contains("line separator"),
+        "LS before a CRLF stays at 1:4: {output}"
+    );
+    assert!(
+        output.contains("2:4") && output.contains("next line"),
+        "NEL before a bare CR stays at 2:4 (the CR advanced the line): {output}"
+    );
+}
+
+#[test]
 fn rule_does_not_fire_when_not_enabled() {
     let (code, output) =
         lint_with_toml_config("a: \"x\u{2028}y\"\n", "[rules]\ntruthy = \"enable\"\n");

--- a/tests/rule_comments_indentation.rs
+++ b/tests/rule_comments_indentation.rs
@@ -244,7 +244,8 @@ fn allow_any_open_indent_accepts_comment_at_open_block_level() {
 fn allow_any_open_indent_accepts_middle_open_level() {
     // The comment matches the middle open level (2 = `b:`), not the innermost (4) or
     // outermost (0); since the following content `e:` is at 0, the default flags it.
-    // Pins that `push_open_indent` keeps interior levels on the stack.
+    // Pins that `compute_open_indents` keeps interior block levels open (the middle
+    // `b:` level survives until its mapping ends), not just the innermost/outermost.
     let input = "a:\n  b:\n    c: 1\n  # mid\ne: 2\n";
     assert_eq!(run(input), vec![Violation { line: 4, column: 3 }]);
     assert!(

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Prepares the **0.16.0** release and, while here, consolidates the scattered YAML line-break handling onto a single source of truth — completing the bare-`\r` unification started in #287.

### Version bump
- `Cargo.toml`, `pyproject.toml`, `package.json` → `0.16.0`
- `Cargo.lock` / `uv.lock` refreshed (the `Cargo.lock` refresh pulls transitive dep updates; `cargo audit` clean)

0.16.0 ships the work merged since 0.15.0: per-line-ignores (#288), `comments-indentation: allow-any-open-indent` (#289), `hyphens: dash-on-own-line` (#293), and the bare-`\r` line-break unification (#287).

### Consolidation (behaviour-neutral, src net **−40 lines**)
- **`line_break_at(bytes, idx)`** — one break-classification primitive in `support::line_syntax`. `scan_lines`, `first_line_break`, and `new_lines::fix` all classify the YAML 1.2 break set (`\r\n`/`\r`/`\n`) through it, so "what counts as a break" is a one-line edit instead of 5 hand-rolled copies.
- Collapsed the two duplicated line splitters onto a shared `scan_lines` core.
- Routed `unicode_line_breaks::check` through `split_lines_preserve_endings` (removed a third hand-rolled break loop).
- Added a shared `first_line_break` helper; `new_lines::check` and the fixer's `target_newline` delegate. `buffer_newline` deliberately stays separate (dominant-insertion-style, not first-break — documented).
- Dropped the dead `allow_any_open_indent` parameter from `comments_indentation::comment_is_aligned` (the option's effect is already carried by gating `open_indents` to empty when off — which is also a deliberate perf optimization, preserved).
- Added a deterministic guard pinning NEL/LS/PS columns adjacent to CR/CRLF breaks.

### Verification
- `prek run --all-files` clean
- Coverage zero-missed (`coverage-missing.sh`)
- `property_check` 512k cases · `property_safe_fix` 100k cases · green
- Local `/code-review` (high): 0 correctness findings; the cleanup/altitude finding (only-half-consolidated) is what motivated the `line_break_at` primitive
- Local Codex adversarial review: `approve`, no findings