### PR TITLE
Add shell completions (--generate-completions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1593,7 @@ name = "ryl"
 version = "0.16.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "diffy",
  "dirs-next",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.0", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "suggestions"] }
+clap_complete = "4.6"
 globset = "0.4.18"
 ignore = "0.4.25"
 rayon = "1.11.0"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -33,4 +33,5 @@ Verify the install:
 ryl --version
 ```
 
-Continue to the [Quick start](quickstart.md) to run your first lint.
+Set up tab-completion with [Shell completions](shell-completions.md), or
+continue to the [Quick start](quickstart.md) to run your first lint.

--- a/docs/getting-started/shell-completions.md
+++ b/docs/getting-started/shell-completions.md
@@ -1,0 +1,75 @@
+# Shell completions
+
+ryl can generate tab-completion scripts for its flags. `ryl --generate-completions
+<SHELL>` prints the script for one shell to stdout, where `<SHELL>` is one of
+`bash`, `zsh`, `fish`, `powershell`, or `elvish`:
+
+```bash
+ryl --generate-completions zsh
+```
+
+The same command is what packagers (conda-forge, a Homebrew tap) run at build
+time to ship completions with the binary. To set them up yourself, write the
+script where your shell looks for completions.
+
+=== "Bash"
+
+    System-wide (needs the `bash-completion` package):
+
+    ```bash
+    ryl --generate-completions bash | sudo tee /etc/bash_completion.d/ryl > /dev/null
+    ```
+
+    Or just for your user (bash-completion searches
+    `${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions`):
+
+    ```bash
+    dir="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
+    mkdir -p "$dir"
+    ryl --generate-completions bash > "$dir/ryl"
+    ```
+
+    Start a new shell to load it.
+
+=== "Zsh"
+
+    Write the script as `_ryl` into a directory on your `$fpath`:
+
+    ```zsh
+    mkdir -p ~/.zfunc
+    ryl --generate-completions zsh > ~/.zfunc/_ryl
+    ```
+
+    Then make sure that directory is on `$fpath` before `compinit` runs in your
+    `~/.zshrc`:
+
+    ```zsh
+    fpath=(~/.zfunc $fpath)
+    autoload -U compinit && compinit
+    ```
+
+=== "Fish"
+
+    ```fish
+    mkdir -p ~/.config/fish/completions
+    ryl --generate-completions fish > ~/.config/fish/completions/ryl.fish
+    ```
+
+    fish loads it automatically on the next shell.
+
+=== "PowerShell"
+
+    Add this line to your PowerShell profile (the file at `$PROFILE`) so
+    completions load on each session:
+
+    ```powershell
+    ryl --generate-completions powershell | Out-String | Invoke-Expression
+    ```
+
+=== "Elvish"
+
+    Add to `~/.config/elvish/rc.elv`:
+
+    ```elvish
+    eval (ryl --generate-completions elvish | slurp)
+    ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use clap::{Parser, ValueEnum};
+use clap::{CommandFactory, Parser, ValueEnum};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use ryl::cli_support::{lexical_abspath, resolve_ctx, sanitize_control};
@@ -199,17 +199,38 @@ struct Cli {
     #[arg(short = 'f', long = "format", default_value_t = CliFormat::Auto, value_enum)]
     format: CliFormat,
 
+    // These print-and-exit meta-actions ignore every other input/flag; mark them
+    // `exclusive` so combining them with a lint/fix/format request is a usage error
+    // rather than a silent no-op. `--migrate-configs` is deliberately not exclusive
+    // (it combines with its `requires`-bound `--migrate-*` sub-flags and a root path).
     /// Print the JSON Schema for ryl TOML config and exit
-    #[arg(long = "print-toml-config-schema", default_value_t = false)]
+    #[arg(
+        long = "print-toml-config-schema",
+        default_value_t = false,
+        exclusive = true
+    )]
     print_toml_config_schema: bool,
 
     /// Print the JSON Schema for yamllint-compatible YAML config and exit
-    #[arg(long = "print-yaml-config-schema", default_value_t = false)]
+    #[arg(
+        long = "print-yaml-config-schema",
+        default_value_t = false,
+        exclusive = true
+    )]
     print_yaml_config_schema: bool,
 
     /// Convert discovered legacy YAML config files into .ryl.toml files
     #[arg(long = "migrate-configs", default_value_t = false)]
     migrate_configs: bool,
+
+    /// Print a shell completion script for SHELL and exit
+    #[arg(
+        long = "generate-completions",
+        value_name = "SHELL",
+        value_enum,
+        exclusive = true
+    )]
+    generate_completions: Option<clap_complete::Shell>,
 
     #[command(flatten)]
     lint: LintFlags,
@@ -361,6 +382,18 @@ fn main() -> ExitCode {
 }
 
 fn run_cli(cli: Cli) -> Result<ExitCode, String> {
+    // A pure meta-action that ignores every other input/flag, like the
+    // schema-print flags below; clap_complete derives the script from `Cli`.
+    if let Some(shell) = cli.generate_completions {
+        clap_complete::generate(
+            shell,
+            &mut Cli::command(),
+            "ryl",
+            &mut std::io::stdout(),
+        );
+        return Ok(ExitCode::SUCCESS);
+    }
+
     if cli.print_toml_config_schema {
         println!("{}", schema_string_pretty());
         return Ok(ExitCode::SUCCESS);

--- a/tests/cli_completions.rs
+++ b/tests/cli_completions.rs
@@ -1,0 +1,58 @@
+use std::process::Command;
+
+mod common;
+use common::cli::run;
+
+/// `--generate-completions <SHELL>` emits a non-empty script (mentioning the
+/// `ryl` binary) and exits 0 for every shell clap_complete supports.
+#[test]
+fn generate_completions_emits_a_script_per_shell() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let (code, stdout, stderr) =
+            run(Command::new(exe).arg("--generate-completions").arg(shell));
+        assert_eq!(code, 0, "{shell}: should succeed: stderr={stderr}");
+        assert!(
+            stderr.trim().is_empty(),
+            "{shell}: unexpected stderr: {stderr}"
+        );
+        assert!(
+            stdout.contains("ryl"),
+            "{shell}: completion script should mention the binary: {stdout}"
+        );
+    }
+}
+
+/// An unknown shell value is rejected by clap itself (usage error, exit 2).
+#[test]
+fn generate_completions_rejects_unknown_shell() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--generate-completions")
+        .arg("nonsense-shell"));
+    assert_eq!(code, 2, "unknown shell should be a usage error");
+    assert!(
+        !stderr.trim().is_empty(),
+        "clap should explain the invalid value: {stderr}"
+    );
+}
+
+/// The flag is `exclusive`: pairing it with a lint input or another action is a
+/// usage error (exit 2) rather than silently emitting the script and skipping
+/// the requested lint/fix.
+#[test]
+fn generate_completions_rejects_being_combined_with_other_args() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let combos: [&[&str]; 2] = [
+        &["--generate-completions", "bash", "ignored.yaml"],
+        &["--generate-completions", "bash", "--fix"],
+    ];
+    for args in combos {
+        let (code, _stdout, stderr) = run(Command::new(exe).args(args));
+        assert_eq!(code, 2, "combining {args:?} should be a usage error");
+        assert!(
+            !stderr.trim().is_empty(),
+            "clap should explain the conflict for {args:?}"
+        );
+    }
+}

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -365,6 +365,30 @@ fn cli_print_toml_config_schema_outputs_generated_schema_without_inputs() {
     assert_eq!(printed_schema("--print-toml-config-schema"), schema_value());
 }
 
+/// The schema-print flags are `exclusive`: pairing one with an input path or the
+/// other schema flag is a clap usage error (exit 2), not a silent schema dump
+/// that ignores the rest of the request.
+#[test]
+fn cli_print_config_schema_flags_reject_being_combined() {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let combos: [&[&str]; 2] = [
+        &["--print-toml-config-schema", "ignored.yaml"],
+        &["--print-toml-config-schema", "--print-yaml-config-schema"],
+    ];
+    for args in combos {
+        let out = Command::new(exe).args(args).output().expect("process");
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "combining {args:?} should be a usage error"
+        );
+        assert!(
+            !out.stderr.is_empty(),
+            "clap should explain the conflict for {args:?}"
+        );
+    }
+}
+
 #[test]
 fn schemastore_toml_schema_sets_expected_metadata() {
     let source_schema = schema_value();

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,6 +15,7 @@ nav = [
   { "Home" = "index.md" },
   { "Getting Started" = [
     { "Installation" = "getting-started/installation.md" },
+    { "Shell completions" = "getting-started/shell-completions.md" },
     { "Quick Start" = "getting-started/quickstart.md" },
     { "Migrating from yamllint" = "getting-started/migrating-from-yamllint.md" },
   ]},


### PR DESCRIPTION
Closes #299.

## What

Adds a `--generate-completions <SHELL>` flag (via `clap_complete`) that prints a shell completion script for `bash`, `zsh`, `fish`, `powershell`, or `elvish` to stdout and exits. The script is derived from the existing `clap` `Parser`, so there is no second source of truth to maintain.

Shape follows ripgrep's `--generate` (a visible flag) rather than a subcommand: ryl's CLI is flat (a variadic `inputs` positional plus print-and-exit meta-flags), so a flag slots cleanly into the `run_cli()` meta-flag chain and avoids ambiguity against the positional. (ruff/uv use a hidden subcommand; that pattern is awkward for ryl's flat shape.)

## Meta-flag hardening (from review)

`--generate-completions` and both `--print-*-config-schema` flags are now clap `exclusive`, so combining a print-and-exit action with a lint/fix/format request is a usage error (exit 2) instead of a silent no-op. `--migrate-configs` is deliberately left non-exclusive: it pairs with its `requires`-bound `--migrate-*` sub-flags and a root path.

## Tests & docs

- `tests/cli_completions.rs`: per-shell generation, invalid-shell rejection, exclusivity.
- `tests/config_schema.rs`: guard for the schema flags' new exclusivity.
- New `docs/getting-started/shell-completions.md` page with per-shell install instructions (+ nav entry and install hint). Bash user-install path is XDG-aware; the elvish `eval ... | slurp` form was verified against the elvish reference and carapace's `arg-completer` precedent.

## Verification

`prek run --all-files` clean (incl. `cargo audit` for the new dep), `cargo test` green, coverage reports zero missed lines/regions, docs site builds clean.

## Downstream follow-up (not in this repo)

The acceptance item "conda-forge recipe updated to install completions" lives in the staged-recipes/feedstock repo (tracked under #152/#298); it will restore the completions-install block invoking `ryl --generate-completions <shell>` at build time once the feedstock exists.