### PR TITLE
Add JUnit XML and GitLab code-quality output formats (#285)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -633,7 +633,7 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   `report::ReportEntry` carries the report display path (relativized via
   `cli_support::report_display_path` against the project root =
   `CI_PROJECT_DIR` or cwd, like ruff; forward-slashed, no `./` prefix; a path outside the
-  root keeps its absolute form), the kept problems, and an optional processing-error
+  root gets `..` segments), the kept problems, and an optional processing-error
   message. GitLab severity maps error->`major`, warning->`minor`, a read/parse
   failure->`blocker`; its `fingerprint` is a stable SHA-256 (`sha2`) of
   `(path, rule, message)` — deliberately NOT line/column, so an edit that shifts the line

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -624,9 +624,10 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   format to a file (any format), `conflicts_with` `--diff`; `--format junit|gitlab` with
   `--diff` is rejected by `reject_diff_with_report_format`. An `--output-file` that
   lexically resolves to a linted input or the `--stdin-filename` is refused
-  (`reject_output_file_collision`) so the report cannot truncate the source — stricter
-  than ruff, which guards nothing; other destinations (e.g. a config file) are overwritten
-  as directed, and symlink/hard-link aliases follow ryl's lexical identity. An
+  (`reject_output_file_collision`: lexical-path match, plus a `same_file::Handle`
+  file-identity match for an existing destination so a symlinked or hard-linked `-o` is
+  caught too) so the report cannot truncate the source — stricter than ruff, which guards
+  nothing; other destinations (e.g. a config file) are overwritten as directed. An
   empty/all-ignored input set still emits a valid empty report (`emit_empty_report`:
   `[]` / `<testsuites .../>`) so CI artifact ingestion does not see a missing file.
   `report::ReportEntry` carries the report display path (relativized via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -614,4 +614,33 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   `YamlLintConfig::enables_any_rule`; `main::no_rules_error(config_found)` picks the
   message. The `default`/`relaxed`/`empty` presets stay available via `extends:` (YAML
   only). `--migrate-configs` (warns instead) and `--list-files` are exempt.
+- Output formats (`--format`/`-f`): the streaming console formats `standard`/`colored`/
+  `github`/`parsable` write per-diagnostic lines to **stderr** (unchanged); the
+  whole-document report formats `junit` (JUnit XML via `quick-xml`) and `gitlab` (GitLab
+  Code Quality JSON via `serde_json`) buffer every file and serialize once to **stdout**.
+  `auto` never selects junit/gitlab. `process_results` (in `main`) does the shared
+  filter+tally pass for all formats then either streams or hands a `Vec<ReportEntry>` to
+  `ryl::report::render_junit`/`render_gitlab`. `-o/--output-file` redirects the selected
+  format to a file (any format), `conflicts_with` `--diff`; `--format junit|gitlab` with
+  `--diff` is rejected by `reject_diff_with_report_format`. An `--output-file` that
+  lexically resolves to a linted input or the `--stdin-filename` is refused
+  (`reject_output_file_collision`) so the report cannot truncate the source — stricter
+  than ruff, which guards nothing; other destinations (e.g. a config file) are overwritten
+  as directed, and symlink/hard-link aliases follow ryl's lexical identity. An
+  empty/all-ignored input set still emits a valid empty report (`emit_empty_report`:
+  `[]` / `<testsuites .../>`) so CI artifact ingestion does not see a missing file.
+  `report::ReportEntry` carries the report display path (relativized via
+  `cli_support::report_display_path` against the project root =
+  `CI_PROJECT_DIR` or cwd, like ruff; forward-slashed, no `./` prefix; a path outside the
+  root keeps its absolute form), the kept problems, and an optional processing-error
+  message. GitLab severity maps error->`major`, warning->`minor`, a read/parse
+  failure->`blocker`; its `fingerprint` is a stable SHA-256 (`sha2`) of
+  `(path, rule, message)` — deliberately NOT line/column, so an edit that shifts the line
+  keeps the issue tracked — salted to stay unique within a report (`DefaultHasher` would
+  not be stable across toolchains). A clean file is a passing JUnit testcase and is omitted
+  from GitLab. Output is validated against authoritative sources in tests: GitLab against
+  the vendored `tests/fixtures/gitlab-code-quality.schema.json` (via the `jsonschema`
+  dev-dep), JUnit by re-parsing with `quick-xml`. See `docs/output-formats.md`. ryl follows
+  ruff's model (single format + `--output-file`); it does not (yet) emit a report file and
+  console output simultaneously.
 - Exit codes: `0` (ok/none), `1` (invalid YAML), `2` (usage error).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,13 +581,21 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   YAML/TOML config errors ("not a mapping" / "configuration is empty") rather than
   silently linting nothing. Output is injection-safe: the GitHub format escapes user
   text (`github_escape_data`/`_property`) so a crafted key/anchor/filename can't
-  inject a `::command::`; the other formats run user text through `sanitize_control`.
+  inject a `::command::` (it is a line-oriented command protocol); the streaming
+  console formats run user text through `sanitize_control`. The `junit`/`gitlab`
+  report formats are structured data, not command protocols, so the analogous risk is
+  breaking out of an XML attribute / JSON string: `sanitize_control` first strips
+  control chars, then `quick-xml` (XML) and `serde_json` (JSON) apply structural
+  escaping, and fixed fields (`severity`, `check_name`, the testcase `name`) are
+  derived from the rule/level, not the message. `tests/property_report.rs` fuzzes this
+  (every output must stay well-formed XML / schema-valid JSON under hostile input).
   granit caps nesting recursion (~256), and config regexes
   (`key-ordering`/`quoted-strings`) are validated at parse time with the linear-time
   `regex` crate (no ReDoS). Guards:
   `tests/cli_alias_bomb.rs`, `cli_fix_symlink.rs`, `cli_config_data_error.rs`,
   `cli_toml_config.rs`, `config_extends_inline.rs`, `cli_format_options.rs`,
-  `cli_markdown_embed.rs`, `property_config.rs`.
+  `cli_markdown_embed.rs`, `property_config.rs`, `report_formats.rs`,
+  `property_report.rs`.
 - Stdin (`-`): bytes are read raw and decoded with the same BOM/encoding detection as
   files; `-` can't be combined with other inputs or with `--fix`. `--stdin-filename
   <PATH>` (ruff convention) sets the diagnostic label, anchors config discovery at the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +259,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -271,6 +295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +316,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
 dependencies = [
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -657,6 +701,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1257,6 +1310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,12 +1667,14 @@ dependencies = [
  "ordered-float",
  "proptest",
  "pulldown-cmark",
+ "quick-xml",
  "rayon",
  "regex",
  "schemars",
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "similar",
  "tempfile",
  "toml",
@@ -1756,6 +1820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2080,6 +2155,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "quick-xml",
  "rayon",
  "regex",
+ "same-file",
  "schemars",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ unicode-normalization = "0.1"
 encoding_rs = "0.8"
 toml = "1.1.2"
 pulldown-cmark = { version = "0.13.4", default-features = false }
+quick-xml = { version = "0.40", default-features = false }
+sha2 = "0.11"
 
 [dev-dependencies]
 # Independent unified-diff applier for the `--diff` round-trip property test: a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ toml = "1.1.2"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 quick-xml = { version = "0.40", default-features = false }
 sha2 = "0.11"
+same-file = "1.0.6"
 
 [dev-dependencies]
 # Independent unified-diff applier for the `--diff` round-trip property test: a

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -214,6 +214,14 @@ items:
 With the option off (the default) ryl matches yamllint exactly. Being ryl-only, the
 option is configured in TOML and rejected in yamllint-compatible YAML config.
 
+### JUnit and GitLab report formats
+
+yamllint offers `standard`, `parsable`, `colored`, `github`, and `auto` output formats.
+ryl keeps those and adds two machine-readable report formats modelled on ruff:
+`--format junit` (JUnit XML) and `--format gitlab` (GitLab Code Quality JSON). These write
+to stdout (or to a file with `-o`/`--output-file`) so a Git forge can ingest them as a
+report artifact. See [Output formats](../output-formats.md).
+
 ## Side-by-side example
 
 === "yamllint (.yamllint)"

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -1,0 +1,114 @@
+# Output formats
+
+`ryl` renders diagnostics in several formats, selected with `--format` (`-f`). The
+default, `auto`, picks a human-readable format for your environment; the machine-readable
+formats are opt-in and are meant to be consumed by editors, CI, and Git forges.
+
+| Format | Purpose | Default destination |
+| --- | --- | --- |
+| `auto` (default) | GitHub annotations in GitHub Actions, otherwise colored or plain | stderr |
+| `standard` | Plain text, grouped per file | stderr |
+| `colored` | Plain text with ANSI colors | stderr |
+| `github` | GitHub Actions workflow commands (`::error ...`) | stderr |
+| `parsable` | One `path:line:col: [level] message (rule)` line per diagnostic | stderr |
+| `junit` | JUnit XML test report | stdout |
+| `gitlab` | GitLab Code Quality JSON report | stdout |
+
+The exit code is the same for every format: `0` when clean, `1` when any error-level
+diagnostic is found (or `2` with `--strict` and only warnings), `2` for a usage or config
+error.
+
+## Choosing where output goes
+
+The console formats (`standard`, `colored`, `github`, `parsable`) print diagnostics to
+**stderr**. The report formats (`junit`, `gitlab`) print to **stdout**, so they can be
+redirected into an artifact file:
+
+```console
+$ ryl --format gitlab . > gl-code-quality-report.json
+```
+
+`--output-file` (`-o`) writes the selected format to a file instead of its default
+stream, which is the most robust option in CI (no shell redirection of the wrong stream):
+
+```console
+$ ryl --format junit -o report.xml .
+$ ryl --format gitlab -o gl-code-quality-report.json .
+```
+
+This follows the same model as ruff and eslint: one format goes to one place per run. To
+see human output **and** keep a report file in a single run, pipe the console output
+through `tee`, or run `ryl` twice.
+
+`--output-file` cannot be combined with `--diff` (which previews fixes and ignores
+`--format`), and `--format junit`/`--format gitlab` cannot be combined with `--diff`. An
+`--output-file` that points at a file being linted (or at the `--stdin-filename`) is
+refused, so a report can never truncate the source it just linted. Otherwise
+`--output-file` overwrites its destination, so do not point it at a file you want to keep
+(such as a config file). A clean or empty project still produces a valid empty report
+(`[]` for GitLab, an empty `<testsuites>` for JUnit), so a CI step that ingests the
+artifact never fails on a missing file.
+
+## JUnit XML
+
+The JUnit report is one `<testsuite>` per file and one `<testcase>` per diagnostic. A
+failing diagnostic is a `<failure>` carrying the message and the rule id as its `type`; a
+clean file is a single passing testcase; a file that could not be read or parsed is an
+`<error>` testcase.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ryl" tests="2" failures="1" errors="0">
+  <testsuite name="config.yaml" tests="1" failures="1" errors="0">
+    <testcase name="colons:3:8" classname="config.yaml">
+      <failure message="too many spaces after colon" type="colons">3:8 too many spaces after colon</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="ok.yaml" tests="1" failures="0" errors="0">
+    <testcase name="ok.yaml" classname="ok.yaml"/>
+  </testsuite>
+</testsuites>
+```
+
+In GitLab CI it is published with `artifacts:reports:junit`; other forges that render
+JUnit reports consume it the same way. The shape follows the de-facto
+[JUnit XML specification](https://llg.cubic.org/docs/junit/).
+
+## GitLab Code Quality
+
+The GitLab report is a single JSON array, one object per diagnostic, matching the
+[Code Quality report format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format):
+
+```json
+[
+  {
+    "description": "too many spaces after colon",
+    "check_name": "colons",
+    "severity": "major",
+    "fingerprint": "2f8a...e1",
+    "location": { "path": "config.yaml", "lines": { "begin": 3 } }
+  }
+]
+```
+
+- `severity` maps from the rule level: an error is `major`, a warning is `minor`, and a
+  file that could not be processed is a `blocker`.
+- `location.path` is relative to `CI_PROJECT_DIR` (the repository root in GitLab CI) when
+  that variable is set, otherwise to the working directory, with no `./` prefix, as GitLab
+  requires. A file outside that root keeps its absolute path (there is no repo-relative
+  form for it).
+- `fingerprint` is a stable SHA-256 of the diagnostic's identity (path, rule, and message,
+  deliberately not the line or column), so GitLab keeps tracking the same issue across
+  pipeline runs even when an edit elsewhere shifts its line.
+
+Publish it with `artifacts:reports:codequality` pointing at the file you wrote with
+`-o` (conventionally `gl-code-quality-report.json`):
+
+```yaml
+lint:
+  script:
+    - ryl --format gitlab -o gl-code-quality-report.json .
+  artifacts:
+    reports:
+      codequality: gl-code-quality-report.json
+```

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -95,8 +95,7 @@ The GitLab report is a single JSON array, one object per diagnostic, matching th
   file that could not be processed is a `blocker`.
 - `location.path` is relative to `CI_PROJECT_DIR` (the repository root in GitLab CI) when
   that variable is set, otherwise to the working directory, with no `./` prefix, as GitLab
-  requires. A file outside that root keeps its absolute path (there is no repo-relative
-  form for it).
+  requires. A file outside that root is expressed with `..` segments (like ruff).
 - `fingerprint` is a stable SHA-256 of the diagnostic's identity (path, rule, and message,
   deliberately not the line or column), so GitLab keeps tracking the same issue across
   pipeline runs even when an edit elsewhere shifts its line.

--- a/src/cli_support.rs
+++ b/src/cli_support.rs
@@ -65,16 +65,36 @@ pub fn lexical_abspath(path: &Path) -> PathBuf {
 /// GitLab requires. The caller relativizes against the project root (`CI_PROJECT_DIR` or
 /// the working directory, like ruff), so a `--stdin-filename` or a path under the repo
 /// stays relative even when the config lives elsewhere. A path outside the project root
-/// (the strip fails) keeps its normalized absolute form: there is no repo-relative
-/// representation for a file outside the tree. Control characters are stripped so a
-/// crafted filename cannot inject into the report.
+/// is expressed with `..` segments (like ruff's `pathdiff`) rather than kept absolute.
+/// Control characters are stripped so a crafted filename cannot inject into the report.
 #[must_use]
 pub fn report_display_path(display: &Path, project_root: &Path) -> String {
     let absolute = lexical_abspath(display);
     let root = lexical_abspath(project_root);
-    let relative = absolute.strip_prefix(&root).unwrap_or(&absolute);
+    let relative = relativize(&absolute, &root);
     let text = relative.to_string_lossy().replace('\\', "/");
     sanitize_control(&text).into_owned()
+}
+
+/// `target` expressed relative to `base`, with `..` segments for the part of `base` that
+/// `target` does not share. Both are absolute and lexically normalized (no `.`/`..`
+/// components), so this is a pure component walk: drop the common prefix, emit one `..`
+/// per remaining `base` component, then append the rest of `target`. On a shared root this
+/// yields a clean relative path; two different Windows drive prefixes share nothing and
+/// fall back to a best-effort `..`-prefixed path (no relative path exists across drives).
+fn relativize(target: &Path, base: &Path) -> PathBuf {
+    let mut target_parts = target.components().peekable();
+    let mut base_parts = base.components().peekable();
+    while target_parts.peek().is_some() && target_parts.peek() == base_parts.peek() {
+        target_parts.next();
+        base_parts.next();
+    }
+    let mut relative = PathBuf::new();
+    for _ in base_parts {
+        relative.push("..");
+    }
+    relative.extend(target_parts);
+    relative
 }
 
 /// Resolve the configuration context for a given file path, optionally using a cached

--- a/src/cli_support.rs
+++ b/src/cli_support.rs
@@ -60,6 +60,34 @@ pub fn lexical_abspath(path: &Path) -> PathBuf {
     out
 }
 
+// User-controlled text (a quoted key, an anchor name, a filename) reaches GitHub
+// Actions workflow-command output, where a raw newline would start a new
+// `::command::` — a command-injection vector in CI. Encode it the way GitHub's
+// `@actions/core` does (data escapes `%`/CR/LF; a `property` such as `file=` also
+// escapes `:`/`,`), and additionally render any other control character as a
+// literal `\u{..}` — never a `%XX`, which the runner would decode back into the raw
+// control char and let it drive ANSI sequences in the log viewer. The result never
+// contains a control character, so it cannot inject or split a workflow-command line.
+#[must_use]
+pub fn github_escape(value: &str, property: bool) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '%' => out.push_str("%25"),
+            '\r' => out.push_str("%0D"),
+            '\n' => out.push_str("%0A"),
+            ':' if property => out.push_str("%3A"),
+            ',' if property => out.push_str("%2C"),
+            c if c.is_control() => {
+                write!(out, "\\u{{{:x}}}", c as u32)
+                    .expect("writing to a String is infallible");
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 /// The display path for a report (`location.path` in GitLab, `name`/`classname` in JUnit):
 /// `display` made relative to `project_root` with forward slashes and no `./` prefix, as
 /// GitLab requires. The caller relativizes against the project root (`CI_PROJECT_DIR` or

--- a/src/cli_support.rs
+++ b/src/cli_support.rs
@@ -60,6 +60,23 @@ pub fn lexical_abspath(path: &Path) -> PathBuf {
     out
 }
 
+/// The display path for a report (`location.path` in GitLab, `name`/`classname` in JUnit):
+/// `display` made relative to `project_root` with forward slashes and no `./` prefix, as
+/// GitLab requires. The caller relativizes against the project root (`CI_PROJECT_DIR` or
+/// the working directory, like ruff), so a `--stdin-filename` or a path under the repo
+/// stays relative even when the config lives elsewhere. A path outside the project root
+/// (the strip fails) keeps its normalized absolute form: there is no repo-relative
+/// representation for a file outside the tree. Control characters are stripped so a
+/// crafted filename cannot inject into the report.
+#[must_use]
+pub fn report_display_path(display: &Path, project_root: &Path) -> String {
+    let absolute = lexical_abspath(display);
+    let root = lexical_abspath(project_root);
+    let relative = absolute.strip_prefix(&root).unwrap_or(&absolute);
+    let text = relative.to_string_lossy().replace('\\', "/");
+    sanitize_control(&text).into_owned()
+}
+
 /// Resolve the configuration context for a given file path, optionally using a cached
 /// global configuration.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod fix;
 pub mod lint;
 pub mod markdown_embed;
 pub mod migrate;
+pub mod report;
 pub mod rules;
 pub mod yaml_dom;
 
@@ -25,3 +26,4 @@ pub use lint::{LintProblem, Severity, lint_file, lint_markdown_file, lint_str};
 pub use markdown_embed::{
     EmbeddedRegion, MarkdownSources, RegionKind, extract_regions, lint_markdown_str,
 };
+pub use report::{ReportEntry, render_gitlab, render_junit};

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ use ryl::report::{ReportEntry, render_gitlab, render_junit};
 use ryl::{
     LintProblem, Severity, lint_file, lint_markdown_file, lint_markdown_str, lint_str,
 };
+use same_file::Handle;
 
 const STDIN_LABEL: &str = "<stdin>";
 
@@ -461,11 +462,10 @@ fn emit_empty_report(
 
 /// Refuse an `--output-file` whose lexical path matches a linted input, so a report can
 /// never truncate the source it just linted (or, with `--fix`, the freshly-fixed file).
-/// Matches on the lexical identity (`lexical_abspath`) used for input de-duplication, and
-/// additionally on the canonical path of an existing destination so an `-o` symlinked onto
-/// an input is caught too. Hard links share an inode under distinct, non-symlinked paths
-/// that canonicalization does not resolve; detecting those would need platform-specific
-/// file-id comparison and is left unguarded.
+/// Matches on the lexical identity (`lexical_abspath`) used for input de-duplication —
+/// which also covers a not-yet-created destination — and, for a destination that already
+/// exists, on its underlying file identity via `same_file::Handle`, so an `-o` that is a
+/// symlink *or* a hard link onto a linted input is caught too.
 ///
 /// # Errors
 ///
@@ -477,11 +477,11 @@ fn reject_output_file_collision<'a>(
     inputs: impl Iterator<Item = &'a Path>,
 ) -> Result<(), String> {
     let output_abs = lexical_abspath(output);
-    let output_real = std::fs::canonicalize(output).ok();
+    let output_handle = Handle::from_path(output).ok();
     let collides = inputs.into_iter().any(|input| {
         lexical_abspath(input) == output_abs
-            || output_real.as_deref().is_some_and(|real| {
-                std::fs::canonicalize(input).ok().as_deref() == Some(real)
+            || output_handle.as_ref().is_some_and(|handle| {
+                Handle::from_path(input).ok().as_ref() == Some(handle)
             })
     });
     if collides {

--- a/src/main.rs
+++ b/src/main.rs
@@ -461,21 +461,30 @@ fn emit_empty_report(
 
 /// Refuse an `--output-file` whose lexical path matches a linted input, so a report can
 /// never truncate the source it just linted (or, with `--fix`, the freshly-fixed file).
-/// Uses the same lexical identity (`lexical_abspath`) as input de-duplication, so a
-/// symlink or hard link aliasing an input under a different path is treated as distinct
-/// (matching ryl's lexical identity everywhere; resolving them would need symlink/inode
-/// canonicalization that diverges from the rest of the CLI).
+/// Matches on the lexical identity (`lexical_abspath`) used for input de-duplication, and
+/// additionally on the canonical path of an existing destination so an `-o` symlinked onto
+/// an input is caught too. Hard links share an inode under distinct, non-symlinked paths
+/// that canonicalization does not resolve; detecting those would need platform-specific
+/// file-id comparison and is left unguarded.
 ///
 /// # Errors
 ///
 /// Returns a usage error when `output` resolves to one of the `inputs` (for stdin, the
-/// single `--stdin-filename`/label entry).
+/// single `--stdin-filename`/label entry). `output` is the clap-parsed `--output-file`,
+/// which clap guarantees is non-empty, so `lexical_abspath` never sees an empty path.
 fn reject_output_file_collision<'a>(
     output: &Path,
     inputs: impl Iterator<Item = &'a Path>,
 ) -> Result<(), String> {
     let output_abs = lexical_abspath(output);
-    if inputs.map(lexical_abspath).any(|input| input == output_abs) {
+    let output_real = std::fs::canonicalize(output).ok();
+    let collides = inputs.into_iter().any(|input| {
+        lexical_abspath(input) == output_abs
+            || output_real.as_deref().is_some_and(|real| {
+                std::fs::canonicalize(input).ok().as_deref() == Some(real)
+            })
+    });
+    if collides {
         return Err(format!(
             "error: --output-file {} is also a linted input; refusing to overwrite it",
             sanitize_control(&output.display().to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,17 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Write as _;
-use std::io::{IsTerminal, Read};
+use std::fs::File;
+use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{CommandFactory, Parser, ValueEnum};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
-use ryl::cli_support::{lexical_abspath, resolve_ctx, sanitize_control};
+use ryl::cli_support::{
+    lexical_abspath, report_display_path, resolve_ctx, sanitize_control,
+};
 use ryl::config::{
     ConfigContext, Overrides, SourceKind, YamlLintConfig, discover_config,
 };
@@ -29,11 +32,18 @@ use ryl::migrate::{
     MigrateOptions, OutputMode as MigrateOutputMode, SourceCleanup, WriteMode,
     migrate_configs,
 };
+use ryl::report::{ReportEntry, render_gitlab, render_junit};
 use ryl::{
     LintProblem, Severity, lint_file, lint_markdown_file, lint_markdown_str, lint_str,
 };
 
 const STDIN_LABEL: &str = "<stdin>";
+
+// Formatted output is built in an owned `Vec<u8>`, whose `io::Write` never errors, so the
+// per-diagnostic writes are `expect`s rather than `?`s that would leave dead error arms.
+// Only the final write to the destination (file/stdout/stderr) is fallible.
+const OUTPUT_INFALLIBLE: &str =
+    "writing diagnostics to an in-memory buffer cannot fail";
 
 // A resolved config that enables no rules would lint nothing while exiting 0 — a
 // silent no-op that almost always means a misconfiguration. The lint commands fail
@@ -174,6 +184,8 @@ enum CliFormat {
     Colored,
     Github,
     Parsable,
+    Junit,
+    Gitlab,
 }
 
 #[derive(Parser, Debug)]
@@ -195,9 +207,19 @@ struct Cli {
     #[arg(short = 'd', long = "config-data", value_name = "YAML")]
     config_data: Option<String>,
 
-    /// Output format (auto, standard, colored, github, parsable)
+    /// Output format (auto, standard, colored, github, parsable, junit, gitlab)
     #[arg(short = 'f', long = "format", default_value_t = CliFormat::Auto, value_enum)]
     format: CliFormat,
+
+    /// Write the formatted output to this file instead of the default stream (stderr for
+    /// the console formats, stdout for junit/gitlab)
+    #[arg(
+        short = 'o',
+        long = "output-file",
+        value_name = "FILE",
+        conflicts_with = "diff"
+    )]
+    output_file: Option<PathBuf>,
 
     // These print-and-exit meta-actions ignore every other input/flag; mark them
     // `exclusive` so combining them with a lint/fix/format request is a usage error
@@ -331,6 +353,19 @@ enum OutputFormat {
     Colored,
     Github,
     Parsable,
+    Junit,
+    Gitlab,
+}
+
+impl OutputFormat {
+    /// Streaming formats emit one line per diagnostic as files are visited; the
+    /// whole-document formats (junit/gitlab) buffer every diagnostic and serialize once.
+    const fn is_streaming(self) -> bool {
+        matches!(
+            self,
+            Self::Standard | Self::Colored | Self::Github | Self::Parsable
+        )
+    }
 }
 
 fn detect_output_format(choice: CliFormat) -> OutputFormat {
@@ -339,6 +374,8 @@ fn detect_output_format(choice: CliFormat) -> OutputFormat {
         CliFormat::Colored => OutputFormat::Colored,
         CliFormat::Github => OutputFormat::Github,
         CliFormat::Parsable => OutputFormat::Parsable,
+        CliFormat::Junit => OutputFormat::Junit,
+        CliFormat::Gitlab => OutputFormat::Gitlab,
         CliFormat::Auto => {
             if github_env_active() {
                 OutputFormat::Github
@@ -349,6 +386,128 @@ fn detect_output_format(choice: CliFormat) -> OutputFormat {
             }
         }
     }
+}
+
+/// Open the destination for formatted output: the `--output-file` path when given,
+/// otherwise stdout for the whole-document report formats (so they can be redirected or
+/// piped as an artifact) and stderr for the streaming console formats (unchanged
+/// behavior). The console diagnostics are the only thing routed here; notices, `--fix`
+/// summaries, and skip messages always stay on stderr.
+///
+/// # Errors
+///
+/// Returns an error if the `--output-file` path cannot be created.
+fn open_output_sink(
+    output_file: Option<&Path>,
+    format: OutputFormat,
+) -> Result<Box<dyn Write>, String> {
+    if let Some(path) = output_file {
+        let file = File::create(path).map_err(|err| {
+            format!(
+                "error: cannot open --output-file {}: {err}",
+                sanitize_control(&path.display().to_string())
+            )
+        })?;
+        return Ok(Box::new(BufWriter::new(file)));
+    }
+    if format.is_streaming() {
+        Ok(Box::new(std::io::stderr()))
+    } else {
+        Ok(Box::new(BufWriter::new(std::io::stdout())))
+    }
+}
+
+/// `--diff` previews safe fixes and ignores `--format`, so combining it with a
+/// whole-document report format is a usage error rather than a silent no-op. (`--diff`
+/// with `--output-file` is rejected declaratively by clap's `conflicts_with`.)
+///
+/// # Errors
+///
+/// Returns a usage error when `--diff` is combined with `--format junit|gitlab`.
+fn reject_diff_with_report_format(
+    diff: bool,
+    format: OutputFormat,
+) -> Result<(), String> {
+    if diff && !format.is_streaming() {
+        return Err(
+            "error: `--diff` cannot be combined with `--format junit` or `--format gitlab`"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Emit a valid empty report for the whole-document formats when there are no files to
+/// lint, so CI artifact ingestion sees a present, valid file. Streaming formats emit
+/// nothing (unchanged).
+///
+/// # Errors
+///
+/// Returns an error if the `--output-file` cannot be created or written.
+fn emit_empty_report(
+    output_file: Option<&Path>,
+    output_format: OutputFormat,
+) -> Result<(), String> {
+    // A streaming format writes nothing to its default stream for an empty input, but an
+    // explicit --output-file is still created (empty) and validated, so `-o` uniformly
+    // produces the file and an unopenable destination still errors.
+    if output_file.is_none() && output_format.is_streaming() {
+        return Ok(());
+    }
+    let mut sink = open_output_sink(output_file, output_format)?;
+    let (_summary, output) = process_results(&[], Vec::new(), output_format, false);
+    write_output(sink.as_mut(), &output)
+}
+
+/// Refuse an `--output-file` whose lexical path matches a linted input, so a report can
+/// never truncate the source it just linted (or, with `--fix`, the freshly-fixed file).
+/// Uses the same lexical identity (`lexical_abspath`) as input de-duplication, so a
+/// symlink or hard link aliasing an input under a different path is treated as distinct
+/// (matching ryl's lexical identity everywhere; resolving them would need symlink/inode
+/// canonicalization that diverges from the rest of the CLI).
+///
+/// # Errors
+///
+/// Returns a usage error when `output` resolves to one of the `inputs` (for stdin, the
+/// single `--stdin-filename`/label entry).
+fn reject_output_file_collision<'a>(
+    output: &Path,
+    inputs: impl Iterator<Item = &'a Path>,
+) -> Result<(), String> {
+    let output_abs = lexical_abspath(output);
+    if inputs.map(lexical_abspath).any(|input| input == output_abs) {
+        return Err(format!(
+            "error: --output-file {} is also a linted input; refusing to overwrite it",
+            sanitize_control(&output.display().to_string())
+        ));
+    }
+    Ok(())
+}
+
+/// The project root that report paths are made relative to: `CI_PROJECT_DIR` when set
+/// (matching ruff's GitLab integration), otherwise `.` (which `lexical_abspath` resolves
+/// to the working directory). Computed once per run, not per file.
+fn report_project_root() -> PathBuf {
+    std::env::var_os("CI_PROJECT_DIR").map_or_else(|| PathBuf::from("."), PathBuf::from)
+}
+
+fn write_output_error(err: &std::io::Error) -> String {
+    format!(
+        "error: failed to write output: {}",
+        sanitize_control(&err.to_string())
+    )
+}
+
+/// Write the buffered, formatted output to its destination: the single fallible step of
+/// the output pipeline (the formatting itself is infallible, see [`OUTPUT_INFALLIBLE`]).
+///
+/// # Errors
+///
+/// Returns an error if the destination cannot be written or flushed (e.g. a full disk).
+fn write_output(sink: &mut dyn Write, output: &[u8]) -> Result<(), String> {
+    sink.write_all(output)
+        .and_then(|()| sink.flush())
+        .map_err(|err| write_output_error(&err))
 }
 
 fn github_env_active() -> bool {
@@ -483,7 +642,22 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         return Ok(ExitCode::SUCCESS);
     }
 
+    let output_format = detect_output_format(cli.format);
+    reject_diff_with_report_format(cli.lint.fix.diff, output_format)?;
+
+    // Refuse an --output-file that resolves to a linted input: writing the report there
+    // would truncate the source we just linted (and, with --fix, the freshly-fixed file).
+    if let Some(output) = cli.output_file.as_deref() {
+        reject_output_file_collision(
+            output,
+            files.iter().map(|(path, ..)| path.as_path()),
+        )?;
+    }
+
     if files.is_empty() {
+        // A clean or fully-ignored project still gets a valid empty report, so CI artifact
+        // ingestion sees `[]` / `<testsuites .../>` rather than a missing or invalid file.
+        emit_empty_report(cli.output_file.as_deref(), output_format)?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -495,6 +669,10 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         return Ok(emit_diff(&diff_safe_fixes_for_files(&files)?));
     }
 
+    // Open the destination before `--fix` mutates anything, so an unopenable --output-file
+    // fails fast rather than leaving sources fixed-but-no-report.
+    let mut sink = open_output_sink(cli.output_file.as_deref(), output_format)?;
+
     let initial_problem_count = if cli.lint.fix.fix {
         apply_fixes_reporting_skips(&files, cli.lint.compatibility.no_warnings)?
     } else {
@@ -503,13 +681,13 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
 
     let results = lint_files(&files);
 
-    let output_format = detect_output_format(cli.format);
-    let summary = process_results(
+    let (summary, output) = process_results(
         &files,
         results,
         output_format,
         cli.lint.compatibility.no_warnings,
     );
+    write_output(sink.as_mut(), &output)?;
 
     if cli.lint.fix.fix && initial_problem_count > 0 {
         eprintln!(
@@ -561,9 +739,20 @@ fn summary_to_exit(summary: &LintSummary, strict: bool) -> ExitCode {
 
 fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     let (path, base_dir, cfg, apply_yaml_files, config_found) = resolve_stdin_ctx(cli)?;
+    let output_format = detect_output_format(cli.format);
+    reject_diff_with_report_format(cli.lint.fix.diff, output_format)?;
+
+    // The stdin content is labelled by `--stdin-filename`; refuse writing the report to
+    // that same path so it cannot truncate the file the label names.
+    if let Some(output) = cli.output_file.as_deref() {
+        reject_output_file_collision(output, std::iter::once(path.as_path()))?;
+    }
 
     let Some(kind) = resolve_stdin_kind(cli, &cfg, &path, &base_dir, apply_yaml_files)?
     else {
+        // An ignored stdin filename is an empty input set: still emit a valid empty
+        // report so CI artifact ingestion does not see a missing file.
+        emit_empty_report(cli.output_file.as_deref(), output_format)?;
         return Ok(ExitCode::SUCCESS);
     };
 
@@ -585,13 +774,14 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     let files = vec![(path, base_dir, cfg, kind)];
     let results = vec![(0usize, outcome)];
 
-    let output_format = detect_output_format(cli.format);
-    let summary = process_results(
+    let mut sink = open_output_sink(cli.output_file.as_deref(), output_format)?;
+    let (summary, output) = process_results(
         &files,
         results,
         output_format,
         cli.lint.compatibility.no_warnings,
     );
+    write_output(sink.as_mut(), &output)?;
     Ok(summary_to_exit(&summary, cli.lint.compatibility.strict))
 }
 
@@ -822,13 +1012,22 @@ fn gather_lint_files(
     Ok(ruleless_config_found)
 }
 
+/// Filter, tally, and format diagnostics into an owned buffer. Streaming formats append
+/// one line per diagnostic as files are visited; the whole-document formats (junit/gitlab)
+/// buffer every file into a [`ReportEntry`] and serialize once after the loop. The buffer
+/// is written to its destination by the caller (a single fallible step); the returned
+/// [`LintSummary`] (and thus the exit code) is identical across all formats. Output is
+/// built in memory so the per-diagnostic writes cannot fail (see [`OUTPUT_INFALLIBLE`]).
 fn process_results(
     files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
     results: Vec<(usize, Result<Vec<LintProblem>, String>)>,
     output_format: OutputFormat,
     no_warnings: bool,
-) -> LintSummary {
+) -> (LintSummary, Vec<u8>) {
     let mut summary = LintSummary::default();
+    let mut entries: Vec<ReportEntry> = Vec::new();
+    let mut out: Vec<u8> = Vec::new();
+    let project_root = report_project_root();
 
     for (idx, outcome) in results {
         let (path, ..) = &files[idx];
@@ -838,83 +1037,64 @@ fn process_results(
                 // crafted filename cannot inject terminal escapes or (via a newline)
                 // a GitHub workflow command. `sanitize_control` is safe for every
                 // format because it neutralises the newline that injection needs.
-                eprintln!("{}", sanitize_control(&message));
+                let message = sanitize_control(&message).into_owned();
                 summary.has_error = true;
                 summary.problem_count += 1;
+                if output_format.is_streaming() {
+                    writeln!(out, "{message}").expect(OUTPUT_INFALLIBLE);
+                } else {
+                    entries.push(ReportEntry {
+                        path: report_display_path(path, &project_root),
+                        problems: Vec::new(),
+                        error: Some(message),
+                    });
+                }
             }
             Ok(diagnostics) => {
-                let mut problems = diagnostics
-                    .iter()
-                    .filter(|problem| {
-                        !(no_warnings && problem.level == Severity::Warning)
-                    })
-                    .peekable();
+                let mut kept: Vec<LintProblem> = Vec::new();
+                for problem in diagnostics {
+                    if no_warnings && problem.level == Severity::Warning {
+                        continue;
+                    }
+                    match problem.level {
+                        Severity::Error => summary.has_error = true,
+                        Severity::Warning => summary.has_warning = true,
+                    }
+                    summary.problem_count += 1;
+                    kept.push(problem);
+                }
 
-                if problems.peek().is_none() {
+                // Streaming formats print nothing for a file with no reportable
+                // diagnostics; junit still records it as a passing test, so the
+                // whole-document formats keep the (possibly empty) entry.
+                if output_format.is_streaming() && kept.is_empty() {
                     continue;
                 }
 
                 match output_format {
-                    OutputFormat::Standard => {
-                        eprintln!("{}", sanitize_control(&path.display().to_string()));
-                        for problem in problems {
-                            eprintln!("{}", format_standard(problem));
-                            match problem.level {
-                                Severity::Error => summary.has_error = true,
-                                Severity::Warning => summary.has_warning = true,
-                            }
-                            summary.problem_count += 1;
-                        }
-                        eprintln!();
-                    }
-                    OutputFormat::Colored => {
-                        eprintln!(
-                            "\u{001b}[4m{}\u{001b}[0m",
-                            sanitize_control(&path.display().to_string())
-                        );
-                        for problem in problems {
-                            eprintln!("{}", format_colored(problem));
-                            match problem.level {
-                                Severity::Error => summary.has_error = true,
-                                Severity::Warning => summary.has_warning = true,
-                            }
-                            summary.problem_count += 1;
-                        }
-                        eprintln!();
-                    }
-                    OutputFormat::Github => {
-                        let path_str = path.display().to_string();
-                        eprintln!("::group::{}", github_escape(&path_str, false));
-                        let escaped_file = github_escape(&path_str, true);
-                        for problem in problems {
-                            eprintln!("{}", format_github(problem, &escaped_file));
-                            match problem.level {
-                                Severity::Error => summary.has_error = true,
-                                Severity::Warning => summary.has_warning = true,
-                            }
-                            summary.problem_count += 1;
-                        }
-                        eprintln!("::endgroup::");
-                        eprintln!();
-                    }
-                    OutputFormat::Parsable => {
-                        let sanitized_path =
-                            sanitize_control(&path.display().to_string()).into_owned();
-                        for problem in problems {
-                            eprintln!("{}", format_parsable(problem, &sanitized_path));
-                            match problem.level {
-                                Severity::Error => summary.has_error = true,
-                                Severity::Warning => summary.has_warning = true,
-                            }
-                            summary.problem_count += 1;
-                        }
+                    OutputFormat::Standard => append_standard(&mut out, path, &kept),
+                    OutputFormat::Colored => append_colored(&mut out, path, &kept),
+                    OutputFormat::Github => append_github(&mut out, path, &kept),
+                    OutputFormat::Parsable => append_parsable(&mut out, path, &kept),
+                    OutputFormat::Junit | OutputFormat::Gitlab => {
+                        entries.push(ReportEntry {
+                            path: report_display_path(path, &project_root),
+                            problems: kept,
+                            error: None,
+                        });
                     }
                 }
             }
         }
     }
 
-    summary
+    match output_format {
+        OutputFormat::Junit => out = render_junit(&entries),
+        OutputFormat::Gitlab => out = render_gitlab(&entries),
+        _ => {}
+    }
+
+    (summary, out)
 }
 
 #[derive(Default)]
@@ -942,6 +1122,60 @@ fn count_reported_problems(
 
 fn pluralize(singular: &str, count: usize) -> &str {
     if count == 1 { singular } else { "problems" }
+}
+
+// The streaming formats append a per-file block to the in-memory output buffer. Each is
+// only reached with a non-empty `problems` slice (the caller skips clean files), and each
+// write is infallible (see `OUTPUT_INFALLIBLE`).
+
+/// Shared shape of the standard/colored formats: a file `header` line, one `format_line`
+/// per diagnostic, then a trailing blank line.
+fn append_grouped(
+    out: &mut Vec<u8>,
+    header: &str,
+    problems: &[LintProblem],
+    format_line: fn(&LintProblem) -> String,
+) {
+    writeln!(out, "{header}").expect(OUTPUT_INFALLIBLE);
+    for problem in problems {
+        writeln!(out, "{}", format_line(problem)).expect(OUTPUT_INFALLIBLE);
+    }
+    writeln!(out).expect(OUTPUT_INFALLIBLE);
+}
+
+fn append_standard(out: &mut Vec<u8>, path: &Path, problems: &[LintProblem]) {
+    let display = path.display().to_string();
+    let header = sanitize_control(&display);
+    append_grouped(out, &header, problems, format_standard);
+}
+
+fn append_colored(out: &mut Vec<u8>, path: &Path, problems: &[LintProblem]) {
+    let header = format!(
+        "\u{001b}[4m{}\u{001b}[0m",
+        sanitize_control(&path.display().to_string())
+    );
+    append_grouped(out, &header, problems, format_colored);
+}
+
+fn append_github(out: &mut Vec<u8>, path: &Path, problems: &[LintProblem]) {
+    let path_str = path.display().to_string();
+    writeln!(out, "::group::{}", github_escape(&path_str, false))
+        .expect(OUTPUT_INFALLIBLE);
+    let escaped_file = github_escape(&path_str, true);
+    for problem in problems {
+        writeln!(out, "{}", format_github(problem, &escaped_file))
+            .expect(OUTPUT_INFALLIBLE);
+    }
+    writeln!(out, "::endgroup::").expect(OUTPUT_INFALLIBLE);
+    writeln!(out).expect(OUTPUT_INFALLIBLE);
+}
+
+fn append_parsable(out: &mut Vec<u8>, path: &Path, problems: &[LintProblem]) {
+    let sanitized_path = sanitize_control(&path.display().to_string()).into_owned();
+    for problem in problems {
+        writeln!(out, "{}", format_parsable(problem, &sanitized_path))
+            .expect(OUTPUT_INFALLIBLE);
+    }
 }
 
 fn format_standard(problem: &LintProblem) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::fmt::Write as _;
 use std::fs::File;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
@@ -18,7 +17,7 @@ use clap::{CommandFactory, Parser, ValueEnum};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use ryl::cli_support::{
-    lexical_abspath, report_display_path, resolve_ctx, sanitize_control,
+    github_escape, lexical_abspath, report_display_path, resolve_ctx, sanitize_control,
 };
 use ryl::config::{
     ConfigContext, Overrides, SourceKind, YamlLintConfig, discover_config,
@@ -1224,32 +1223,6 @@ fn format_colored(problem: &LintProblem) -> String {
         line.push_str(")\u{001b}[0m");
     }
     line
-}
-
-// User-controlled text (a quoted key, an anchor name, a filename) reaches GitHub
-// Actions workflow-command output, where a raw newline would start a new
-// `::command::` — a command-injection vector in CI. Encode it the way GitHub's
-// `@actions/core` does (data escapes `%`/CR/LF; a `property` such as `file=` also
-// escapes `:`/`,`), and additionally render any other control character as a
-// literal `\u{..}` — never a `%XX`, which the runner would decode back into the raw
-// control char and let it drive ANSI sequences in the log viewer.
-fn github_escape(value: &str, property: bool) -> String {
-    let mut out = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '%' => out.push_str("%25"),
-            '\r' => out.push_str("%0D"),
-            '\n' => out.push_str("%0A"),
-            ':' if property => out.push_str("%3A"),
-            ',' if property => out.push_str("%2C"),
-            c if c.is_control() => {
-                write!(out, "\\u{{{:x}}}", c as u32)
-                    .expect("writing to a String is infallible");
-            }
-            c => out.push(c),
-        }
-    }
-    out
 }
 
 /// `escaped_file` is the `file=` property value, escaped once per file by the

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,7 +497,11 @@ fn reject_output_file_collision<'a>(
 /// (matching ruff's GitLab integration), otherwise `.` (which `lexical_abspath` resolves
 /// to the working directory). Computed once per run, not per file.
 fn report_project_root() -> PathBuf {
-    std::env::var_os("CI_PROJECT_DIR").map_or_else(|| PathBuf::from("."), PathBuf::from)
+    // An empty `CI_PROJECT_DIR` (set but blank, e.g. a misconfigured CI) is treated as
+    // unset: an empty path would panic `lexical_abspath`, and `.` resolves to the cwd.
+    std::env::var_os("CI_PROJECT_DIR")
+        .filter(|dir| !dir.is_empty())
+        .map_or_else(|| PathBuf::from("."), PathBuf::from)
 }
 
 fn write_output_error(err: &std::io::Error) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1030,6 +1030,10 @@ fn gather_lint_files(
 /// is written to its destination by the caller (a single fallible step); the returned
 /// [`LintSummary`] (and thus the exit code) is identical across all formats. Output is
 /// built in memory so the per-diagnostic writes cannot fail (see [`OUTPUT_INFALLIBLE`]).
+///
+/// Buffering rather than streaming the console formats is not a regression: `lint_files`
+/// has already collected every result (in parallel) before this runs, so output only ever
+/// appears after linting completes — the buffer just emits the same bytes in one write.
 fn process_results(
     files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
     results: Vec<(usize, Result<Vec<LintProblem>, String>)>,

--- a/src/report.rs
+++ b/src/report.rs
@@ -33,6 +33,7 @@ const INFALLIBLE: &str = "writing report output to an in-memory buffer cannot fa
 /// One linted file's contribution to a report. `error` (a failed read/parse, from the
 /// `Err` arm of a lint result) and `problems` are mutually exclusive; a clean file has
 /// both empty, which `JUnit` renders as a passing test and `GitLab` omits entirely.
+#[derive(Debug)]
 pub struct ReportEntry {
     /// Display path, already relativized to the project root and forward-slashed.
     pub path: String,

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,296 @@
+//! Whole-document report formats: `JUnit` XML and `GitLab` code quality JSON.
+//!
+//! Unlike the streaming console formats (standard/colored/github/parsable), these emit a
+//! single root document (one `<testsuites>` / one JSON array), so the caller buffers every
+//! file's diagnostics into [`ReportEntry`]s and renders once. Rendering takes a
+//! `&mut dyn Write`, so the destination (file, stdout, in-memory) is the caller's choice.
+//!
+//! Sources:
+//! - `JUnit`: <https://llg.cubic.org/docs/junit/>; shape modelled on ruff's emitter.
+//! - `GitLab`: <https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format>,
+//!   a documented subset of the Code Climate engine spec.
+//!
+//! All user text is run through [`sanitize_control`] before serialization (XML cannot
+//! represent control characters at all; JSON would escape them but a forge would decode
+//! them back), then quick-xml / `serde_json` apply structural escaping.
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::io::Write;
+
+use quick_xml::Writer;
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::cli_support::sanitize_control;
+use crate::lint::{LintProblem, Severity};
+
+// The emitters build into an owned `Vec<u8>`, whose `io::Write` never fails, so each
+// write is an `expect` rather than a `?` that would leave a dead, uncovered error arm.
+const INFALLIBLE: &str = "writing report output to an in-memory buffer cannot fail";
+
+/// One linted file's contribution to a report. `error` (a failed read/parse, from the
+/// `Err` arm of a lint result) and `problems` are mutually exclusive; a clean file has
+/// both empty, which `JUnit` renders as a passing test and `GitLab` omits entirely.
+pub struct ReportEntry {
+    /// Display path, already relativized to the project root and forward-slashed.
+    pub path: String,
+    pub problems: Vec<LintProblem>,
+    pub error: Option<String>,
+}
+
+/// Render every entry as a `JUnit` `<testsuites>` document: one `<testsuite>` per file, one
+/// `<testcase>` per diagnostic (a `<failure>`), a single passing case for a clean file,
+/// and an `<error>` case for a file that could not be processed.
+///
+/// # Panics
+///
+/// Does not panic in practice: every write targets an in-memory buffer, which cannot fail.
+#[must_use]
+pub fn render_junit(entries: &[ReportEntry]) -> Vec<u8> {
+    let (mut tests, mut failures, mut errors) = (0usize, 0usize, 0usize);
+    for entry in entries {
+        let (t, f, e) = suite_counts(entry);
+        tests += t;
+        failures += f;
+        errors += e;
+    }
+
+    let mut buffer = Vec::new();
+    let mut writer = Writer::new_with_indent(&mut buffer, b' ', 2);
+    writer
+        .write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))
+        .expect(INFALLIBLE);
+    let mut root = BytesStart::new("testsuites");
+    root.push_attribute(("name", "ryl"));
+    root.push_attribute(("tests", tests.to_string().as_str()));
+    root.push_attribute(("failures", failures.to_string().as_str()));
+    root.push_attribute(("errors", errors.to_string().as_str()));
+    writer.write_event(Event::Start(root)).expect(INFALLIBLE);
+    for entry in entries {
+        write_suite(&mut writer, entry);
+    }
+    writer
+        .write_event(Event::End(BytesEnd::new("testsuites")))
+        .expect(INFALLIBLE);
+    writer.into_inner().push(b'\n');
+    buffer
+}
+
+/// `JUnit` `(tests, failures, errors)` for one file: a processing error is one errored case,
+/// a clean file is one passing case, otherwise one failing case per diagnostic.
+fn suite_counts(entry: &ReportEntry) -> (usize, usize, usize) {
+    if entry.error.is_some() {
+        (1, 0, 1)
+    } else if entry.problems.is_empty() {
+        (1, 0, 0)
+    } else {
+        (entry.problems.len(), entry.problems.len(), 0)
+    }
+}
+
+fn write_suite<W: Write>(writer: &mut Writer<W>, entry: &ReportEntry) {
+    let (tests, failures, errors) = suite_counts(entry);
+    let mut suite = BytesStart::new("testsuite");
+    suite.push_attribute(("name", entry.path.as_str()));
+    suite.push_attribute(("tests", tests.to_string().as_str()));
+    suite.push_attribute(("failures", failures.to_string().as_str()));
+    suite.push_attribute(("errors", errors.to_string().as_str()));
+    writer.write_event(Event::Start(suite)).expect(INFALLIBLE);
+
+    if let Some(error) = &entry.error {
+        let message = sanitize_control(error);
+        write_case_with_child(
+            writer,
+            "error",
+            &entry.path,
+            "error",
+            message.as_ref(),
+            "error",
+            message.as_ref(),
+        );
+    } else if entry.problems.is_empty() {
+        let mut case = BytesStart::new("testcase");
+        case.push_attribute(("name", entry.path.as_str()));
+        case.push_attribute(("classname", entry.path.as_str()));
+        writer.write_event(Event::Empty(case)).expect(INFALLIBLE);
+    } else {
+        for problem in &entry.problems {
+            let rule = problem.rule.unwrap_or("syntax");
+            // Suffix the line:col so two diagnostics from the same rule do not produce
+            // testcases with an identical `name`, which some JUnit consumers merge.
+            let name = format!("{rule}:{}:{}", problem.line, problem.column);
+            let message = sanitize_control(&problem.message);
+            let body = format!("{}:{} {message}", problem.line, problem.column);
+            write_case_with_child(
+                writer,
+                &name,
+                &entry.path,
+                "failure",
+                message.as_ref(),
+                rule,
+                &body,
+            );
+        }
+    }
+
+    writer
+        .write_event(Event::End(BytesEnd::new("testsuite")))
+        .expect(INFALLIBLE);
+}
+
+/// Write a `<testcase>` wrapping a single `<failure>` or `<error>` child carrying the
+/// message (attribute), type (rule id or `error`), and a body line.
+fn write_case_with_child<W: Write>(
+    writer: &mut Writer<W>,
+    case_name: &str,
+    classname: &str,
+    child_tag: &str,
+    message: &str,
+    type_attr: &str,
+    body: &str,
+) {
+    let mut case = BytesStart::new("testcase");
+    case.push_attribute(("name", case_name));
+    case.push_attribute(("classname", classname));
+    writer.write_event(Event::Start(case)).expect(INFALLIBLE);
+
+    let mut child = BytesStart::new(child_tag);
+    child.push_attribute(("message", message));
+    child.push_attribute(("type", type_attr));
+    writer.write_event(Event::Start(child)).expect(INFALLIBLE);
+    writer
+        .write_event(Event::Text(BytesText::new(body)))
+        .expect(INFALLIBLE);
+    writer
+        .write_event(Event::End(BytesEnd::new(child_tag)))
+        .expect(INFALLIBLE);
+
+    writer
+        .write_event(Event::End(BytesEnd::new("testcase")))
+        .expect(INFALLIBLE);
+}
+
+#[derive(Serialize)]
+struct GitlabIssue {
+    description: String,
+    check_name: String,
+    severity: &'static str,
+    fingerprint: String,
+    location: GitlabLocation,
+}
+
+#[derive(Serialize)]
+struct GitlabLocation {
+    path: String,
+    lines: GitlabLines,
+}
+
+#[derive(Serialize)]
+struct GitlabLines {
+    begin: usize,
+}
+
+/// Render every diagnostic as a `GitLab` code quality JSON array. Clean files contribute
+/// nothing; a processing error becomes a single `blocker` issue on line 1.
+///
+/// # Panics
+///
+/// Does not panic in practice: serialization targets an in-memory buffer, which cannot
+/// fail for these always-serializable structs.
+#[must_use]
+pub fn render_gitlab(entries: &[ReportEntry]) -> Vec<u8> {
+    let mut issues: Vec<GitlabIssue> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for entry in entries {
+        if let Some(error) = &entry.error {
+            issues.push(make_issue(
+                &entry.path,
+                "error",
+                1,
+                error,
+                "blocker",
+                &mut seen,
+            ));
+        } else {
+            for problem in &entry.problems {
+                let check_name = problem.rule.unwrap_or("syntax");
+                let severity = gitlab_severity(problem.level);
+                issues.push(make_issue(
+                    &entry.path,
+                    check_name,
+                    problem.line,
+                    &problem.message,
+                    severity,
+                    &mut seen,
+                ));
+            }
+        }
+    }
+
+    let mut buffer = serde_json::to_vec(&issues)
+        .expect("serializing report issues to a Vec cannot fail");
+    buffer.push(b'\n');
+    buffer
+}
+
+fn gitlab_severity(level: Severity) -> &'static str {
+    match level {
+        Severity::Error => "major",
+        Severity::Warning => "minor",
+    }
+}
+
+fn make_issue(
+    path: &str,
+    check_name: &str,
+    line: usize,
+    message: &str,
+    severity: &'static str,
+    seen: &mut HashSet<String>,
+) -> GitlabIssue {
+    // GitLab requires fingerprints unique within a report, so two findings sharing the same
+    // (path, rule, message) are disambiguated by an encounter-order salt. This is the same
+    // trade-off ruff makes: identity is stable under line shifts (the common edit) but a
+    // duplicate added/removed/reordered ahead of another reassigns its salt. There is no
+    // scheme stable under both line shifts and duplicate reordering from these inputs alone.
+    let mut salt = 0u64;
+    let mut hash = fingerprint(path, check_name, message, salt);
+    while !seen.insert(hash.clone()) {
+        salt += 1;
+        hash = fingerprint(path, check_name, message, salt);
+    }
+    GitlabIssue {
+        description: sanitize_control(message).into_owned(),
+        check_name: check_name.to_string(),
+        severity,
+        fingerprint: hash,
+        location: GitlabLocation {
+            path: path.to_string(),
+            lines: GitlabLines { begin: line },
+        },
+    }
+}
+
+/// SHA-256 hex of the diagnostic's identity. Identity is `(path, rule, message)` and
+/// deliberately excludes the line/column: GitLab uses the fingerprint to track an issue
+/// across report versions, so an edit elsewhere that shifts the diagnostic's line must not
+/// make it look new (matching ruff). A stable digest (not `DefaultHasher`, whose output is
+/// not stable across Rust versions) keeps it constant across toolchains; `salt`
+/// disambiguates two findings that share the same `(path, rule, message)`.
+fn fingerprint(path: &str, check_name: &str, message: &str, salt: u64) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(salt.to_le_bytes());
+    hasher.update(path.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(check_name.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(message.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(out, "{byte:02x}").expect("writing to a String is infallible");
+    }
+    out
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -14,7 +14,7 @@
 //! represent control characters at all; JSON would escape them but a forge would decode
 //! them back), then quick-xml / `serde_json` apply structural escaping.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::io::Write;
 
@@ -116,11 +116,20 @@ fn write_suite<W: Write>(writer: &mut Writer<W>, entry: &ReportEntry) {
         case.push_attribute(("classname", entry.path.as_str()));
         writer.write_event(Event::Empty(case)).expect(INFALLIBLE);
     } else {
+        // Name each testcase `rule:line:col`, disambiguating a repeat (same rule at the
+        // same position) with a `#n` suffix so no two testcases in a suite share a name,
+        // which some JUnit consumers merge.
+        let mut seen: HashMap<String, u32> = HashMap::new();
         for problem in &entry.problems {
             let rule = problem.rule.unwrap_or("syntax");
-            // Suffix the line:col so two diagnostics from the same rule do not produce
-            // testcases with an identical `name`, which some JUnit consumers merge.
-            let name = format!("{rule}:{}:{}", problem.line, problem.column);
+            let base = format!("{rule}:{}:{}", problem.line, problem.column);
+            let occurrence = seen.entry(base.clone()).or_insert(0);
+            let name = if *occurrence == 0 {
+                base.clone()
+            } else {
+                format!("{base}#{occurrence}")
+            };
+            *occurrence += 1;
             let message = sanitize_control(&problem.message);
             let body = format!("{}:{} {message}", problem.line, problem.column);
             write_case_with_child(

--- a/src/report.rs
+++ b/src/report.rs
@@ -10,10 +10,11 @@
 //! - `GitLab`: <https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format>,
 //!   a documented subset of the Code Climate engine spec.
 //!
-//! All user text is run through [`sanitize_control`] before serialization (XML cannot
-//! represent control characters at all; JSON would escape them but a forge would decode
-//! them back), then quick-xml / `serde_json` apply structural escaping.
+//! All user text is sanitized before serialization — `JUnit` via `xml_sanitize` (control
+//! chars plus the U+FFFE/U+FFFF noncharacters XML forbids), `GitLab` via
+//! [`sanitize_control`] — then quick-xml / `serde_json` apply structural escaping.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::io::Write;
@@ -93,19 +94,20 @@ fn suite_counts(entry: &ReportEntry) -> (usize, usize, usize) {
 
 fn write_suite<W: Write>(writer: &mut Writer<W>, entry: &ReportEntry) {
     let (tests, failures, errors) = suite_counts(entry);
+    let path = xml_sanitize(&entry.path);
     let mut suite = BytesStart::new("testsuite");
-    suite.push_attribute(("name", entry.path.as_str()));
+    suite.push_attribute(("name", path.as_ref()));
     suite.push_attribute(("tests", tests.to_string().as_str()));
     suite.push_attribute(("failures", failures.to_string().as_str()));
     suite.push_attribute(("errors", errors.to_string().as_str()));
     writer.write_event(Event::Start(suite)).expect(INFALLIBLE);
 
     if let Some(error) = &entry.error {
-        let message = sanitize_control(error);
+        let message = xml_sanitize(error);
         write_case_with_child(
             writer,
             "error",
-            &entry.path,
+            path.as_ref(),
             "error",
             message.as_ref(),
             "error",
@@ -113,8 +115,8 @@ fn write_suite<W: Write>(writer: &mut Writer<W>, entry: &ReportEntry) {
         );
     } else if entry.problems.is_empty() {
         let mut case = BytesStart::new("testcase");
-        case.push_attribute(("name", entry.path.as_str()));
-        case.push_attribute(("classname", entry.path.as_str()));
+        case.push_attribute(("name", path.as_ref()));
+        case.push_attribute(("classname", path.as_ref()));
         writer.write_event(Event::Empty(case)).expect(INFALLIBLE);
     } else {
         // Name each testcase `rule:line:col`, disambiguating a repeat (same rule at the
@@ -131,12 +133,12 @@ fn write_suite<W: Write>(writer: &mut Writer<W>, entry: &ReportEntry) {
                 format!("{base}#{occurrence}")
             };
             *occurrence += 1;
-            let message = sanitize_control(&problem.message);
+            let message = xml_sanitize(&problem.message);
             let body = format!("{}:{} {message}", problem.line, problem.column);
             write_case_with_child(
                 writer,
                 &name,
-                &entry.path,
+                path.as_ref(),
                 "failure",
                 message.as_ref(),
                 rule,
@@ -148,6 +150,30 @@ fn write_suite<W: Write>(writer: &mut Writer<W>, entry: &ReportEntry) {
     writer
         .write_event(Event::End(BytesEnd::new("testsuite")))
         .expect(INFALLIBLE);
+}
+
+/// Like [`sanitize_control`], but also escapes the U+FFFE/U+FFFF noncharacters that XML
+/// 1.0 forbids even as numeric references, so a crafted scalar cannot make the `JUnit`
+/// document unparsable. JSON has no such restriction, so `GitLab` output keeps plain
+/// [`sanitize_control`]. (Control characters are the only other XML-invalid scalars a Rust
+/// `char` can hold — surrogates are unrepresentable — so this covers the whole gap.)
+fn xml_sanitize(text: &str) -> Cow<'_, str> {
+    fn forbidden(c: char) -> bool {
+        c.is_control() || c == '\u{fffe}' || c == '\u{ffff}'
+    }
+    if !text.contains(forbidden) {
+        return Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        if forbidden(c) {
+            write!(out, "\\u{{{:x}}}", c as u32)
+                .expect("writing to a String is infallible");
+        } else {
+            out.push(c);
+        }
+    }
+    Cow::Owned(out)
 }
 
 /// Write a `<testcase>` wrapping a single `<failure>` or `<error>` child carrying the

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -1120,3 +1120,31 @@ fn output_file_symlinked_to_an_input_is_rejected() {
         "the aliased input must be left untouched"
     );
 }
+
+#[test]
+fn blank_ci_project_dir_does_not_panic() {
+    // A set-but-blank CI_PROJECT_DIR is treated as unset; it must not panic lexical_abspath.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, _stderr) = run(Command::new(exe)
+        .env("CI_PROJECT_DIR", "")
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(
+        code, 1,
+        "a blank CI_PROJECT_DIR must report diagnostics, not panic"
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("valid JSON output, not a panic");
+    assert_eq!(
+        json.as_array().unwrap().len(),
+        1,
+        "the diagnostic is still reported"
+    );
+}

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -1148,3 +1148,38 @@ fn blank_ci_project_dir_does_not_panic() {
         "the diagnostic is still reported"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn output_file_hardlinked_to_an_input_is_rejected() {
+    // A hard-linked --output-file shares the input's inode under a distinct path; the
+    // file-identity (same-file) check must refuse it so the report cannot truncate the
+    // input through the hard link.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let input = dir.path().join("real.yaml");
+    fs::write(&input, "key: value").unwrap();
+    let original = fs::read_to_string(&input).unwrap();
+    let hardlink = dir.path().join("hard.yaml");
+    fs::hard_link(&input, &hardlink).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&hardlink)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&input));
+    assert_eq!(code, 2, "a hard-linked output aliasing an input is refused");
+    assert!(
+        stderr.contains("is also a linted input"),
+        "expected a collision message: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&input).unwrap(),
+        original,
+        "the hard-linked input must be left untouched"
+    );
+}

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -1085,3 +1085,38 @@ fn stdin_output_file_matching_stdin_filename_is_rejected() {
         "the named file must be left untouched"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn output_file_symlinked_to_an_input_is_rejected() {
+    // A symlinked --output-file resolving to a linted input must be refused (canonical-path
+    // match), not just an exact lexical match, so the report cannot truncate the source.
+    use std::os::unix::fs::symlink;
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let input = dir.path().join("real.yaml");
+    fs::write(&input, "key: value").unwrap();
+    let original = fs::read_to_string(&input).unwrap();
+    let link = dir.path().join("alias.yaml");
+    symlink(&input, &link).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&link)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&input));
+    assert_eq!(code, 2, "a symlinked output aliasing an input is refused");
+    assert!(
+        stderr.contains("is also a linted input"),
+        "expected a collision message: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&input).unwrap(),
+        original,
+        "the aliased input must be left untouched"
+    );
+}

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -1183,3 +1183,30 @@ fn output_file_hardlinked_to_an_input_is_rejected() {
         "the hard-linked input must be left untouched"
     );
 }
+
+#[test]
+fn gitlab_path_uses_dotdot_for_files_outside_the_project_root() {
+    // A file above CI_PROJECT_DIR is expressed with `..` segments (ruff-style), not an
+    // absolute path.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dir.path().join("dirty.yaml");
+    fs::write(&file, "key: value").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, _stderr) = run(Command::new(exe)
+        // Project root is a subdirectory below the file, so the file is one level up.
+        .env("CI_PROJECT_DIR", dir.path().join("sub"))
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("gitlab output is JSON");
+    assert_eq!(
+        json[0]["location"]["path"], "../dirty.yaml",
+        "a file above the project root uses a `..` segment: {stdout}"
+    );
+}

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -457,3 +457,631 @@ fn auto_format_respects_no_color_env() {
         "NO_COLOR should disable ANSI sequences: {stderr}"
     );
 }
+
+// --- JUnit / GitLab report formats (issue #285) ---
+
+/// A file missing its trailing newline trips `new-line-at-end-of-file`, giving every
+/// report format at least one diagnostic to render.
+fn dirty_yaml(dir: &std::path::Path) -> std::path::PathBuf {
+    let file = dir.join("dirty.yaml");
+    fs::write(&file, "key: value").unwrap();
+    file
+}
+
+#[test]
+fn gitlab_format_writes_json_array_to_stdout() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1, "gitlab format keeps the error exit code");
+    assert!(
+        stderr.is_empty(),
+        "report formats go to stdout, not stderr: {stderr}"
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("gitlab output is a JSON array");
+    let issues = json.as_array().expect("top level array");
+    assert_eq!(issues.len(), 1, "one diagnostic expected: {stdout}");
+    assert_eq!(issues[0]["check_name"], "new-line-at-end-of-file");
+    assert_eq!(issues[0]["severity"], "major");
+    assert_eq!(issues[0]["location"]["lines"]["begin"], 1);
+}
+
+#[test]
+fn junit_format_writes_xml_to_stdout() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("junit")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1, "junit format keeps the error exit code");
+    assert!(
+        stderr.is_empty(),
+        "report formats go to stdout, not stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("<testsuites name=\"ryl\""),
+        "junit output should start with a testsuites root: {stdout}"
+    );
+    assert!(
+        stdout.contains("type=\"new-line-at-end-of-file\""),
+        "the diagnostic's rule id should appear as the failure type: {stdout}"
+    );
+}
+
+#[test]
+fn output_file_writes_report_and_leaves_streams_clean() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let report = dir.path().join("report.xml");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("junit")
+        .arg("-o")
+        .arg(&report)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1, "--output-file keeps the error exit code");
+    assert!(
+        stdout.is_empty(),
+        "with --output-file nothing goes to stdout: {stdout}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "with --output-file nothing goes to stderr: {stderr}"
+    );
+    let written = fs::read_to_string(&report).expect("report file written");
+    assert!(
+        written.contains("<testsuites"),
+        "the report file holds the junit document: {written}"
+    );
+}
+
+#[test]
+fn output_file_redirects_streaming_format() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let report = dir.path().join("out.txt");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("parsable")
+        .arg("-o")
+        .arg(&report)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1, "redirected streaming format keeps the error exit");
+    assert!(
+        stderr.is_empty(),
+        "--output-file diverts the streaming diagnostics: {stderr}"
+    );
+    let written = fs::read_to_string(&report).expect("report file written");
+    assert!(
+        written.contains(": [error]") && written.contains("new-line-at-end-of-file"),
+        "the parsable diagnostic should be in the file: {written}"
+    );
+}
+
+#[test]
+fn output_file_open_failure_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    // A path under a directory that does not exist cannot be created.
+    let report = dir.path().join("missing-dir").join("report.json");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&report)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "an unopenable --output-file is a usage error");
+    assert!(
+        stderr.contains("cannot open --output-file"),
+        "expected an open-failure message: {stderr}"
+    );
+}
+
+#[test]
+fn diff_with_report_format_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("--diff")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "--diff with a report format is a usage error");
+    assert!(
+        stderr.contains("`--diff` cannot be combined with"),
+        "expected the diff/report conflict message: {stderr}"
+    );
+}
+
+#[test]
+fn gitlab_reports_processing_error_as_blocker() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let missing = dir.path().join("absent.yaml");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, _stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&missing));
+    assert_eq!(code, 1, "a file that cannot be read is an error");
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("gitlab output is JSON");
+    let issues = json.as_array().expect("array");
+    assert_eq!(issues.len(), 1, "the read failure is one issue: {stdout}");
+    assert_eq!(issues[0]["check_name"], "error");
+    assert_eq!(issues[0]["severity"], "blocker");
+}
+
+#[test]
+fn gitlab_format_reads_stdin_with_filename() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let mut child = Command::new(exe)
+        // The path is relativized against CI_PROJECT_DIR when set; clear it so the
+        // assertion holds regardless of the surrounding (GitLab) CI environment.
+        .env_remove("CI_PROJECT_DIR")
+        .arg("-")
+        .arg("--format")
+        .arg("gitlab")
+        .arg("--stdin-filename")
+        .arg("nested/from-stdin.yaml")
+        .arg("-c")
+        .arg(&cfg)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn ryl");
+    use std::io::Write as _;
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"key: value")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdin diagnostic keeps error exit"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("gitlab output is JSON");
+    assert_eq!(
+        json[0]["location"]["path"], "nested/from-stdin.yaml",
+        "the stdin filename becomes location.path: {stdout}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn output_file_write_failure_is_reported() {
+    // `/dev/full` opens successfully but fails every write with ENOSPC, exercising the
+    // destination-write error path (the one fallible step of the output pipeline).
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg("/dev/full")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "a failed write is a usage error");
+    assert!(
+        stderr.contains("failed to write output"),
+        "expected a write-failure message: {stderr}"
+    );
+}
+
+/// Spawn ryl reading `input` from stdin with the given args, returning (code, stdout, stderr).
+fn run_stdin(args: &[&str], input: &[u8]) -> (i32, String, String) {
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let mut child = Command::new(exe)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn ryl");
+    use std::io::Write as _;
+    child.stdin.take().unwrap().write_all(input).unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn stdin_diff_with_report_format_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let cfg = cfg.to_str().unwrap();
+
+    let (code, _stdout, stderr) = run_stdin(
+        &["-", "--format", "gitlab", "--diff", "-c", cfg],
+        b"key: value",
+    );
+    assert_eq!(
+        code, 2,
+        "--diff with a report format is a usage error on stdin"
+    );
+    assert!(
+        stderr.contains("`--diff` cannot be combined with"),
+        "expected the diff/report conflict message: {stderr}"
+    );
+}
+
+#[test]
+fn stdin_output_file_open_failure_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let bad = dir.path().join("missing-dir").join("report.json");
+    let (code, _stdout, stderr) = run_stdin(
+        &[
+            "-",
+            "--format",
+            "gitlab",
+            "-o",
+            bad.to_str().unwrap(),
+            "-c",
+            cfg.to_str().unwrap(),
+        ],
+        b"key: value",
+    );
+    assert_eq!(
+        code, 2,
+        "an unopenable --output-file is a usage error on stdin"
+    );
+    assert!(
+        stderr.contains("cannot open --output-file"),
+        "expected an open-failure message: {stderr}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn stdin_output_file_write_failure_is_reported() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let (code, _stdout, stderr) = run_stdin(
+        &[
+            "-",
+            "--format",
+            "gitlab",
+            "-o",
+            "/dev/full",
+            "-c",
+            cfg.to_str().unwrap(),
+        ],
+        b"key: value",
+    );
+    assert_eq!(code, 2, "a failed write is a usage error on stdin");
+    assert!(
+        stderr.contains("failed to write output"),
+        "expected a write-failure message: {stderr}"
+    );
+}
+
+#[test]
+fn output_file_pointing_at_a_linted_input_is_rejected() {
+    // Guard against data loss: writing the report to a file that is also being linted
+    // would truncate the source. Must be refused before any lint/fix runs.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let original = fs::read_to_string(&file).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&file)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "output file colliding with an input is a usage error"
+    );
+    assert!(
+        stderr.contains("is also a linted input"),
+        "expected a collision message: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        original,
+        "the input file must be left untouched"
+    );
+}
+
+#[test]
+fn empty_input_emits_an_empty_gitlab_report() {
+    // A clean/empty project must still produce a valid `[]` artifact, not a missing file.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let empty = dir.path().join("empty");
+    fs::create_dir(&empty).unwrap();
+    let report = dir.path().join("gl.json");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, _stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&report)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&empty));
+    assert_eq!(code, 0, "an empty project lints clean");
+    assert_eq!(
+        fs::read_to_string(&report).unwrap().trim(),
+        "[]",
+        "the report file holds an empty JSON array"
+    );
+}
+
+#[test]
+fn gitlab_path_is_relative_to_ci_project_dir() {
+    // Like ruff, location.path is relativized against CI_PROJECT_DIR when set.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let nested = dir.path().join("pkg");
+    fs::create_dir(&nested).unwrap();
+    let file = nested.join("dirty.yaml");
+    fs::write(&file, "key: value").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, _stderr) = run(Command::new(exe)
+        .env("CI_PROJECT_DIR", dir.path())
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("gitlab output is JSON");
+    assert_eq!(
+        json[0]["location"]["path"], "pkg/dirty.yaml",
+        "path is relative to CI_PROJECT_DIR: {stdout}"
+    );
+}
+
+#[test]
+fn empty_input_report_open_failure_is_usage_error() {
+    // The empty-report path must still surface an unopenable --output-file as a usage error.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let empty = dir.path().join("empty");
+    fs::create_dir(&empty).unwrap();
+    let report = dir.path().join("missing-dir").join("gl.json");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&report)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&empty));
+    assert_eq!(
+        code, 2,
+        "an unopenable --output-file is a usage error even when empty"
+    );
+    assert!(
+        stderr.contains("cannot open --output-file"),
+        "expected an open-failure message: {stderr}"
+    );
+}
+
+#[test]
+fn ignored_stdin_emits_an_empty_gitlab_report() {
+    // An ignored stdin filename is an empty input set; the report must still be a valid `[]`.
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "ignore = [\"ignored.yaml\"]\n[rules]\ncolons = \"enable\"\n",
+    )
+    .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let mut child = Command::new(exe)
+        .current_dir(dir.path())
+        .arg("-")
+        .arg("--stdin-filename")
+        .arg(dir.path().join("ignored.yaml"))
+        .arg("--format")
+        .arg("gitlab")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn ryl");
+    use std::io::Write as _;
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"key:  value\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(0), "ignored stdin lints clean");
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "[]",
+        "ignored stdin still emits an empty JSON array"
+    );
+}
+
+#[test]
+fn ignored_stdin_report_open_failure_is_usage_error() {
+    // The ignored-stdin empty-report path must still surface an unopenable --output-file.
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "ignore = [\"ignored.yaml\"]\n[rules]\ncolons = \"enable\"\n",
+    )
+    .unwrap();
+    let report = dir.path().join("missing-dir").join("gl.json");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let mut child = Command::new(exe)
+        .current_dir(dir.path())
+        .arg("-")
+        .arg("--stdin-filename")
+        .arg(dir.path().join("ignored.yaml"))
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&report)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn ryl");
+    use std::io::Write as _;
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"key:  value\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "unopenable --output-file is a usage error"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("cannot open --output-file"),
+        "expected an open-failure message: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn empty_input_with_output_file_creates_file_for_streaming_format() {
+    // --output-file uniformly produces the file even for an empty streaming-format run.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let empty = dir.path().join("empty");
+    fs::create_dir(&empty).unwrap();
+    let report = dir.path().join("lint.txt");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, _stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("parsable")
+        .arg("-o")
+        .arg(&report)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&empty));
+    assert_eq!(code, 0, "an empty project lints clean");
+    assert_eq!(
+        fs::read_to_string(&report).unwrap(),
+        "",
+        "the output file is created empty for a clean streaming run"
+    );
+}
+
+#[test]
+fn stdin_output_file_matching_stdin_filename_is_rejected() {
+    // The stdin path must honor the same data-loss guard: `-o` equal to the
+    // --stdin-filename would truncate the file that label names.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let target = dir.path().join("config.yaml");
+    fs::write(&target, "original: content\n").unwrap();
+    let original = fs::read_to_string(&target).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let mut child = Command::new(exe)
+        .arg("-")
+        .arg("--stdin-filename")
+        .arg(&target)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&target)
+        .arg("-c")
+        .arg(&cfg)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn ryl");
+    use std::io::Write as _;
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"key: value")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "stdin output-file collision is a usage error"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("is also a linted input"),
+        "expected a collision message: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        original,
+        "the named file must be left untouched"
+    );
+}

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -673,12 +673,7 @@ fn gitlab_format_reads_stdin_with_filename() {
         .spawn()
         .expect("spawn ryl");
     use std::io::Write as _;
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(b"key: value")
-        .unwrap();
+    child.stdin.take().unwrap().write_all(b"key: value").ok();
     let out = child.wait_with_output().unwrap();
     assert_eq!(
         out.status.code(),
@@ -730,7 +725,10 @@ fn run_stdin(args: &[&str], input: &[u8]) -> (i32, String, String) {
         .spawn()
         .expect("spawn ryl");
     use std::io::Write as _;
-    child.stdin.take().unwrap().write_all(input).unwrap();
+    // A usage error (e.g. a rejected `--output-file`) makes ryl exit before reading stdin,
+    // closing the pipe; a broken-pipe write here is expected, so the exit code/output (not
+    // the write) is what the caller asserts.
+    child.stdin.take().unwrap().write_all(input).ok();
     let out = child.wait_with_output().unwrap();
     (
         out.status.code().unwrap_or(-1),
@@ -948,12 +946,7 @@ fn ignored_stdin_emits_an_empty_gitlab_report() {
         .spawn()
         .expect("spawn ryl");
     use std::io::Write as _;
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(b"key:  value\n")
-        .unwrap();
+    child.stdin.take().unwrap().write_all(b"key:  value\n").ok();
     let out = child.wait_with_output().unwrap();
     assert_eq!(out.status.code(), Some(0), "ignored stdin lints clean");
     assert_eq!(
@@ -990,12 +983,7 @@ fn ignored_stdin_report_open_failure_is_usage_error() {
         .spawn()
         .expect("spawn ryl");
     use std::io::Write as _;
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(b"key:  value\n")
-        .unwrap();
+    child.stdin.take().unwrap().write_all(b"key:  value\n").ok();
     let out = child.wait_with_output().unwrap();
     assert_eq!(
         out.status.code(),
@@ -1062,12 +1050,7 @@ fn stdin_output_file_matching_stdin_filename_is_rejected() {
         .spawn()
         .expect("spawn ryl");
     use std::io::Write as _;
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(b"key: value")
-        .unwrap();
+    child.stdin.take().unwrap().write_all(b"key: value").ok();
     let out = child.wait_with_output().unwrap();
     assert_eq!(
         out.status.code(),

--- a/tests/fixtures/gitlab-code-quality.schema.json
+++ b/tests/fixtures/gitlab-code-quality.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Vendored from the GitLab Code Quality report format (https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format), a documented subset of the Code Climate engine spec. ryl validates its `--format gitlab` output against this so the emitter cannot drift from the published contract.",
+  "items": {
+    "properties": {
+      "check_name": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "fingerprint": {
+        "type": "string"
+      },
+      "location": {
+        "properties": {
+          "lines": {
+            "properties": {
+              "begin": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "begin"
+            ],
+            "type": "object"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "lines"
+        ],
+        "type": "object"
+      },
+      "severity": {
+        "enum": [
+          "info",
+          "minor",
+          "major",
+          "critical",
+          "blocker"
+        ]
+      }
+    },
+    "required": [
+      "description",
+      "check_name",
+      "fingerprint",
+      "severity",
+      "location"
+    ],
+    "type": "object"
+  },
+  "title": "GitLab Code Quality report",
+  "type": "array"
+}

--- a/tests/property_report.rs
+++ b/tests/property_report.rs
@@ -15,6 +15,7 @@ use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
 use quick_xml::Reader;
 use quick_xml::events::Event;
+use ryl::cli_support::github_escape;
 use ryl::report::{ReportEntry, render_gitlab, render_junit};
 use ryl::{LintProblem, Severity};
 use serde_json::Value;
@@ -29,7 +30,8 @@ static GITLAB_SCHEMA: LazyLock<Validator> = LazyLock::new(|| {
 
 /// Characters spanning ryl's real escaping surface: ordinary text, XML metacharacters,
 /// JSON-ish punctuation, C0/DEL control characters, the whitespace controls XML keeps,
-/// NEL/LS/PS line separators, and multibyte scalars.
+/// NEL/LS/PS line separators, the U+FFFE/U+FFFF noncharacters XML 1.0 forbids, and
+/// multibyte scalars.
 fn arb_char() -> impl Strategy<Value = char> {
     prop_oneof![
         Just('a'),
@@ -60,6 +62,8 @@ fn arb_char() -> impl Strategy<Value = char> {
         Just('\u{85}'),
         Just('\u{2028}'),
         Just('\u{2029}'),
+        Just('\u{fffe}'),
+        Just('\u{ffff}'),
         Just('é'),
         Just('日'),
         Just('🦀'),
@@ -224,5 +228,20 @@ proptest! {
         prop_assert_eq!(root_tests, Some(testcases), "root tests count mismatch");
         prop_assert_eq!(root_failures, Some(failures), "root failures count mismatch");
         prop_assert_eq!(root_errors, Some(errors), "root errors count mismatch");
+    }
+
+    /// The GitHub workflow-command format is a line-oriented protocol, so its only injection
+    /// defense is `github_escape`: no input may leave a control character (a newline would
+    /// start a new `::command::`) in the encoded text, in either data or property mode.
+    #[test]
+    fn github_escape_never_emits_a_control_character(
+        text in arb_hostile_string(),
+        property in any::<bool>(),
+    ) {
+        let escaped = github_escape(&text, property);
+        prop_assert!(
+            !escaped.chars().any(|c| c.is_control()),
+            "github_escape leaked a control character from {text:?}: {escaped:?}"
+        );
     }
 }

--- a/tests/property_report.rs
+++ b/tests/property_report.rs
@@ -1,0 +1,228 @@
+//! Property tests for the report emitters (`ryl::report::render_junit`/`render_gitlab`).
+//!
+//! These fuzz the *output* path the deterministic `report_formats.rs` tests only sample:
+//! arbitrary [`ReportEntry`] lists with hostile paths and messages (control characters, XML
+//! and JSON metacharacters, line separators, multibyte) are rendered and checked against
+//! oracle-free invariants. The headline ones are escaping/injection robustness: JUnit output
+//! must *always* re-parse as well-formed XML, and GitLab output must *always* parse as JSON
+//! and validate against the vendored schema (the same contract the deterministic test uses).
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use jsonschema::{Validator, validator_for};
+use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use ryl::report::{ReportEntry, render_gitlab, render_junit};
+use ryl::{LintProblem, Severity};
+use serde_json::Value;
+
+/// The published GitLab contract, compiled once and reused across every generated case.
+static GITLAB_SCHEMA: LazyLock<Validator> = LazyLock::new(|| {
+    let schema: Value =
+        serde_json::from_str(include_str!("fixtures/gitlab-code-quality.schema.json"))
+            .expect("vendored schema is valid JSON");
+    validator_for(&schema).expect("vendored schema compiles")
+});
+
+/// Characters spanning ryl's real escaping surface: ordinary text, XML metacharacters,
+/// JSON-ish punctuation, C0/DEL control characters, the whitespace controls XML keeps,
+/// NEL/LS/PS line separators, and multibyte scalars.
+fn arb_char() -> impl Strategy<Value = char> {
+    prop_oneof![
+        Just('a'),
+        Just('Z'),
+        Just('0'),
+        Just(' '),
+        Just('/'),
+        Just('.'),
+        Just('-'),
+        Just('<'),
+        Just('>'),
+        Just('&'),
+        Just('"'),
+        Just('\''),
+        Just('{'),
+        Just('}'),
+        Just('['),
+        Just(']'),
+        Just(':'),
+        Just(','),
+        Just('\u{0}'),
+        Just('\u{1}'),
+        Just('\u{1b}'),
+        Just('\u{7f}'),
+        Just('\t'),
+        Just('\n'),
+        Just('\r'),
+        Just('\u{85}'),
+        Just('\u{2028}'),
+        Just('\u{2029}'),
+        Just('é'),
+        Just('日'),
+        Just('🦀'),
+    ]
+}
+
+fn arb_hostile_string() -> impl Strategy<Value = String> {
+    proptest::collection::vec(arb_char(), 0..16)
+        .prop_map(|chars| chars.into_iter().collect())
+}
+
+fn arb_rule() -> impl Strategy<Value = Option<&'static str>> {
+    prop_oneof![
+        Just(None),
+        Just(Some("commas")),
+        Just(Some("colons")),
+        Just(Some("truthy")),
+        Just(Some("key-duplicates")),
+    ]
+}
+
+fn arb_problem() -> impl Strategy<Value = LintProblem> {
+    (
+        1usize..1000,
+        1usize..200,
+        prop_oneof![Just(Severity::Error), Just(Severity::Warning)],
+        arb_rule(),
+        arb_hostile_string(),
+    )
+        .prop_map(|(line, column, level, rule, message)| LintProblem {
+            line,
+            column,
+            level,
+            message,
+            rule,
+        })
+}
+
+/// `error` and `problems` are mutually exclusive in real entries (a file failed to process,
+/// or it has diagnostics, or it is clean); the generator mirrors that.
+fn arb_entry() -> impl Strategy<Value = ReportEntry> {
+    (
+        arb_hostile_string(),
+        prop_oneof![
+            arb_hostile_string().prop_map(|error| (Vec::new(), Some(error))),
+            proptest::collection::vec(arb_problem(), 0..6)
+                .prop_map(|problems| (problems, None)),
+        ],
+    )
+        .prop_map(|(path, (problems, error))| ReportEntry {
+            path,
+            problems,
+            error,
+        })
+}
+
+fn arb_entries() -> impl Strategy<Value = Vec<ReportEntry>> {
+    proptest::collection::vec(arb_entry(), 0..6)
+}
+
+/// The value of `element`'s `key` attribute, decoded lossily, if present.
+fn read_attr(element: &quick_xml::events::BytesStart, key: &[u8]) -> Option<String> {
+    element.attributes().flatten().find_map(|attr| {
+        (attr.key.as_ref() == key)
+            .then(|| String::from_utf8_lossy(attr.value.as_ref()).into_owned())
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 512,
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "tests/proptest-regressions/property_report.txt",
+        ))),
+        ..ProptestConfig::default()
+    })]
+
+    /// GitLab output is always valid JSON, validates against the vendored schema, uses only
+    /// the allowed severities, has report-unique fingerprints, and one issue per diagnostic
+    /// (plus one per processing error; clean files contribute none).
+    #[test]
+    fn gitlab_output_is_always_valid_and_schema_conformant(entries in arb_entries()) {
+        let bytes = render_gitlab(&entries);
+        let json: Value = serde_json::from_slice(&bytes)
+            .map_err(|err| TestCaseError::fail(format!("invalid JSON: {err}")))?;
+        prop_assert!(
+            GITLAB_SCHEMA.is_valid(&json),
+            "output does not satisfy the GitLab schema: {json}"
+        );
+
+        let issues = json.as_array().expect("schema guarantees a top-level array");
+        let expected: usize = entries
+            .iter()
+            .map(|entry| if entry.error.is_some() { 1 } else { entry.problems.len() })
+            .sum();
+        prop_assert_eq!(issues.len(), expected, "one issue per diagnostic/error");
+
+        let mut fingerprints = HashSet::new();
+        for issue in issues {
+            let severity = issue["severity"].as_str().unwrap();
+            prop_assert!(
+                matches!(severity, "major" | "minor" | "blocker"),
+                "unexpected severity {severity}"
+            );
+            let fingerprint = issue["fingerprint"].as_str().unwrap();
+            prop_assert!(
+                fingerprints.insert(fingerprint.to_owned()),
+                "duplicate fingerprint {fingerprint} within a report"
+            );
+        }
+    }
+
+    /// JUnit output is always well-formed XML (the re-parse fails otherwise), the root
+    /// `<testsuites>` counts equal the actual element tallies, and no two testcases in a
+    /// suite share a `name`.
+    #[test]
+    fn junit_output_is_always_well_formed_with_consistent_counts(
+        entries in arb_entries(),
+    ) {
+        let bytes = render_junit(&entries);
+        let xml = String::from_utf8(bytes)
+            .map_err(|err| TestCaseError::fail(format!("non-UTF-8 output: {err}")))?;
+
+        let mut reader = Reader::from_str(&xml);
+        let (mut root_tests, mut root_failures, mut root_errors) = (None, None, None);
+        let (mut testcases, mut failures, mut errors) = (0usize, 0usize, 0usize);
+        let mut suite_names: HashSet<String> = HashSet::new();
+        loop {
+            match reader.read_event() {
+                Err(err) => {
+                    return Err(TestCaseError::fail(format!("malformed XML: {err}")));
+                }
+                Ok(Event::Eof) => break,
+                Ok(Event::Start(element) | Event::Empty(element)) => {
+                    match element.name().as_ref() {
+                        b"testsuites" => {
+                            root_tests = read_attr(&element, b"tests")
+                                .and_then(|value| value.parse::<usize>().ok());
+                            root_failures = read_attr(&element, b"failures")
+                                .and_then(|value| value.parse::<usize>().ok());
+                            root_errors = read_attr(&element, b"errors")
+                                .and_then(|value| value.parse::<usize>().ok());
+                        }
+                        b"testsuite" => suite_names.clear(),
+                        b"testcase" => {
+                            testcases += 1;
+                            let name = read_attr(&element, b"name").unwrap_or_default();
+                            prop_assert!(
+                                suite_names.insert(name.clone()),
+                                "duplicate testcase name {name} within a suite"
+                            );
+                        }
+                        b"failure" => failures += 1,
+                        b"error" => errors += 1,
+                        _ => {}
+                    }
+                }
+                Ok(_) => {}
+            }
+        }
+
+        prop_assert_eq!(root_tests, Some(testcases), "root tests count mismatch");
+        prop_assert_eq!(root_failures, Some(failures), "root failures count mismatch");
+        prop_assert_eq!(root_errors, Some(errors), "root errors count mismatch");
+    }
+}

--- a/tests/report_formats.rs
+++ b/tests/report_formats.rs
@@ -257,6 +257,47 @@ fn junit_output_is_well_formed_with_matching_counts() {
 }
 
 #[test]
+fn junit_disambiguates_testcases_at_an_identical_position() {
+    // Two diagnostics from the same rule at the same line:col must get distinct testcase
+    // names, or a JUnit consumer that dedups by name would drop one.
+    let entries = vec![ReportEntry {
+        path: "dup.yaml".to_string(),
+        problems: vec![
+            problem(2, 3, Severity::Error, Some("commas"), "first"),
+            problem(2, 3, Severity::Error, Some("commas"), "second"),
+        ],
+        error: None,
+    }];
+    let xml = junit_xml(&entries);
+
+    let mut reader = Reader::from_str(&xml);
+    let mut names = Vec::new();
+    loop {
+        match reader.read_event().expect("well-formed XML") {
+            Event::Start(element) | Event::Empty(element)
+                if element.name().as_ref() == b"testcase" =>
+            {
+                for attr in element.attributes() {
+                    let attr = attr.expect("valid attribute");
+                    if attr.key.as_ref() == b"name" {
+                        names.push(
+                            String::from_utf8_lossy(attr.value.as_ref()).into_owned(),
+                        );
+                    }
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    assert_eq!(names.len(), 2, "two testcases expected: {xml}");
+    assert_ne!(
+        names[0], names[1],
+        "duplicate-position testcases need unique names"
+    );
+}
+
+#[test]
 fn junit_escapes_special_characters_in_messages() {
     // A crafted message with XML metacharacters must round-trip through the writer and a
     // re-parse, proving quick-xml escaped it rather than producing malformed XML.

--- a/tests/report_formats.rs
+++ b/tests/report_formats.rs
@@ -355,6 +355,25 @@ fn junit_message_cannot_inject_extra_elements() {
 }
 
 #[test]
+fn junit_escapes_xml_forbidden_noncharacters() {
+    // U+FFFE/U+FFFF are valid Rust chars but illegal in XML 1.0 (even as references); they
+    // must be escaped so a crafted scalar cannot make the whole report unparsable.
+    let raw = "boom\u{fffe}\u{ffff}";
+    let entries = vec![ReportEntry {
+        path: "p.yaml".to_string(),
+        problems: vec![problem(1, 1, Severity::Error, Some("commas"), raw)],
+        error: None,
+    }];
+    let xml = junit_xml(&entries);
+    // element_counts re-parses the document and panics on malformed XML.
+    assert_eq!(element_counts(&xml).get("failure"), Some(&1));
+    assert!(
+        !xml.contains('\u{fffe}') && !xml.contains('\u{ffff}'),
+        "XML-forbidden noncharacters must not appear raw in the output: {xml}"
+    );
+}
+
+#[test]
 fn gitlab_message_cannot_inject_json_structure() {
     // A message crafted to break out of its JSON string must be encoded as data, never
     // injecting a sibling field or extra issue.

--- a/tests/report_formats.rs
+++ b/tests/report_formats.rs
@@ -1,0 +1,291 @@
+//! In-process validation of the JUnit XML and GitLab JSON report emitters
+//! (`ryl::report`). GitLab output is checked against the vendored schema
+//! (`tests/fixtures/gitlab-code-quality.schema.json`, the published GitLab contract);
+//! JUnit output is re-parsed with quick-xml so structure and escaping are verified without
+//! an external XSD validator. Driving the emitters directly (rather than the CLI) keeps the
+//! assertions deterministic and exercises every report.rs branch.
+
+use std::collections::HashMap;
+
+use jsonschema::validator_for;
+use quick_xml::Reader;
+use quick_xml::escape::unescape;
+use quick_xml::events::Event;
+use ryl::report::{ReportEntry, render_gitlab, render_junit};
+use ryl::{LintProblem, Severity};
+use serde_json::Value;
+
+fn problem(
+    line: usize,
+    column: usize,
+    level: Severity,
+    rule: Option<&'static str>,
+    message: &str,
+) -> LintProblem {
+    LintProblem {
+        line,
+        column,
+        level,
+        message: message.to_string(),
+        rule,
+    }
+}
+
+fn gitlab_json(entries: &[ReportEntry]) -> Value {
+    serde_json::from_slice(&render_gitlab(entries))
+        .expect("gitlab output is valid JSON")
+}
+
+fn junit_xml(entries: &[ReportEntry]) -> String {
+    String::from_utf8(render_junit(entries)).expect("junit output is UTF-8")
+}
+
+/// Element-name -> occurrence count over an XML document; panics on malformed XML, so a
+/// successful parse is itself the well-formedness (and escaping) assertion.
+fn element_counts(xml: &str) -> HashMap<String, usize> {
+    let mut reader = Reader::from_str(xml);
+    let mut counts = HashMap::new();
+    loop {
+        match reader
+            .read_event()
+            .expect("junit output is well-formed XML")
+        {
+            Event::Start(element) | Event::Empty(element) => {
+                let name =
+                    String::from_utf8_lossy(element.name().as_ref()).into_owned();
+                *counts.entry(name).or_insert(0) += 1;
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    counts
+}
+
+#[test]
+fn gitlab_output_matches_vendored_schema_and_maps_severity() {
+    let schema: Value =
+        serde_json::from_str(include_str!("fixtures/gitlab-code-quality.schema.json"))
+            .expect("vendored schema is valid JSON");
+    let validator = validator_for(&schema).expect("vendored schema compiles");
+
+    let entries = vec![
+        ReportEntry {
+            path: "sub/dirty.yaml".to_string(),
+            problems: vec![
+                problem(3, 5, Severity::Error, Some("commas"), "too many spaces"),
+                problem(4, 1, Severity::Warning, Some("truthy"), "truthy value"),
+                problem(5, 2, Severity::Error, None, "syntax error: boom"),
+            ],
+            error: None,
+        },
+        ReportEntry {
+            path: "broken.yaml".to_string(),
+            problems: Vec::new(),
+            error: Some("failed to read broken.yaml".to_string()),
+        },
+    ];
+
+    let json = gitlab_json(&entries);
+    assert!(
+        validator.is_valid(&json),
+        "gitlab output must satisfy the published schema: {json}"
+    );
+
+    let issues = json.as_array().expect("top level is an array");
+    assert_eq!(
+        issues.len(),
+        4,
+        "three diagnostics plus one processing error"
+    );
+
+    let severities: Vec<&str> = issues
+        .iter()
+        .map(|issue| issue["severity"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        severities,
+        ["major", "minor", "major", "blocker"],
+        "error->major, warning->minor, processing error->blocker"
+    );
+
+    let syntax_issue = &issues[2];
+    assert_eq!(
+        syntax_issue["check_name"], "syntax",
+        "a diagnostic without a rule id reports check_name `syntax`"
+    );
+
+    // GitLab requires relative paths without a `./` prefix.
+    for issue in issues {
+        let path = issue["location"]["path"].as_str().unwrap();
+        assert!(
+            !path.starts_with("./") && !path.starts_with('/'),
+            "location.path must be relative: {path}"
+        );
+    }
+}
+
+#[test]
+fn gitlab_skips_clean_files() {
+    let entries = vec![ReportEntry {
+        path: "clean.yaml".to_string(),
+        problems: Vec::new(),
+        error: None,
+    }];
+    let json = gitlab_json(&entries);
+    assert_eq!(
+        json.as_array().expect("array").len(),
+        0,
+        "a clean file contributes no GitLab issues"
+    );
+}
+
+#[test]
+fn gitlab_duplicate_diagnostics_get_distinct_fingerprints() {
+    // Two byte-identical diagnostics on the same line collide on the base hash; the salt
+    // must disambiguate them so GitLab's within-report uniqueness requirement holds.
+    let entries = vec![ReportEntry {
+        path: "dup.yaml".to_string(),
+        problems: vec![
+            problem(2, 3, Severity::Error, Some("commas"), "too many spaces"),
+            problem(2, 3, Severity::Error, Some("commas"), "too many spaces"),
+        ],
+        error: None,
+    }];
+    let json = gitlab_json(&entries);
+    let issues = json.as_array().unwrap();
+    assert_eq!(issues.len(), 2);
+    assert_ne!(
+        issues[0]["fingerprint"], issues[1]["fingerprint"],
+        "duplicate diagnostics must still produce unique fingerprints"
+    );
+}
+
+#[test]
+fn gitlab_fingerprints_are_stable_across_runs() {
+    let build = || {
+        vec![ReportEntry {
+            path: "a.yaml".to_string(),
+            problems: vec![problem(
+                1,
+                1,
+                Severity::Error,
+                Some("commas"),
+                "too many spaces",
+            )],
+            error: None,
+        }]
+    };
+    let first = gitlab_json(&build());
+    let second = gitlab_json(&build());
+    assert_eq!(
+        first[0]["fingerprint"], second[0]["fingerprint"],
+        "a stable hash keeps the fingerprint constant across runs"
+    );
+}
+
+#[test]
+fn gitlab_fingerprint_ignores_line_shifts() {
+    // An edit elsewhere that shifts a diagnostic's line must not change its fingerprint,
+    // or GitLab would treat the same issue as newly introduced and lose cross-run tracking.
+    let at = |line| {
+        vec![ReportEntry {
+            path: "a.yaml".to_string(),
+            problems: vec![problem(
+                line,
+                1,
+                Severity::Error,
+                Some("commas"),
+                "too many spaces",
+            )],
+            error: None,
+        }]
+    };
+    let early = gitlab_json(&at(3));
+    let later = gitlab_json(&at(40));
+    assert_eq!(
+        early[0]["fingerprint"], later[0]["fingerprint"],
+        "fingerprint must be independent of the diagnostic's line"
+    );
+    assert_ne!(
+        early[0]["location"]["lines"]["begin"], later[0]["location"]["lines"]["begin"],
+        "but the reported line still reflects the actual position"
+    );
+}
+
+#[test]
+fn junit_output_is_well_formed_with_matching_counts() {
+    let entries = vec![
+        ReportEntry {
+            path: "sub/dirty.yaml".to_string(),
+            problems: vec![
+                problem(3, 5, Severity::Error, Some("commas"), "too many spaces"),
+                problem(4, 1, Severity::Warning, None, "syntax error"),
+            ],
+            error: None,
+        },
+        ReportEntry {
+            path: "clean.yaml".to_string(),
+            problems: Vec::new(),
+            error: None,
+        },
+        ReportEntry {
+            path: "broken.yaml".to_string(),
+            problems: Vec::new(),
+            error: Some("failed to read broken.yaml".to_string()),
+        },
+    ];
+
+    let xml = junit_xml(&entries);
+    let counts = element_counts(&xml);
+    assert_eq!(counts.get("testsuites"), Some(&1));
+    assert_eq!(counts.get("testsuite"), Some(&3), "one suite per file");
+    assert_eq!(
+        counts.get("testcase"),
+        Some(&4),
+        "two failures, one clean, one error"
+    );
+    assert_eq!(counts.get("failure"), Some(&2));
+    assert_eq!(counts.get("error"), Some(&1));
+
+    assert!(
+        xml.contains(
+            "<testsuites name=\"ryl\" tests=\"4\" failures=\"2\" errors=\"1\">"
+        ),
+        "root totals should aggregate every suite: {xml}"
+    );
+}
+
+#[test]
+fn junit_escapes_special_characters_in_messages() {
+    // A crafted message with XML metacharacters must round-trip through the writer and a
+    // re-parse, proving quick-xml escaped it rather than producing malformed XML.
+    let raw = "a < b & \"c\" > d";
+    let entries = vec![ReportEntry {
+        path: "x.yaml".to_string(),
+        problems: vec![problem(1, 1, Severity::Error, Some("commas"), raw)],
+        error: None,
+    }];
+    let xml = junit_xml(&entries);
+
+    let mut reader = Reader::from_str(&xml);
+    let message = loop {
+        match reader.read_event().expect("well-formed XML") {
+            Event::Start(element) if element.name().as_ref() == b"failure" => {
+                let attr = element
+                    .attributes()
+                    .find_map(|attr| {
+                        let attr = attr.expect("valid attribute");
+                        (attr.key.as_ref() == b"message").then_some(attr)
+                    })
+                    .expect("failure has a message attribute");
+                let escaped =
+                    std::str::from_utf8(attr.value.as_ref()).expect("UTF-8 value");
+                break unescape(escaped).expect("attribute unescapes").into_owned();
+            }
+            Event::Eof => panic!("no failure element found"),
+            _ => {}
+        }
+    };
+    assert_eq!(message, raw, "the message must survive XML escaping intact");
+}

--- a/tests/report_formats.rs
+++ b/tests/report_formats.rs
@@ -330,3 +330,50 @@ fn junit_escapes_special_characters_in_messages() {
     };
     assert_eq!(message, raw, "the message must survive XML escaping intact");
 }
+
+#[test]
+fn junit_message_cannot_inject_extra_elements() {
+    // A message crafted to close the <failure> and open a new <testcase> must be escaped to
+    // text: the document stays well-formed with exactly one testcase and one failure.
+    let raw = "boom</failure><testcase name=\"x\"/><failure>";
+    let entries = vec![ReportEntry {
+        path: "p.yaml".to_string(),
+        problems: vec![problem(1, 1, Severity::Error, Some("commas"), raw)],
+        error: None,
+    }];
+    let counts = element_counts(&junit_xml(&entries));
+    assert_eq!(
+        counts.get("testcase"),
+        Some(&1),
+        "the payload must not inject a testcase"
+    );
+    assert_eq!(
+        counts.get("failure"),
+        Some(&1),
+        "the payload must not inject a failure element"
+    );
+}
+
+#[test]
+fn gitlab_message_cannot_inject_json_structure() {
+    // A message crafted to break out of its JSON string must be encoded as data, never
+    // injecting a sibling field or extra issue.
+    let raw = "evil\",\"check_name\":\"injected\",\"x\":\"\n}], [{";
+    let entries = vec![ReportEntry {
+        path: "p.yaml".to_string(),
+        problems: vec![problem(1, 1, Severity::Error, Some("commas"), raw)],
+        error: None,
+    }];
+    let json = gitlab_json(&entries);
+    let issues = json.as_array().expect("array");
+    assert_eq!(issues.len(), 1, "the payload must not create extra issues");
+    assert_eq!(
+        issues[0]["check_name"], "commas",
+        "check_name comes from the rule, not an injected message field"
+    );
+    let description = issues[0]["description"].as_str().unwrap();
+    assert!(
+        !description.contains('\n'),
+        "control characters are stripped from the description: {description:?}"
+    );
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -26,6 +26,7 @@ nav = [
     { "Per-line ignores" = "per-line-ignores.md" },
     { "YAML in Markdown" = "markdown.md" },
   ]},
+  { "Output formats" = "output-formats.md" },
   { "YAML version compatibility" = "yaml-version.md" },
 ]
 


### PR DESCRIPTION
Closes #285.

Adds two machine-readable output formats so `ryl` results can be ingested by Git forges, modelled on ruff's CLI.

## What's new
- **`--format junit`** — JUnit XML (`<testsuites>`/`<testsuite>` per file/`<testcase>` per diagnostic), built with `quick-xml`.
- **`--format gitlab`** — [GitLab Code Quality](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format) JSON array, built with `serde_json`.
- **`-o/--output-file`** — write the selected format to a file (any format). Console formats stay on **stderr**; the report formats serialize to **stdout** by default (or the `-o` file).

## Design notes
- **ruff-aligned CLI** (single format choice + `--output-file`). It does **not** emit a report file and console output *simultaneously* (the issue's pytest-style ask); ruff/eslint don't either. That remains a possible follow-up (golangci-style `fmt:path`, or a dedicated side-artifact flag) — flagging for the issue author.
- **`quick-xml` rather than ruff's `quick-junit`**, to avoid pulling in `chrono`/`uuid`; `quick-xml` (1.5k★) + `sha2` (2.2k★) are the only new deps.
- **Stable fingerprints**: SHA-256 over `(path, rule, message)` — deliberately not line/column, so an edit that shifts a line keeps the GitLab issue tracked (ruff's trade-off).
- **Paths**: `location.path` relativized against `CI_PROJECT_DIR` or cwd (like ruff), no `./` prefix.
- **Data-loss guards**: an `-o` resolving to a linted input or the `--stdin-filename` is refused; `-o` is opened before `--fix` mutates; an empty/ignored input still emits a valid empty report (`[]` / empty `<testsuites>`) so CI artifact ingestion never sees a missing file.

## Validation & tests
- GitLab output validated against a vendored JSON Schema (`tests/fixtures/gitlab-code-quality.schema.json`) via the `jsonschema` dev-dep; JUnit re-parsed with `quick-xml`.
- New `tests/report_formats.rs` (in-process) + extensive `tests/cli_format_options.rs` coverage (stdout/stderr/file routing, collisions, empty/ignored inputs, CI_PROJECT_DIR, stdin).
- prek green; full suite passes; zero uncovered lines/regions. Reviewed locally (code-review + 5 rounds of Codex).

Docs: `docs/output-formats.md` (+ nav), `AGENTS.md` CLI Behavior, migrating-from-yamllint note.