### PR TITLE
Multi-target output: repeatable --format/--output-file + TOML [output] (closes #285)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,6 +443,18 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   opaque mechanic that names cannot (the standard minimal-comment bar applies).
 - `#[cfg(test)]` modules inside `src/` is forbidden; add coverage through integration
   tests in `tests/` so LLVM regions stay unique.
+- **Config-discovery isolation.** ryl's project-config discovery climbs from each input
+  through its ancestors up to `HOME`, so a test whose inputs live under the system temp
+  dir can walk into that shared dir and discover a stray `ryl.toml`/`.ryl.toml`/
+  `pyproject.toml`/`.yamllint*` left by another test, a concurrent process, or a manual
+  smoke run — silently overriding the test's setup (and a TOML candidate outranks a
+  tempdir's `.yamllint`, so an adjacent YAML config does not shield it). Any test that
+  exercises discovery (does **not** pass `-c`/`-d`, and has no adjacent TOML config in its
+  input's directory) must build its command via `common::cli::ryl(<its tempdir>)`, which
+  sets `HOME` to bound the walk at the tempdir. Tests that pass `-c`/`-d` bypass discovery
+  and need no isolation; tests that write an adjacent `.ryl.toml` are already shielded.
+  Correspondingly, manual/agent smoke runs must keep scratch configs in a dedicated
+  subdirectory and never drop a config-candidate-named file at the temp root.
 - CLI/system tests that drive `env!("CARGO_BIN_EXE_ryl")` run under CI's environment,
   where `GITHUB_ACTIONS` makes ryl auto-select the GitHub output format
   (`::error file=…,line=L,col=C::L:C [rule] message`) rather than the standard format
@@ -623,33 +635,56 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
   message. The `default`/`relaxed`/`empty` presets stay available via `extends:` (YAML
   only). `--migrate-configs` (warns instead) and `--list-files` are exempt.
 - Output formats (`--format`/`-f`): the streaming console formats `standard`/`colored`/
-  `github`/`parsable` write per-diagnostic lines to **stderr** (unchanged); the
-  whole-document report formats `junit` (JUnit XML via `quick-xml`) and `gitlab` (GitLab
-  Code Quality JSON via `serde_json`) buffer every file and serialize once to **stdout**.
-  `auto` never selects junit/gitlab. `process_results` (in `main`) does the shared
-  filter+tally pass for all formats then either streams or hands a `Vec<ReportEntry>` to
-  `ryl::report::render_junit`/`render_gitlab`. `-o/--output-file` redirects the selected
-  format to a file (any format), `conflicts_with` `--diff`; `--format junit|gitlab` with
-  `--diff` is rejected by `reject_diff_with_report_format`. An `--output-file` that
-  lexically resolves to a linted input or the `--stdin-filename` is refused
-  (`reject_output_file_collision`: lexical-path match, plus a `same_file::Handle`
-  file-identity match for an existing destination so a symlinked or hard-linked `-o` is
-  caught too) so the report cannot truncate the source — stricter than ruff, which guards
-  nothing; other destinations (e.g. a config file) are overwritten as directed. An
-  empty/all-ignored input set still emits a valid empty report (`emit_empty_report`:
-  `[]` / `<testsuites .../>`) so CI artifact ingestion does not see a missing file.
-  `report::ReportEntry` carries the report display path (relativized via
-  `cli_support::report_display_path` against the project root =
-  `CI_PROJECT_DIR` or cwd, like ruff; forward-slashed, no `./` prefix; a path outside the
-  root gets `..` segments), the kept problems, and an optional processing-error
-  message. GitLab severity maps error->`major`, warning->`minor`, a read/parse
-  failure->`blocker`; its `fingerprint` is a stable SHA-256 (`sha2`) of
+  `github`/`parsable` default to **stderr**; the whole-document report formats `junit`
+  (JUnit XML via `quick-xml`) and `gitlab` (GitLab Code Quality JSON via `serde_json`)
+  default to **stdout**. `auto` never selects junit/gitlab. **Multiple outputs per run**
+  (RuboCop/Biome model): `--format` is repeatable and each `-o/--output-file` binds to
+  the most recent `--format` (`resolve_cli_targets` recovers CLI order via
+  `ArgMatches::indices_of`, so `main` uses `Cli::command().get_matches()` +
+  `from_arg_matches`); `-o -` is stdout, a path is a file, none is the format's default
+  stream. Console + a report file in one run is therefore supported (closes #285's
+  original ask), e.g. `--format auto --format gitlab -o gl.json`. An `[output]` **TOML
+  table** (ryl-only, TOML-only — `config_schema::OutputTable`/`OutputDestination`,
+  rejected in YAML config) configures the same per-format destinations
+  (`[output.gitlab] path=…`; absent `path` = default stream, `"-"` = stdout). Precedence
+  **CLI > config > default**: `resolve_targets` returns the CLI pairs if any `--format`
+  was given, else `config_targets_from_table` of the run config's `[output]`, else one
+  default auto-console target. The `[output]` is read run-level by `run_output_config`
+  (the `-c`/`-d`/env global config, else the inputs-anchored project config so `ryl .`
+  honors a project `.ryl.toml`; a malformed config is propagated — the empty-input case
+  has no per-file discovery to surface it, so an invalid `[output]` still errors). `--diff`
+  skips config `[output]` (it has its own unified-diff output), so only an explicit CLI
+  `--format junit|gitlab` conflicts with it. Pipeline: `collect_records` does the shared
+  filter+tally once into format-agnostic `FileRecord{path,kept,error}`; `write_targets`
+  renders each target via `render_target` (`render_streaming` + an `append_*` fn for
+  console formats; `render_junit`/`render_gitlab` over `build_entries` for reports, built
+  once and shared) and `commit`s to each `open_destination` (a file is opened create+write
+  **without** truncate, then truncated+written at commit, so an *existing* artifact survives
+  a later target failing to open; a *freshly*-created destination may be left empty on a
+  rejected run — cleaning it by path would race a concurrent writer, so it is left for the
+  failed run, gate CI artifact use on the exit code). `open_targets` opens all destinations
+  before `--fix` mutates (unopenable `-o` fails fast). Guards (each exit 2):
+  `resolve_cli_targets` rejects an unpaired `-o` and a second `-o` on one `--format`;
+  `validate_targets` rejects `--diff` with a report format and two outputs on one stream
+  (`reject_duplicate_streams`, ≤1 stdout / ≤1 stderr); `open_targets` then rejects two
+  outputs resolving to one file (`reject_colliding_output_files`, post-open so file
+  identity resolves symlink/hard-link/aliased-parent destinations — `PathIdentity` =
+  lexical + `same_file::Handle`; an unreadable existing destination matches lexically only,
+  an adversarial case); `reject_input_collisions` refuses an output that is also a linted
+  input or the `--stdin-filename` (same lexical + `same_file::Handle` match), so a report
+  can never truncate the source. `--output-file` `conflicts_with` `--diff` in clap. An
+  empty/all-ignored input set still emits a valid empty report per target (`emit_targets`
+  with empty records → `[]` / `<testsuites .../>`). `report::ReportEntry`
+  carries the report display path (relativized via `cli_support::report_display_path`
+  against the project root = `CI_PROJECT_DIR` or cwd, like ruff; forward-slashed, no `./`
+  prefix; a path outside the root gets `..` segments), the kept problems, and an optional
+  processing-error message. GitLab severity maps error->`major`, warning->`minor`, a
+  read/parse failure->`blocker`; its `fingerprint` is a stable SHA-256 (`sha2`) of
   `(path, rule, message)` — deliberately NOT line/column, so an edit that shifts the line
   keeps the issue tracked — salted to stay unique within a report (`DefaultHasher` would
-  not be stable across toolchains). A clean file is a passing JUnit testcase and is omitted
-  from GitLab. Output is validated against authoritative sources in tests: GitLab against
-  the vendored `tests/fixtures/gitlab-code-quality.schema.json` (via the `jsonschema`
-  dev-dep), JUnit by re-parsing with `quick-xml`. See `docs/output-formats.md`. ryl follows
-  ruff's model (single format + `--output-file`); it does not (yet) emit a report file and
-  console output simultaneously.
+  not be stable across toolchains). A clean file is a passing JUnit testcase and is
+  omitted from GitLab. Output is validated against authoritative sources in tests: GitLab
+  against the vendored `tests/fixtures/gitlab-code-quality.schema.json` (via the
+  `jsonschema` dev-dep), JUnit by re-parsing with `quick-xml`. See
+  `docs/output-formats.md`.
 - Exit codes: `0` (ok/none), `1` (invalid YAML), `2` (usage error).

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -217,10 +217,12 @@ option is configured in TOML and rejected in yamllint-compatible YAML config.
 ### JUnit and GitLab report formats
 
 yamllint offers `standard`, `parsable`, `colored`, `github`, and `auto` output formats.
-ryl keeps those and adds two machine-readable report formats modelled on ruff:
-`--format junit` (JUnit XML) and `--format gitlab` (GitLab Code Quality JSON). These write
-to stdout (or to a file with `-o`/`--output-file`) so a Git forge can ingest them as a
-report artifact. See [Output formats](../output-formats.md).
+ryl keeps those and adds two machine-readable report formats: `--format junit` (JUnit XML)
+and `--format gitlab` (GitLab Code Quality JSON), which write to stdout (or to a file with
+`-o`/`--output-file`) so a Git forge can ingest them as a report artifact. Going beyond
+yamllint, `--format` is repeatable and each pairs with its own `--output-file`, so a single
+run can emit console diagnostics **and** one or more report files; the same targets can be
+set in a ryl-only TOML `[output]` table. See [Output formats](../output-formats.md).
 
 ## Side-by-side example
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -20,34 +20,76 @@ error.
 
 ## Choosing where output goes
 
-The console formats (`standard`, `colored`, `github`, `parsable`) print diagnostics to
-**stderr**. The report formats (`junit`, `gitlab`) print to **stdout**, so they can be
-redirected into an artifact file:
+Each format has a default stream: the console formats (`standard`, `colored`, `github`,
+`parsable`) go to **stderr**, and the report formats (`junit`, `gitlab`) go to **stdout**,
+so a report can be redirected into an artifact file:
 
 ```console
 $ ryl --format gitlab . > gl-code-quality-report.json
 ```
 
-`--output-file` (`-o`) writes the selected format to a file instead of its default
-stream, which is the most robust option in CI (no shell redirection of the wrong stream):
+### Multiple outputs in one run
+
+`--format` (`-f`) is repeatable, and each `--output-file` (`-o`) binds to the **most
+recent** `--format`, so a single run can produce several outputs at once (the RuboCop /
+Biome model). `-o` takes a file path, or `-` for stdout:
 
 ```console
-$ ryl --format junit -o report.xml .
-$ ryl --format gitlab -o gl-code-quality-report.json .
+# console diagnostics on stderr AND a GitLab report written to a file
+$ ryl --format auto --format gitlab -o gl-code-quality-report.json .
+
+# a JUnit file and a GitLab file together, with no console output
+$ ryl --format junit -o report.xml --format gitlab -o gl.json .
 ```
 
-This follows the same model as ruff and eslint: one format goes to one place per run. To
-see human output **and** keep a report file in a single run, pipe the console output
-through `tee`, or run `ryl` twice.
+A `--format` with no `--output-file` uses its default stream, so the way to get your usual
+console output **and** a report file is to add the report `--format` with its own `-o`, as
+in the first example above.
 
-`--output-file` cannot be combined with `--diff` (which previews fixes and ignores
-`--format`), and `--format junit`/`--format gitlab` cannot be combined with `--diff`. An
-`--output-file` that points at a file being linted (or at the `--stdin-filename`) is
-refused, so a report can never truncate the source it just linted. Otherwise
-`--output-file` overwrites its destination, so do not point it at a file you want to keep
-(such as a config file). A clean or empty project still produces a valid empty report
-(`[]` for GitLab, an empty `<testsuites>` for JUnit), so a CI step that ingests the
-artifact never fails on a missing file.
+The rules that keep the outputs unambiguous (each a usage error, exit code 2):
+
+- an `--output-file` must follow a `--format`, since it binds to that format;
+- a `--format` takes at most one `--output-file`;
+- at most one output may go to stdout and at most one to the console (stderr); two
+  documents sharing a stream would interleave, so give the others a file destination;
+- two outputs may not resolve to the same file (the second would clobber the first);
+- an output file that is also a linted input (or the `--stdin-filename`) is refused, so a
+  report can never truncate the source it just linted.
+
+Otherwise an `--output-file` overwrites its destination, so do not point it at a file you
+want to keep. `--diff` previews fixes and ignores `--format`, so it combines with neither
+`--output-file` nor `--format junit`/`--format gitlab`. A clean or empty project still
+produces a valid empty report for each report target (`[]` for GitLab, an empty
+`<testsuites>` for JUnit), so a CI step that ingests the artifact never fails on a missing
+file.
+
+### Configuring outputs in TOML
+
+The same outputs can be set once in a project's TOML config under `[output]`, so `ryl .`
+in CI produces the artifacts without repeating the flags. Each format is a sub-table; an
+absent `path` uses that format's default stream, `path = "-"` is stdout, and any other
+value is a file:
+
+```toml
+# keep the normal console output, and also write a GitLab report file
+[output.auto]
+
+[output.gitlab]
+path = "gl-code-quality-report.json"
+```
+
+`[output]` is ryl-only and TOML-only (it is rejected in a YAML config). It is read once
+from the configuration governing the run: the `-c`/`-d` config, or the project config
+discovered for the inputs (so a project's `.ryl.toml` applies to `ryl .`). A CLI
+`--format` overrides the entire `[output]` table, so the command line always wins over the
+config. The same unambiguous-output rules above apply to a config that declares several
+targets.
+
+`[output]` produces a single, run-level set of artifacts, so it is read from one config.
+That is unambiguous for a single project (one root, or subdirectories that share the
+project config). If you point one run at *separate* projects that each declare their own
+differing `[output]`, the first project config discovered along the inputs wins; pass
+`-c`/`-d` to choose the output config explicitly in that case.
 
 ## JUnit XML
 
@@ -71,13 +113,19 @@ clean file is a single passing testcase; a file that could not be read or parsed
 ```
 
 In GitLab CI it is published with `artifacts:reports:junit`; other forges that render
-JUnit reports consume it the same way. The shape follows the de-facto
-[JUnit XML specification](https://llg.cubic.org/docs/junit/).
+JUnit reports consume it the same way. JUnit XML has no single official standard; `ryl`
+follows the [`junit-10.xsd`](https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd)
+schema maintained by the Jenkins xUnit plugin (the most authoritative published schema),
+cross-checked against the widely cited
+[JUnit XML reference](https://llg.cubic.org/docs/junit/).
 
 ## GitLab Code Quality
 
 The GitLab report is a single JSON array, one object per diagnostic, matching the
-[Code Quality report format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format):
+[Code Quality report format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format),
+a documented subset of the Code Climate engine's
+[`spec/analyzers/SPEC.md`](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md)
+(the underlying standard):
 
 ```json
 [

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -158,6 +158,103 @@
       ],
       "type": "string"
     },
+    "OutputDestination": {
+      "additionalProperties": false,
+      "description": "Where one format's output goes. An absent `path` means the format's default stream\n(stderr for the console formats, stdout for `junit`/`gitlab`); `\"-\"` means stdout; any\nother value is a file path.",
+      "properties": {
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "OutputTable": {
+      "additionalProperties": false,
+      "description": "Output targets (ryl-only; TOML). Each format present is rendered to its destination,\nso several formats produce several outputs in one run (e.g. console plus a report\nfile). A CLI `--format` overrides this table wholesale. yamllint has no equivalent;\nsee `docs/output-formats.md`.",
+      "properties": {
+        "auto": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Auto-detected console format (GitHub annotations in CI, otherwise colored/plain)."
+        },
+        "colored": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Plain text with ANSI colors."
+        },
+        "github": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "GitHub Actions workflow commands."
+        },
+        "gitlab": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "`GitLab` Code Quality JSON report."
+        },
+        "junit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "`JUnit` XML test report."
+        },
+        "parsable": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "One `path:line:col: [level] message (rule)` line per diagnostic."
+        },
+        "standard": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Plain text grouped per file."
+        }
+      },
+      "type": "object"
+    },
     "PerLineIgnore": {
       "additionalProperties": false,
       "description": "A single `per-line-ignores` entry. Suppresses `rules` on source lines matching\n`regex` (the whole physical line, unanchored) within files matching `path` (a\nglob). All present fields must match (logical AND); at least one of `regex`/`path`\nis required (validated in `validate_toml_config`), so an entry can't disable a rule\nglobally.",
@@ -2127,6 +2224,17 @@
         }
       ],
       "description": "Behaviour for YAML embedded in markdown (front matter and fenced blocks)."
+    },
+    "output": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OutputTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Output targets: which format goes to which destination (file/stdout/stderr)."
     },
     "per-file-ignores": {
       "additionalProperties": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 use crate::config_schema::{
     FixRuleName as TomlFixRuleName, FixableRuleSelector as TomlFixableRuleSelector,
     NormalizedConfig, NormalizedFixConfig, NormalizedMarkdown, NormalizedPerLineIgnore,
-    TomlConfig, normalize_toml_config, normalized_config_to_toml_value,
+    OutputTable, TomlConfig, normalize_toml_config, normalized_config_to_toml_value,
     parse_toml_config_str, parse_yaml_config, validate_toml_config,
     yaml_rule_filter_patterns, yaml_rule_level,
 };
@@ -154,6 +154,9 @@ pub struct YamlLintConfig {
     markdown_from_flag: bool,
     lint_markdown_front_matter: bool,
     lint_markdown_fenced_blocks: bool,
+    /// Output targets from a TOML `[output]` table (ryl-only). Run-level: read once from
+    /// the config governing the invocation, then resolved into destinations by the CLI.
+    output: Option<OutputTable>,
     locale: Option<String>,
     fix: FixConfig,
 }
@@ -508,6 +511,7 @@ impl Default for YamlLintConfig {
             markdown_from_flag: false,
             lint_markdown_front_matter: true,
             lint_markdown_fenced_blocks: true,
+            output: None,
             locale: None,
             fix: FixConfig::default(),
         }
@@ -798,6 +802,13 @@ impl YamlLintConfig {
         self.lint_markdown_fenced_blocks
     }
 
+    /// The TOML `[output]` table, if the config declared one (ryl-only). The CLI resolves
+    /// it into output destinations; a CLI `--format` overrides it wholesale.
+    #[must_use]
+    pub fn output(&self) -> Option<&OutputTable> {
+        self.output.as_ref()
+    }
+
     fn from_yaml_str_with_env(
         s: &str,
         envx: Option<&dyn Env>,
@@ -915,6 +926,12 @@ impl YamlLintConfig {
             if let Some(fenced_blocks) = markdown.fenced_blocks {
                 self.lint_markdown_fenced_blocks = fenced_blocks;
             }
+        }
+
+        // A child config's `[output]` replaces an `extends:` base's wholesale (last wins);
+        // omitting it preserves the base, mirroring the other top-level tables here.
+        if normalized.output.is_some() {
+            self.output = normalized.output;
         }
 
         if !normalized.per_file_ignores.is_empty() {
@@ -1258,6 +1275,7 @@ fn normalized_config_from_runtime(config: &YamlLintConfig) -> NormalizedConfig {
                 fenced_blocks: Some(config.lint_markdown_fenced_blocks),
             },
         ),
+        output: config.output.clone(),
         locale: config.locale.clone(),
         fix: normalized_fix_config(&config.fix),
         rules: config

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -21,6 +21,8 @@ pub struct TomlConfig {
     pub files: Option<FilesTable>,
     /// Behaviour for YAML embedded in markdown (front matter and fenced blocks).
     pub markdown: Option<MarkdownTable>,
+    /// Output targets: which format goes to which destination (file/stdout/stderr).
+    pub output: Option<OutputTable>,
     /// Ignore patterns, either as one multi-line string or a list of patterns.
     pub ignore: Option<StringOrVec>,
     /// Paths to files that contain ignore patterns.
@@ -72,6 +74,56 @@ pub struct MarkdownTable {
     /// Lint fenced `yaml`/`yml` code blocks. Defaults to `true`.
     #[serde(rename = "fenced-blocks")]
     pub fenced_blocks: Option<bool>,
+}
+
+/// Output targets (ryl-only; TOML). Each format present is rendered to its destination,
+/// so several formats produce several outputs in one run (e.g. console plus a report
+/// file). A CLI `--format` overrides this table wholesale. yamllint has no equivalent;
+/// see `docs/output-formats.md`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OutputTable {
+    /// Auto-detected console format (GitHub annotations in CI, otherwise colored/plain).
+    pub auto: Option<OutputDestination>,
+    /// Plain text grouped per file.
+    pub standard: Option<OutputDestination>,
+    /// Plain text with ANSI colors.
+    pub colored: Option<OutputDestination>,
+    /// GitHub Actions workflow commands.
+    pub github: Option<OutputDestination>,
+    /// One `path:line:col: [level] message (rule)` line per diagnostic.
+    pub parsable: Option<OutputDestination>,
+    /// `JUnit` XML test report.
+    pub junit: Option<OutputDestination>,
+    /// `GitLab` Code Quality JSON report.
+    pub gitlab: Option<OutputDestination>,
+}
+
+impl OutputTable {
+    /// Every format entry as `(format-name, destination?)`, in a fixed order. The single
+    /// authoritative enumeration of the table's fields: validation iterates it, and the
+    /// CLI resolves each name to a target, so neither hand-maintains a parallel list.
+    #[must_use]
+    pub fn entries(&self) -> [(&'static str, Option<&OutputDestination>); 7] {
+        [
+            ("auto", self.auto.as_ref()),
+            ("standard", self.standard.as_ref()),
+            ("colored", self.colored.as_ref()),
+            ("github", self.github.as_ref()),
+            ("parsable", self.parsable.as_ref()),
+            ("junit", self.junit.as_ref()),
+            ("gitlab", self.gitlab.as_ref()),
+        ]
+    }
+}
+
+/// Where one format's output goes. An absent `path` means the format's default stream
+/// (stderr for the console formats, stdout for `junit`/`gitlab`); `"-"` means stdout; any
+/// other value is a file path.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OutputDestination {
+    pub path: Option<String>,
 }
 
 /// JSON Schema root for yamllint-compatible YAML configuration.
@@ -977,11 +1029,32 @@ pub fn validate_toml_config(config: &TomlConfig) -> Result<(), String> {
         validation::validate_per_line_ignores(entries)?;
     }
 
+    if let Some(output) = config.output.as_ref() {
+        validate_output_table(output)?;
+    }
+
     validate_common_config(
         config.ignore.as_ref(),
         config.ignore_from_file.as_ref(),
         config.rules.as_ref(),
     )
+}
+
+/// Reject an empty `path` in an `[output.<format>]` table. An empty path can neither be a
+/// file (`File::create("")` fails) nor mean stdout (`"-"`), and the CLI's lexical path
+/// normalization rejects empty paths, so it is a config error rather than a silent no-op.
+fn validate_output_table(output: &OutputTable) -> Result<(), String> {
+    for (name, destination) in output.entries() {
+        if let Some(destination) = destination
+            && destination.path.as_deref() == Some("")
+        {
+            return Err(format!(
+                "invalid config: output.{name}.path must not be empty (omit it for the \
+                 default stream, or use \"-\" for stdout)"
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Validate semantic constraints for a typed YAML config model.
@@ -1031,6 +1104,9 @@ pub struct NormalizedConfig {
     pub yaml_file_patterns: Option<Vec<String>>,
     pub markdown_file_patterns: Option<Vec<String>>,
     pub markdown: Option<NormalizedMarkdown>,
+    /// Output targets, passed through unchanged (no transformation needed; the CLI
+    /// resolves each format/path into a destination at render time).
+    pub output: Option<OutputTable>,
     pub locale: Option<String>,
     pub fix: Option<NormalizedFixConfig>,
     pub rules: BTreeMap<String, YamlOwned>,
@@ -1111,6 +1187,13 @@ pub(crate) fn parse_yaml_config(doc: &YamlOwned) -> Result<ParsedYamlConfig, Str
     if doc.as_mapping_get("per-line-ignores").is_some() {
         return Err(
             "invalid config: per-line-ignores is only supported in TOML configuration"
+                .to_string(),
+        );
+    }
+
+    if doc.as_mapping_get("output").is_some() {
+        return Err(
+            "invalid config: output is only supported in TOML configuration"
                 .to_string(),
         );
     }

--- a/src/config_schema/serialization.rs
+++ b/src/config_schema/serialization.rs
@@ -160,6 +160,7 @@ pub fn normalize_toml_config(config: &TomlConfig) -> NormalizedConfig {
             .as_ref()
             .and_then(|files| files.markdown.clone()),
         markdown: config.markdown.as_ref().map(normalize_markdown_table),
+        output: config.output.clone(),
         locale: config.locale.clone(),
         fix: config.fix.as_ref().map(normalize_fix_table),
         rules: config
@@ -185,6 +186,7 @@ pub fn normalize_yaml_config(config: &YamlConfig) -> NormalizedConfig {
         yaml_file_patterns: config.yaml_files.clone(),
         markdown_file_patterns: None,
         markdown: None,
+        output: None,
         locale: config.locale.clone(),
         fix: None,
         rules: config
@@ -296,6 +298,7 @@ pub fn toml_config_to_value(config: &TomlConfig) -> toml::Value {
     let mut table = toml::map::Map::new();
     insert_serialized(&mut table, "files", config.files.as_ref());
     insert_serialized(&mut table, "markdown", config.markdown.as_ref());
+    insert_serialized(&mut table, "output", config.output.as_ref());
     insert_serialized(&mut table, "ignore", config.ignore.as_ref());
     insert_serialized(
         &mut table,
@@ -372,6 +375,8 @@ pub fn normalized_config_to_toml_value(config: &NormalizedConfig) -> toml::Value
             normalized_markdown_to_toml_value(markdown),
         );
     }
+
+    insert_serialized(&mut table, "output", config.output.as_ref());
 
     if let Some(ignore_from_file) = config.ignore_from_files.as_ref() {
         insert_string_array(&mut table, "ignore-from-file", ignore_from_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,19 +207,22 @@ struct Cli {
     #[arg(short = 'd', long = "config-data", value_name = "YAML")]
     config_data: Option<String>,
 
-    /// Output format (auto, standard, colored, github, parsable, junit, gitlab)
-    #[arg(short = 'f', long = "format", default_value_t = CliFormat::Auto, value_enum)]
-    format: CliFormat,
+    /// Output format (auto, standard, colored, github, parsable, junit, gitlab). Repeatable:
+    /// each `--format` may be followed by an `--output-file` to send that format to a file,
+    /// so console and report artifacts can be produced together.
+    #[arg(short = 'f', long = "format", value_enum)]
+    format: Vec<CliFormat>,
 
-    /// Write the formatted output to this file instead of the default stream (stderr for
-    /// the console formats, stdout for junit/gitlab)
+    /// Destination for the preceding `--format` (a path, or `-` for stdout). Repeatable;
+    /// each binds to the most recent `--format`. Default stream otherwise: stderr for the
+    /// console formats, stdout for junit/gitlab.
     #[arg(
         short = 'o',
         long = "output-file",
         value_name = "FILE",
         conflicts_with = "diff"
     )]
-    output_file: Option<PathBuf>,
+    output_file: Vec<PathBuf>,
 
     // These print-and-exit meta-actions ignore every other input/flag; mark them
     // `exclusive` so combining them with a lint/fix/format request is a usage error
@@ -366,6 +369,17 @@ impl OutputFormat {
             Self::Standard | Self::Colored | Self::Github | Self::Parsable
         )
     }
+}
+
+// TODO(#285): temporary bridge while `--format`/`-o` are repeatable but the multi-target
+// resolution is not wired yet — collapse to the last occurrence (current single-output
+// behavior). Replaced by the (format -> destination) target resolution.
+fn primary_format(formats: &[CliFormat]) -> CliFormat {
+    formats.last().copied().unwrap_or(CliFormat::Auto)
+}
+
+fn primary_output_file(files: &[PathBuf]) -> Option<&Path> {
+    files.last().map(PathBuf::as_path)
 }
 
 fn detect_output_format(choice: CliFormat) -> OutputFormat {
@@ -540,7 +554,7 @@ fn supports_color() -> bool {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    match run_cli(cli) {
+    match run_cli(&cli) {
         Ok(code) => code,
         Err(err) => {
             // Usage/config errors embed user-controlled paths and config values;
@@ -552,7 +566,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run_cli(cli: Cli) -> Result<ExitCode, String> {
+fn run_cli(cli: &Cli) -> Result<ExitCode, String> {
     // A pure meta-action that ignores every other input/flag, like the
     // schema-print flags below; clap_complete derives the script from `Cli`.
     if let Some(shell) = cli.generate_completions {
@@ -576,13 +590,13 @@ fn run_cli(cli: Cli) -> Result<ExitCode, String> {
     }
 
     if cli.migrate_configs {
-        return run_migration(&cli);
+        return run_migration(cli);
     }
 
     run_lint(cli)
 }
 
-fn run_lint(cli: Cli) -> Result<ExitCode, String> {
+fn run_lint(cli: &Cli) -> Result<ExitCode, String> {
     let stdin_input = Path::new("-");
     let has_stdin = cli.inputs.iter().any(|p| p.as_path() == stdin_input);
     if has_stdin {
@@ -596,7 +610,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
                 "error: `--fix` is not supported when reading from stdin".to_string()
             );
         }
-        return run_stdin_lint(&cli);
+        return run_stdin_lint(cli);
     }
 
     if cli.stdin_filename.is_some() {
@@ -614,7 +628,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
     }
 
     // Build a global config if -d/-c provided or env var set; else None for per-file discovery.
-    let mut global_cfg = build_global_cfg(&cli.inputs, &cli)?;
+    let mut global_cfg = build_global_cfg(&cli.inputs, cli)?;
     if cli.lint.markdown
         && let Some(ctx) = global_cfg.as_mut()
     {
@@ -626,12 +640,12 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
             eprintln!("{}", sanitize_control(notice));
         }
     }
-    let inputs = cli.inputs;
+    let inputs = &cli.inputs;
 
     // Determine files to parse from mixed inputs.
     // - Directories: recursively gather only .yml/.yaml
     // - Files: include as-is (even if extension isn't yaml)
-    let (candidates, explicit_files) = gather_inputs(&inputs);
+    let (candidates, explicit_files) = gather_inputs(inputs);
 
     // Filter directory candidates via ignores, respecting global vs per-file behavior.
     let mut cache: HashMap<PathBuf, (PathBuf, YamlLintConfig, bool)> = HashMap::new();
@@ -654,12 +668,12 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    let output_format = detect_output_format(cli.format);
+    let output_format = detect_output_format(primary_format(&cli.format));
     reject_diff_with_report_format(cli.lint.fix.diff, output_format)?;
 
     // Refuse an --output-file that resolves to a linted input: writing the report there
     // would truncate the source we just linted (and, with --fix, the freshly-fixed file).
-    if let Some(output) = cli.output_file.as_deref() {
+    if let Some(output) = primary_output_file(&cli.output_file) {
         reject_output_file_collision(
             output,
             files.iter().map(|(path, ..)| path.as_path()),
@@ -669,7 +683,7 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
     if files.is_empty() {
         // A clean or fully-ignored project still gets a valid empty report, so CI artifact
         // ingestion sees `[]` / `<testsuites .../>` rather than a missing or invalid file.
-        emit_empty_report(cli.output_file.as_deref(), output_format)?;
+        emit_empty_report(primary_output_file(&cli.output_file), output_format)?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -681,20 +695,33 @@ fn run_lint(cli: Cli) -> Result<ExitCode, String> {
         return Ok(emit_diff(&diff_safe_fixes_for_files(&files)?));
     }
 
-    // Open the destination before `--fix` mutates anything, so an unopenable --output-file
-    // fails fast rather than leaving sources fixed-but-no-report.
-    let mut sink = open_output_sink(cli.output_file.as_deref(), output_format)?;
+    lint_and_exit(&files, cli, output_format)
+}
+
+/// Open the output destination (before `--fix` mutates anything, so an unopenable
+/// `--output-file` fails fast), apply fixes if requested, lint, render the chosen format,
+/// write it, print the `--fix` summary, and map the tally to an exit code.
+///
+/// # Errors
+///
+/// Returns an error if a file cannot be read/written or the output destination fails.
+fn lint_and_exit(
+    files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
+    cli: &Cli,
+    output_format: OutputFormat,
+) -> Result<ExitCode, String> {
+    let mut sink =
+        open_output_sink(primary_output_file(&cli.output_file), output_format)?;
 
     let initial_problem_count = if cli.lint.fix.fix {
-        apply_fixes_reporting_skips(&files, cli.lint.compatibility.no_warnings)?
+        apply_fixes_reporting_skips(files, cli.lint.compatibility.no_warnings)?
     } else {
         0
     };
 
-    let results = lint_files(&files);
-
+    let results = lint_files(files);
     let (summary, output) = process_results(
-        &files,
+        files,
         results,
         output_format,
         cli.lint.compatibility.no_warnings,
@@ -751,12 +778,12 @@ fn summary_to_exit(summary: &LintSummary, strict: bool) -> ExitCode {
 
 fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     let (path, base_dir, cfg, apply_yaml_files, config_found) = resolve_stdin_ctx(cli)?;
-    let output_format = detect_output_format(cli.format);
+    let output_format = detect_output_format(primary_format(&cli.format));
     reject_diff_with_report_format(cli.lint.fix.diff, output_format)?;
 
     // The stdin content is labelled by `--stdin-filename`; refuse writing the report to
     // that same path so it cannot truncate the file the label names.
-    if let Some(output) = cli.output_file.as_deref() {
+    if let Some(output) = primary_output_file(&cli.output_file) {
         reject_output_file_collision(output, std::iter::once(path.as_path()))?;
     }
 
@@ -764,7 +791,7 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     else {
         // An ignored stdin filename is an empty input set: still emit a valid empty
         // report so CI artifact ingestion does not see a missing file.
-        emit_empty_report(cli.output_file.as_deref(), output_format)?;
+        emit_empty_report(primary_output_file(&cli.output_file), output_format)?;
         return Ok(ExitCode::SUCCESS);
     };
 
@@ -786,7 +813,8 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     let files = vec![(path, base_dir, cfg, kind)];
     let results = vec![(0usize, outcome)];
 
-    let mut sink = open_output_sink(cli.output_file.as_deref(), output_format)?;
+    let mut sink =
+        open_output_sink(primary_output_file(&cli.output_file), output_format)?;
     let (summary, output) = process_results(
         &files,
         results,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, ValueEnum};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use ryl::cli_support::{
@@ -22,7 +22,9 @@ use ryl::cli_support::{
 use ryl::config::{
     ConfigContext, Overrides, SourceKind, YamlLintConfig, discover_config,
 };
-use ryl::config_schema::{schema_string_pretty, yaml_schema_string_pretty};
+use ryl::config_schema::{
+    OutputDestination, OutputTable, schema_string_pretty, yaml_schema_string_pretty,
+};
 use ryl::decoder;
 use ryl::fix::{
     DiffStats, apply_safe_fixes_to_files, diff_outcome, diff_safe_fixes_for_files,
@@ -118,6 +120,40 @@ fn build_global_cfg(
     } else {
         Ok(None)
     }
+}
+
+/// The TOML `[output]` table governing the run, or `None` if no config declares one.
+/// Read from the global config when one was provided (`-c`/`-d`/env), otherwise from the
+/// project config discovered for the inputs (so `ryl .` picks up the project's
+/// `.ryl.toml [output]`). This is a run-level setting, read once rather than per file; a
+/// CLI `--format` overrides whatever it returns.
+///
+/// `[output]` is a single, run-level artifact set, so it is sourced from one config. For a
+/// single root (the usual case) that is unambiguous, and inputs that are subdirectories of
+/// one project share that project's config. A run spanning *separate* projects with their
+/// own differing `[output]` tables takes the first project config discovered along the
+/// inputs (deterministic for a given argument list, but argument-order sensitive); pass
+/// `-c`/`-d` to make the output config explicit when that matters.
+///
+/// # Errors
+///
+/// Propagates a config discovery/parse/validation error from the inputs-anchored project
+/// config. With lintable files present this is the same config the per-file path also
+/// reports on; the value here is the empty-input case, where no per-file discovery runs,
+/// so a malformed run config (e.g. an invalid `[output]`) is surfaced rather than silently
+/// ignored — and a CI step relying on a configured report is not left without one.
+fn run_output_config(
+    global_cfg: Option<&ConfigContext>,
+    inputs: &[PathBuf],
+    cli: &Cli,
+) -> Result<Option<OutputTable>, String> {
+    if let Some(ctx) = global_cfg {
+        return Ok(ctx.config.output().cloned());
+    }
+    Ok(discover_config(inputs, &cli_overrides(cli))?
+        .config
+        .output()
+        .cloned())
 }
 
 fn run_migration(cli: &Cli) -> Result<ExitCode, String> {
@@ -371,15 +407,154 @@ impl OutputFormat {
     }
 }
 
-// TODO(#285): temporary bridge while `--format`/`-o` are repeatable but the multi-target
-// resolution is not wired yet — collapse to the last occurrence (current single-output
-// behavior). Replaced by the (format -> destination) target resolution.
-fn primary_format(formats: &[CliFormat]) -> CliFormat {
-    formats.last().copied().unwrap_or(CliFormat::Auto)
+/// Where one output is written.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Destination {
+    Stdout,
+    Stderr,
+    File(PathBuf),
 }
 
-fn primary_output_file(files: &[PathBuf]) -> Option<&Path> {
-    files.last().map(PathBuf::as_path)
+/// One resolved output: a format and where it goes. The unit both the CLI
+/// (`--format` + paired `--output-file`) and the TOML `[output]` table resolve to.
+struct OutputTarget {
+    format: OutputFormat,
+    destination: Destination,
+}
+
+/// A format's destination when none is given: console formats go to stderr (unchanged),
+/// the whole-document report formats to stdout so they can be piped/redirected.
+fn default_destination(format: OutputFormat) -> Destination {
+    if format.is_streaming() {
+        Destination::Stderr
+    } else {
+        Destination::Stdout
+    }
+}
+
+/// Resolve the `--format`/`--output-file` occurrences into output targets, pairing each
+/// `--output-file` with the most recent `--format` (RuboCop/Biome style). `-` means stdout.
+/// Returns an empty vec when no `--format` was given (the caller then falls back to config
+/// `[output]` or the default). Relies on clap arg indices to recover CLI order.
+///
+/// # Errors
+///
+/// Returns a usage error for an `--output-file` with no preceding `--format`, or a second
+/// `--output-file` bound to the same `--format`.
+fn resolve_cli_targets(
+    matches: &ArgMatches,
+    cli: &Cli,
+) -> Result<Vec<OutputTarget>, String> {
+    enum Occurrence {
+        Format(OutputFormat),
+        Output(PathBuf),
+    }
+    let mut occurrences: Vec<(usize, Occurrence)> = Vec::new();
+    if let Some(indices) = matches.indices_of("format") {
+        for (index, format) in indices.zip(&cli.format) {
+            occurrences
+                .push((index, Occurrence::Format(detect_output_format(*format))));
+        }
+    }
+    if let Some(indices) = matches.indices_of("output_file") {
+        for (index, path) in indices.zip(&cli.output_file) {
+            occurrences.push((index, Occurrence::Output(path.clone())));
+        }
+    }
+    occurrences.sort_by_key(|(index, _)| *index);
+
+    // Build (format, explicit destination?) pairs in CLI order; fill defaults at the end.
+    let mut pending: Vec<(OutputFormat, Option<Destination>)> = Vec::new();
+    for (_, occurrence) in occurrences {
+        match occurrence {
+            Occurrence::Format(format) => pending.push((format, None)),
+            Occurrence::Output(path) => {
+                let Some((_, destination)) = pending.last_mut() else {
+                    return Err(
+                        "error: --output-file must follow a --format".to_string()
+                    );
+                };
+                if destination.is_some() {
+                    return Err(
+                        "error: a --format takes at most one --output-file".to_string()
+                    );
+                }
+                *destination = Some(if path.as_os_str() == "-" {
+                    Destination::Stdout
+                } else {
+                    Destination::File(path)
+                });
+            }
+        }
+    }
+    Ok(pending
+        .into_iter()
+        .map(|(format, destination)| OutputTarget {
+            format,
+            destination: destination.unwrap_or_else(|| default_destination(format)),
+        })
+        .collect())
+}
+
+/// The output targets for a run, in precedence order CLI > config > default: the CLI
+/// `--format`/`--output-file` pairs when any `--format` was given, otherwise the TOML
+/// `[output]` table from the run's config when it declares any target, otherwise the
+/// single default target (the auto-detected console format on its default stream).
+///
+/// # Errors
+///
+/// Propagates a `--format`/`--output-file` pairing error from [`resolve_cli_targets`].
+fn resolve_targets(
+    matches: &ArgMatches,
+    cli: &Cli,
+    config_output: Option<&OutputTable>,
+) -> Result<Vec<OutputTarget>, String> {
+    let cli_targets = resolve_cli_targets(matches, cli)?;
+    if !cli_targets.is_empty() {
+        return Ok(cli_targets);
+    }
+    if let Some(config_targets) = config_output.map(config_targets_from_table)
+        && !config_targets.is_empty()
+    {
+        return Ok(config_targets);
+    }
+    let format = detect_output_format(CliFormat::Auto);
+    Ok(vec![OutputTarget {
+        destination: default_destination(format),
+        format,
+    }])
+}
+
+/// Resolve a TOML `[output]` table into targets, one per declared format, in
+/// `OutputTable::entries` order (deterministic output and stream-conflict reporting). Each
+/// entry's name maps to its `CliFormat` (the table field names are exactly the `--format`
+/// value names), so `auto` is env-resolved like the CLI's `--format auto`.
+fn config_targets_from_table(table: &OutputTable) -> Vec<OutputTarget> {
+    table
+        .entries()
+        .into_iter()
+        .filter_map(|(name, destination)| {
+            let destination = destination?;
+            let choice = CliFormat::from_str(name, false)
+                .expect("OutputTable field names match CliFormat value names");
+            Some(config_target(choice, destination))
+        })
+        .collect()
+}
+
+/// One config output entry to a target: `path` absent uses the format's default stream,
+/// `"-"` is stdout, anything else is a file path.
+fn config_target(choice: CliFormat, destination: &OutputDestination) -> OutputTarget {
+    let format = detect_output_format(choice);
+    let destination = match destination.path.as_deref() {
+        None => default_destination(format),
+        Some("-") => Destination::Stdout,
+        Some(path) => Destination::File(PathBuf::from(path)),
+    };
+    OutputTarget {
+        format,
+        destination,
+    }
 }
 
 fn detect_output_format(choice: CliFormat) -> OutputFormat {
@@ -402,47 +577,217 @@ fn detect_output_format(choice: CliFormat) -> OutputFormat {
     }
 }
 
-/// Open the destination for formatted output: the `--output-file` path when given,
-/// otherwise stdout for the whole-document report formats (so they can be redirected or
-/// piped as an artifact) and stderr for the streaming console formats (unchanged
-/// behavior). The console diagnostics are the only thing routed here; notices, `--fix`
-/// summaries, and skip messages always stay on stderr.
-///
-/// # Errors
-///
-/// Returns an error if the `--output-file` path cannot be created.
-fn open_output_sink(
-    output_file: Option<&Path>,
-    format: OutputFormat,
-) -> Result<Box<dyn Write>, String> {
-    if let Some(path) = output_file {
-        let file = File::create(path).map_err(|err| {
-            format!(
-                "error: cannot open --output-file {}: {err}",
-                sanitize_control(&path.display().to_string())
-            )
-        })?;
-        return Ok(Box::new(BufWriter::new(file)));
-    }
-    if format.is_streaming() {
-        Ok(Box::new(std::io::stderr()))
-    } else {
-        Ok(Box::new(BufWriter::new(std::io::stdout())))
+/// An opened output destination. A file is opened with create+write but **not** truncate,
+/// so its current contents survive until [`OutputSink::commit`] truncates and rewrites it —
+/// a later target failing to open then cannot destroy an *existing* artifact (a freshly
+/// created one may be left empty if a later target aborts the run; see [`open_destination`]).
+enum OutputSink {
+    /// stdout or stderr (a console stream; written and flushed as-is).
+    Stream(Box<dyn Write>),
+    /// A `--output-file` target, truncated then written at commit time.
+    File(File),
+}
+
+impl OutputSink {
+    /// Write `bytes` as this sink's complete contents: a stream is written then flushed; a
+    /// file is truncated (clearing any prior artifact) then written from the start and
+    /// flushed. The single fallible step of the output pipeline (rendering is infallible,
+    /// see [`OUTPUT_INFALLIBLE`]); the write/flush are chained into one coverable error.
+    fn commit(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Stream(writer) => {
+                writer.write_all(bytes).and_then(|()| writer.flush())
+            }
+            Self::File(file) => {
+                file.set_len(0).and_then(|()| file.write_all(bytes))?;
+                file.flush()
+            }
+        }
     }
 }
 
-/// `--diff` previews safe fixes and ignores `--format`, so combining it with a
-/// whole-document report format is a usage error rather than a silent no-op. (`--diff`
-/// with `--output-file` is rejected declaratively by clap's `conflicts_with`.)
+/// Open one destination for writing: stdout, stderr, or a file. A file is opened with
+/// create+write but **not** truncate, so an unopenable `--output-file` fails fast (before
+/// `--fix` mutates anything) yet an existing destination's contents survive until
+/// [`OutputSink::commit`] truncates and rewrites it — a later target failing to open then
+/// cannot destroy an existing artifact. (A *freshly*-created destination is left in place,
+/// possibly empty, if a later target/collision aborts the run: cleaning it up by path would
+/// race a concurrent writer at that path, so the empty artifact is left for the failed run
+/// — gate CI artifact use on the exit code.) Console diagnostics are the only thing routed
+/// here; notices, `--fix` summaries, and skip messages always stay on stderr.
 ///
 /// # Errors
 ///
-/// Returns a usage error when `--diff` is combined with `--format junit|gitlab`.
-fn reject_diff_with_report_format(
-    diff: bool,
-    format: OutputFormat,
+/// Returns an error if a [`Destination::File`] path cannot be opened/created.
+fn open_destination(destination: &Destination) -> Result<OutputSink, String> {
+    match destination {
+        Destination::Stdout => Ok(OutputSink::Stream(Box::new(BufWriter::new(
+            std::io::stdout(),
+        )))),
+        Destination::Stderr => Ok(OutputSink::Stream(Box::new(std::io::stderr()))),
+        Destination::File(path) => {
+            let file = File::options()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path)
+                .map_err(|err| {
+                    format!(
+                        "error: cannot open --output-file {}: {err}",
+                        sanitize_control(&path.display().to_string())
+                    )
+                })?;
+            Ok(OutputSink::File(file))
+        }
+    }
+}
+
+/// Open every target's destination up front (so an unopenable `--output-file` fails before
+/// `--fix` mutates any source), then reject two outputs that resolve to the same file. The
+/// collision check runs after opening, so each destination exists and `same_file::Handle`
+/// resolves it through an existing symlink/hard link / aliased parent. Returns the sinks in
+/// target order.
+///
+/// # Errors
+///
+/// Propagates the first [`open_destination`] failure, or a same-file collision among the
+/// `--output-file` targets.
+fn open_targets(targets: &[OutputTarget]) -> Result<Vec<OutputSink>, String> {
+    let sinks = targets
+        .iter()
+        .map(|target| open_destination(&target.destination))
+        .collect::<Result<Vec<_>, _>>()?;
+    reject_colliding_output_files(targets)?;
+    Ok(sinks)
+}
+
+/// Render `records` for each target and write the bytes to that target's (already-opened)
+/// sink. Report entries are built once and shared across any report targets.
+///
+/// # Errors
+///
+/// Propagates the first destination write failure.
+fn write_targets(
+    targets: &[OutputTarget],
+    sinks: &mut [OutputSink],
+    records: &[FileRecord],
 ) -> Result<(), String> {
-    if diff && !format.is_streaming() {
+    let project_root = report_project_root();
+    let entries = targets
+        .iter()
+        .any(|target| !target.format.is_streaming())
+        .then(|| build_entries(records, &project_root));
+    for (target, sink) in targets.iter().zip(sinks.iter_mut()) {
+        let bytes = render_target(target.format, records, entries.as_deref());
+        sink.commit(&bytes)
+            .map_err(|err| write_output_error(&err))?;
+    }
+    Ok(())
+}
+
+/// Open every target's destination, then render and write `records` to each. The combined
+/// open+write step for paths without a `--fix` ordering constraint (the empty-input and
+/// stdin cases); the `--fix` path opens early via [`open_targets`] instead.
+///
+/// # Errors
+///
+/// Propagates an open or write failure.
+fn emit_targets(
+    targets: &[OutputTarget],
+    records: &[FileRecord],
+) -> Result<(), String> {
+    let mut sinks = open_targets(targets)?;
+    write_targets(targets, &mut sinks, records)
+}
+
+/// Render `records` to bytes in `format`. The streaming formats append per-file blocks;
+/// the report formats serialize the pre-built `entries` (always `Some` when a report
+/// target is present, see [`write_targets`]).
+fn render_target(
+    format: OutputFormat,
+    records: &[FileRecord],
+    entries: Option<&[ReportEntry]>,
+) -> Vec<u8> {
+    match format {
+        OutputFormat::Standard => render_streaming(records, append_standard),
+        OutputFormat::Colored => render_streaming(records, append_colored),
+        OutputFormat::Github => render_streaming(records, append_github),
+        OutputFormat::Parsable => render_streaming(records, append_parsable),
+        OutputFormat::Junit => render_junit(entries.expect(REPORT_ENTRIES_BUILT)),
+        OutputFormat::Gitlab => render_gitlab(entries.expect(REPORT_ENTRIES_BUILT)),
+    }
+}
+
+// Report entries are built whenever any target uses a report format, so the Junit/Gitlab
+// arms of `render_target` only ever see `Some`; the `expect` documents that invariant
+// rather than leaving an uncovered `None` arm.
+const REPORT_ENTRIES_BUILT: &str =
+    "report entries are built when a report target is present";
+
+/// Append every record's per-file block to an owned buffer using `append`, skipping clean
+/// files (no error, no kept diagnostics) — the streaming formats print nothing for those.
+/// A processing-error record contributes its (already-sanitized) message line.
+fn render_streaming(
+    records: &[FileRecord],
+    append: fn(&mut Vec<u8>, &Path, &[LintProblem]),
+) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    for record in records {
+        if let Some(message) = &record.error {
+            writeln!(out, "{message}").expect(OUTPUT_INFALLIBLE);
+        } else if !record.kept.is_empty() {
+            append(&mut out, record.path, &record.kept);
+        }
+    }
+    out
+}
+
+/// Convert every record (clean files included) into a [`ReportEntry`] with a project-root
+/// relative display path. Clean files become passing `JUnit` testcases / are omitted by
+/// `GitLab`; the report emitters decide.
+fn build_entries(records: &[FileRecord], project_root: &Path) -> Vec<ReportEntry> {
+    records
+        .iter()
+        .map(|record| ReportEntry {
+            path: report_display_path(record.path, project_root),
+            problems: record.kept.clone(),
+            error: record.error.clone(),
+        })
+        .collect()
+}
+
+/// The `--output-file` paths among `targets` (a stdout/stderr destination has none).
+fn output_file_paths(targets: &[OutputTarget]) -> impl Iterator<Item = &Path> {
+    targets
+        .iter()
+        .filter_map(|target| match &target.destination {
+            Destination::File(path) => Some(path.as_path()),
+            Destination::Stdout | Destination::Stderr => None,
+        })
+}
+
+/// File-independent guards on the resolved targets: `--diff` cannot pair with a report
+/// format, and at most one target may write to each console stream (two would interleave).
+/// The same-file collision guard needs the files opened (so symlinked parents resolve), so
+/// it lives in [`open_targets`] rather than here.
+///
+/// # Errors
+///
+/// Returns a usage error for any of the conflicts above.
+fn validate_targets(targets: &[OutputTarget], diff: bool) -> Result<(), String> {
+    if diff {
+        // `--diff` emits only its own unified diff and ignores output formatting, so no
+        // target is ever rendered on the diff path: the stream-uniqueness and file-collision
+        // checks do not apply, and the sole conflict is an explicit report format.
+        return reject_diff_report_conflict(targets);
+    }
+    reject_duplicate_streams(targets)
+}
+
+/// `--diff` with a whole-document report format is a usage error: the report would never be
+/// produced (the diff path emits only its patch), so the combination signals confusion.
+fn reject_diff_report_conflict(targets: &[OutputTarget]) -> Result<(), String> {
+    if targets.iter().any(|target| !target.format.is_streaming()) {
         return Err(
             "error: `--diff` cannot be combined with `--format junit` or `--format gitlab`"
                 .to_string(),
@@ -451,57 +796,113 @@ fn reject_diff_with_report_format(
     Ok(())
 }
 
-/// Emit a valid empty report for the whole-document formats when there are no files to
-/// lint, so CI artifact ingestion sees a present, valid file. Streaming formats emit
-/// nothing (unchanged).
-///
-/// # Errors
-///
-/// Returns an error if the `--output-file` cannot be created or written.
-fn emit_empty_report(
-    output_file: Option<&Path>,
-    output_format: OutputFormat,
-) -> Result<(), String> {
-    // A streaming format writes nothing to its default stream for an empty input, but an
-    // explicit --output-file is still created (empty) and validated, so `-o` uniformly
-    // produces the file and an unopenable destination still errors.
-    if output_file.is_none() && output_format.is_streaming() {
-        return Ok(());
+/// At most one target may write to stdout (`-`) and one to stderr; two whole-document
+/// reports interleaved on one stream produce an unparsable artifact.
+fn reject_duplicate_streams(targets: &[OutputTarget]) -> Result<(), String> {
+    let (mut stdout, mut stderr) = (false, false);
+    for target in targets {
+        match target.destination {
+            Destination::Stdout if stdout => {
+                return Err(
+                    "error: at most one output may go to stdout (`-`); give the others a \
+                     file destination"
+                        .to_string(),
+                );
+            }
+            Destination::Stderr if stderr => {
+                return Err(
+                    "error: at most one output may go to the console (stderr); give the \
+                     others a file destination"
+                        .to_string(),
+                );
+            }
+            Destination::Stdout => stdout = true,
+            Destination::Stderr => stderr = true,
+            Destination::File(_) => {}
+        }
     }
-    let mut sink = open_output_sink(output_file, output_format)?;
-    let (_summary, output) = process_results(&[], Vec::new(), output_format, false);
-    write_output(sink.as_mut(), &output)
+    Ok(())
 }
 
-/// Refuse an `--output-file` whose lexical path matches a linted input, so a report can
+/// A path's identity for collision checks: its lexical absolute form (which also covers a
+/// not-yet-created destination) plus, for a path that already exists, its underlying file
+/// identity via `same_file::Handle`. The shared comparison behind both the output-output
+/// and the output-input collision guards.
+struct PathIdentity<'a> {
+    display: &'a Path,
+    abs: PathBuf,
+    handle: Option<Handle>,
+}
+
+impl<'a> PathIdentity<'a> {
+    fn of(path: &'a Path) -> Self {
+        Self {
+            display: path,
+            abs: lexical_abspath(path),
+            handle: Handle::from_path(path).ok(),
+        }
+    }
+
+    /// Whether `self` and `other` resolve to the same file: lexically equal, or — when
+    /// `self` exists — the same underlying file (so a symlink or hard link is caught).
+    fn same_file(&self, other: &PathIdentity) -> bool {
+        self.abs == other.abs || (self.handle.is_some() && self.handle == other.handle)
+    }
+}
+
+/// No two `--output-file` targets may resolve to the same file: the second's write would
+/// clobber the first's report. Called from [`open_targets`] *after* the destinations are
+/// opened, so each exists and `same_file::Handle` resolves it through an existing
+/// symlink/hard link or an aliased parent directory (a lexical comparison alone would miss
+/// two distinct paths pointing at one file). A destination whose existing file is not
+/// readable (mode without read permission) cannot be identity-checked and is matched only
+/// lexically — an adversarial, non-real-world case for a report path.
+fn reject_colliding_output_files(targets: &[OutputTarget]) -> Result<(), String> {
+    let outputs: Vec<PathIdentity> =
+        output_file_paths(targets).map(PathIdentity::of).collect();
+    for (index, output) in outputs.iter().enumerate() {
+        if outputs[index + 1..]
+            .iter()
+            .any(|other| output.same_file(other))
+        {
+            return Err(format!(
+                "error: output path {} is written by more than one format",
+                sanitize_control(&output.display.display().to_string())
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Refuse any `--output-file` target whose path matches a linted input, so a report can
 /// never truncate the source it just linted (or, with `--fix`, the freshly-fixed file).
-/// Matches on the lexical identity (`lexical_abspath`) used for input de-duplication —
-/// which also covers a not-yet-created destination — and, for a destination that already
-/// exists, on its underlying file identity via `same_file::Handle`, so an `-o` that is a
-/// symlink *or* a hard link onto a linted input is caught too.
+/// Uses the same lexical + file-identity match as [`reject_colliding_output_files`], so an
+/// `-o` that is a symlink *or* a hard link onto an input is caught. The output identities
+/// are computed once and reused across all inputs.
 ///
 /// # Errors
 ///
-/// Returns a usage error when `output` resolves to one of the `inputs` (for stdin, the
-/// single `--stdin-filename`/label entry). `output` is the clap-parsed `--output-file`,
-/// which clap guarantees is non-empty, so `lexical_abspath` never sees an empty path.
-fn reject_output_file_collision<'a>(
-    output: &Path,
+/// Returns a usage error when an output path resolves to one of the `inputs` (for stdin,
+/// the single `--stdin-filename`/label entry).
+fn reject_input_collisions<'a>(
+    targets: &[OutputTarget],
     inputs: impl Iterator<Item = &'a Path>,
 ) -> Result<(), String> {
-    let output_abs = lexical_abspath(output);
-    let output_handle = Handle::from_path(output).ok();
-    let collides = inputs.into_iter().any(|input| {
-        lexical_abspath(input) == output_abs
-            || output_handle.as_ref().is_some_and(|handle| {
-                Handle::from_path(input).ok().as_ref() == Some(handle)
-            })
-    });
-    if collides {
-        return Err(format!(
-            "error: --output-file {} is also a linted input; refusing to overwrite it",
-            sanitize_control(&output.display().to_string())
-        ));
+    let outputs: Vec<PathIdentity> =
+        output_file_paths(targets).map(PathIdentity::of).collect();
+    if outputs.is_empty() {
+        return Ok(());
+    }
+    for input in inputs {
+        let input = PathIdentity::of(input);
+        for output in &outputs {
+            if output.same_file(&input) {
+                return Err(format!(
+                    "error: output file {} is also a linted input; refusing to overwrite it",
+                    sanitize_control(&output.display.display().to_string())
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -524,18 +925,6 @@ fn write_output_error(err: &std::io::Error) -> String {
     )
 }
 
-/// Write the buffered, formatted output to its destination: the single fallible step of
-/// the output pipeline (the formatting itself is infallible, see [`OUTPUT_INFALLIBLE`]).
-///
-/// # Errors
-///
-/// Returns an error if the destination cannot be written or flushed (e.g. a full disk).
-fn write_output(sink: &mut dyn Write, output: &[u8]) -> Result<(), String> {
-    sink.write_all(output)
-        .and_then(|()| sink.flush())
-        .map_err(|err| write_output_error(&err))
-}
-
 fn github_env_active() -> bool {
     std::env::var_os("GITHUB_ACTIONS").is_some()
         && std::env::var_os("GITHUB_WORKFLOW").is_some()
@@ -552,9 +941,15 @@ fn supports_color() -> bool {
 }
 
 fn main() -> ExitCode {
-    let cli = Cli::parse();
+    // `get_matches` parses (handling `--help`/`--version`/usage errors by exiting) and
+    // keeps the `ArgMatches` so `resolve_cli_targets` can recover the CLI order of the
+    // repeatable `--format`/`--output-file` pairs via `indices_of`; `from_arg_matches`
+    // then builds the typed `Cli` from those same matches (infallible here).
+    let matches = Cli::command().get_matches();
+    let cli =
+        Cli::from_arg_matches(&matches).expect("Cli parses from its own ArgMatches");
 
-    match run_cli(&cli) {
+    match run_cli(&cli, &matches) {
         Ok(code) => code,
         Err(err) => {
             // Usage/config errors embed user-controlled paths and config values;
@@ -566,7 +961,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run_cli(cli: &Cli) -> Result<ExitCode, String> {
+fn run_cli(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
     // A pure meta-action that ignores every other input/flag, like the
     // schema-print flags below; clap_complete derives the script from `Cli`.
     if let Some(shell) = cli.generate_completions {
@@ -593,10 +988,14 @@ fn run_cli(cli: &Cli) -> Result<ExitCode, String> {
         return run_migration(cli);
     }
 
-    run_lint(cli)
+    // Output targets are resolved on the lint path (the meta-actions above ignore
+    // formatting), inside `run_lint`/`run_stdin_lint` where the run's config — and thus a
+    // TOML `[output]` fallback — is known. `matches` carries the CLI arg indices needed to
+    // order-pair `--format` with `--output-file`.
+    run_lint(cli, matches)
 }
 
-fn run_lint(cli: &Cli) -> Result<ExitCode, String> {
+fn run_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
     let stdin_input = Path::new("-");
     let has_stdin = cli.inputs.iter().any(|p| p.as_path() == stdin_input);
     if has_stdin {
@@ -610,7 +1009,7 @@ fn run_lint(cli: &Cli) -> Result<ExitCode, String> {
                 "error: `--fix` is not supported when reading from stdin".to_string()
             );
         }
-        return run_stdin_lint(cli);
+        return run_stdin_lint(cli, matches);
     }
 
     if cli.stdin_filename.is_some() {
@@ -668,22 +1067,31 @@ fn run_lint(cli: &Cli) -> Result<ExitCode, String> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    let output_format = detect_output_format(primary_format(&cli.format));
-    reject_diff_with_report_format(cli.lint.fix.diff, output_format)?;
+    // Resolve output targets now that the run's config is known: a TOML `[output]` table
+    // is read from the global config (`-c`/`-d`/env) or the project config governing the
+    // inputs, so `ryl .` honors a project's `.ryl.toml [output]`. A CLI `--format`
+    // overrides it. (`list_files`/`migrate` above are exempt, like the no-rules check.)
+    // `--diff` previews fixes and has its own unified-diff output; it ignores output
+    // formatting, so a config `[output]` report target must not block it. Only an
+    // explicit CLI `--format junit|gitlab` conflicts with `--diff` (caught by
+    // `validate_targets` via the CLI-derived targets, which are read regardless).
+    let output_config = if cli.lint.fix.diff {
+        None
+    } else {
+        run_output_config(global_cfg.as_ref(), &cli.inputs, cli)?
+    };
+    let targets = resolve_targets(matches, cli, output_config.as_ref())?;
+    validate_targets(&targets, cli.lint.fix.diff)?;
+    let targets = &targets;
 
     // Refuse an --output-file that resolves to a linted input: writing the report there
     // would truncate the source we just linted (and, with --fix, the freshly-fixed file).
-    if let Some(output) = primary_output_file(&cli.output_file) {
-        reject_output_file_collision(
-            output,
-            files.iter().map(|(path, ..)| path.as_path()),
-        )?;
-    }
+    reject_input_collisions(targets, files.iter().map(|(path, ..)| path.as_path()))?;
 
     if files.is_empty() {
-        // A clean or fully-ignored project still gets a valid empty report, so CI artifact
-        // ingestion sees `[]` / `<testsuites .../>` rather than a missing or invalid file.
-        emit_empty_report(primary_output_file(&cli.output_file), output_format)?;
+        // A clean or fully-ignored project still gets a valid empty report per target, so
+        // CI artifact ingestion sees `[]` / `<testsuites .../>` rather than a missing file.
+        emit_targets(targets, &[])?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -695,23 +1103,22 @@ fn run_lint(cli: &Cli) -> Result<ExitCode, String> {
         return Ok(emit_diff(&diff_safe_fixes_for_files(&files)?));
     }
 
-    lint_and_exit(&files, cli, output_format)
+    lint_and_exit(&files, cli, targets)
 }
 
-/// Open the output destination (before `--fix` mutates anything, so an unopenable
-/// `--output-file` fails fast), apply fixes if requested, lint, render the chosen format,
-/// write it, print the `--fix` summary, and map the tally to an exit code.
+/// Open every output destination (before `--fix` mutates anything, so an unopenable
+/// `--output-file` fails fast), apply fixes if requested, lint, render each target's
+/// format, write it, print the `--fix` summary, and map the tally to an exit code.
 ///
 /// # Errors
 ///
-/// Returns an error if a file cannot be read/written or the output destination fails.
+/// Returns an error if a file cannot be read/written or an output destination fails.
 fn lint_and_exit(
     files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
     cli: &Cli,
-    output_format: OutputFormat,
+    targets: &[OutputTarget],
 ) -> Result<ExitCode, String> {
-    let mut sink =
-        open_output_sink(primary_output_file(&cli.output_file), output_format)?;
+    let mut sinks = open_targets(targets)?;
 
     let initial_problem_count = if cli.lint.fix.fix {
         apply_fixes_reporting_skips(files, cli.lint.compatibility.no_warnings)?
@@ -720,13 +1127,9 @@ fn lint_and_exit(
     };
 
     let results = lint_files(files);
-    let (summary, output) = process_results(
-        files,
-        results,
-        output_format,
-        cli.lint.compatibility.no_warnings,
-    );
-    write_output(sink.as_mut(), &output)?;
+    let (summary, records) =
+        collect_records(files, results, cli.lint.compatibility.no_warnings);
+    write_targets(targets, &mut sinks, &records)?;
 
     if cli.lint.fix.fix && initial_problem_count > 0 {
         eprintln!(
@@ -776,22 +1179,30 @@ fn summary_to_exit(summary: &LintSummary, strict: bool) -> ExitCode {
     }
 }
 
-fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
+fn run_stdin_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
     let (path, base_dir, cfg, apply_yaml_files, config_found) = resolve_stdin_ctx(cli)?;
-    let output_format = detect_output_format(primary_format(&cli.format));
-    reject_diff_with_report_format(cli.lint.fix.diff, output_format)?;
+
+    // The stdin config's `[output]` defines the run targets (a CLI `--format` overrides).
+    // As in `run_lint`, `--diff` ignores config `[output]` so a config report can't block
+    // it; an explicit CLI `--format junit|gitlab` still conflicts via the CLI targets.
+    let config_output = if cli.lint.fix.diff {
+        None
+    } else {
+        cfg.output()
+    };
+    let targets = resolve_targets(matches, cli, config_output)?;
+    validate_targets(&targets, cli.lint.fix.diff)?;
+    let targets = &targets;
 
     // The stdin content is labelled by `--stdin-filename`; refuse writing the report to
     // that same path so it cannot truncate the file the label names.
-    if let Some(output) = primary_output_file(&cli.output_file) {
-        reject_output_file_collision(output, std::iter::once(path.as_path()))?;
-    }
+    reject_input_collisions(targets, std::iter::once(path.as_path()))?;
 
     let Some(kind) = resolve_stdin_kind(cli, &cfg, &path, &base_dir, apply_yaml_files)?
     else {
         // An ignored stdin filename is an empty input set: still emit a valid empty
-        // report so CI artifact ingestion does not see a missing file.
-        emit_empty_report(primary_output_file(&cli.output_file), output_format)?;
+        // report per target so CI artifact ingestion does not see a missing file.
+        emit_targets(targets, &[])?;
         return Ok(ExitCode::SUCCESS);
     };
 
@@ -813,15 +1224,10 @@ fn run_stdin_lint(cli: &Cli) -> Result<ExitCode, String> {
     let files = vec![(path, base_dir, cfg, kind)];
     let results = vec![(0usize, outcome)];
 
-    let mut sink =
-        open_output_sink(primary_output_file(&cli.output_file), output_format)?;
-    let (summary, output) = process_results(
-        &files,
-        results,
-        output_format,
-        cli.lint.compatibility.no_warnings,
-    );
-    write_output(sink.as_mut(), &output)?;
+    let mut sinks = open_targets(targets)?;
+    let (summary, records) =
+        collect_records(&files, results, cli.lint.compatibility.no_warnings);
+    write_targets(targets, &mut sinks, &records)?;
     Ok(summary_to_exit(&summary, cli.lint.compatibility.strict))
 }
 
@@ -1052,26 +1458,28 @@ fn gather_lint_files(
     Ok(ruleless_config_found)
 }
 
-/// Filter, tally, and format diagnostics into an owned buffer. Streaming formats append
-/// one line per diagnostic as files are visited; the whole-document formats (junit/gitlab)
-/// buffer every file into a [`ReportEntry`] and serialize once after the loop. The buffer
-/// is written to its destination by the caller (a single fallible step); the returned
-/// [`LintSummary`] (and thus the exit code) is identical across all formats. Output is
-/// built in memory so the per-diagnostic writes cannot fail (see [`OUTPUT_INFALLIBLE`]).
-///
-/// Buffering rather than streaming the console formats is not a regression: `lint_files`
-/// has already collected every result (in parallel) before this runs, so output only ever
-/// appears after linting completes — the buffer just emits the same bytes in one write.
-fn process_results(
-    files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
+/// One linted file's filtered outcome, format-agnostic: a borrowed source path plus
+/// either its kept diagnostics or a single processing-error message (mutually exclusive,
+/// a clean file has neither). Each output target renders the same records its own way
+/// ([`render_target`]), so the filter+tally pass below runs exactly once regardless of how
+/// many targets a run has.
+struct FileRecord<'a> {
+    path: &'a Path,
+    kept: Vec<LintProblem>,
+    error: Option<String>,
+}
+
+/// Filter and tally every lint result into format-agnostic [`FileRecord`]s in file order.
+/// The returned [`LintSummary`] (and thus the exit code) is independent of which formats
+/// the records are later rendered to. `no_warnings` drops warning-level diagnostics before
+/// they are kept or counted, exactly as the streaming path used to.
+fn collect_records<'a>(
+    files: &'a [(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
     results: Vec<(usize, Result<Vec<LintProblem>, String>)>,
-    output_format: OutputFormat,
     no_warnings: bool,
-) -> (LintSummary, Vec<u8>) {
+) -> (LintSummary, Vec<FileRecord<'a>>) {
     let mut summary = LintSummary::default();
-    let mut entries: Vec<ReportEntry> = Vec::new();
-    let mut out: Vec<u8> = Vec::new();
-    let project_root = report_project_root();
+    let mut records: Vec<FileRecord<'a>> = Vec::with_capacity(results.len());
 
     for (idx, outcome) in results {
         let (path, ..) = &files[idx];
@@ -1084,15 +1492,11 @@ fn process_results(
                 let message = sanitize_control(&message).into_owned();
                 summary.has_error = true;
                 summary.problem_count += 1;
-                if output_format.is_streaming() {
-                    writeln!(out, "{message}").expect(OUTPUT_INFALLIBLE);
-                } else {
-                    entries.push(ReportEntry {
-                        path: report_display_path(path, &project_root),
-                        problems: Vec::new(),
-                        error: Some(message),
-                    });
-                }
+                records.push(FileRecord {
+                    path,
+                    kept: Vec::new(),
+                    error: Some(message),
+                });
             }
             Ok(diagnostics) => {
                 let mut kept: Vec<LintProblem> = Vec::new();
@@ -1107,38 +1511,16 @@ fn process_results(
                     summary.problem_count += 1;
                     kept.push(problem);
                 }
-
-                // Streaming formats print nothing for a file with no reportable
-                // diagnostics; junit still records it as a passing test, so the
-                // whole-document formats keep the (possibly empty) entry.
-                if output_format.is_streaming() && kept.is_empty() {
-                    continue;
-                }
-
-                match output_format {
-                    OutputFormat::Standard => append_standard(&mut out, path, &kept),
-                    OutputFormat::Colored => append_colored(&mut out, path, &kept),
-                    OutputFormat::Github => append_github(&mut out, path, &kept),
-                    OutputFormat::Parsable => append_parsable(&mut out, path, &kept),
-                    OutputFormat::Junit | OutputFormat::Gitlab => {
-                        entries.push(ReportEntry {
-                            path: report_display_path(path, &project_root),
-                            problems: kept,
-                            error: None,
-                        });
-                    }
-                }
+                records.push(FileRecord {
+                    path,
+                    kept,
+                    error: None,
+                });
             }
         }
     }
 
-    match output_format {
-        OutputFormat::Junit => out = render_junit(&entries),
-        OutputFormat::Gitlab => out = render_gitlab(&entries),
-        _ => {}
-    }
-
-    (summary, out)
+    (summary, records)
 }
 
 #[derive(Default)]

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,13 +2,17 @@
 //!
 //! Unlike the streaming console formats (standard/colored/github/parsable), these emit a
 //! single root document (one `<testsuites>` / one JSON array), so the caller buffers every
-//! file's diagnostics into [`ReportEntry`]s and renders once. Rendering takes a
-//! `&mut dyn Write`, so the destination (file, stdout, in-memory) is the caller's choice.
+//! file's diagnostics into [`ReportEntry`]s and renders once into an owned `Vec<u8>` it
+//! then writes to its chosen destination (file, stdout, stderr).
 //!
-//! Sources:
-//! - `JUnit`: <https://llg.cubic.org/docs/junit/>; shape modelled on ruff's emitter.
+//! Sources (`JUnit` has no single official standard, so we follow the most authoritative
+//! published schema; `GitLab` documents a subset of the Code Climate engine spec):
+//! - `JUnit`: <https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd>
+//!   (the Jenkins xUnit plugin's `junit-10.xsd`), readable companion
+//!   <https://llg.cubic.org/docs/junit/>; shape modelled on ruff's emitter.
 //! - `GitLab`: <https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format>,
-//!   a documented subset of the Code Climate engine spec.
+//!   a documented subset of the Code Climate engine spec
+//!   <https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md>.
 //!
 //! All user text is sanitized before serialization — `JUnit` via `xml_sanitize` (control
 //! chars plus the U+FFFE/U+FFFF noncharacters XML forbids), `GitLab` via

--- a/tests/cli_exit_and_errors.rs
+++ b/tests/cli_exit_and_errors.rs
@@ -1,5 +1,9 @@
 use std::process::Command;
+
 use tempfile::tempdir;
+
+mod common;
+use common::cli::ryl;
 
 fn run(cmd: &mut Command) -> (i32, String, String) {
     let out = cmd.output().expect("failed to run ryl");
@@ -23,8 +27,9 @@ fn no_arguments_returns_usage_error_code_2() {
 #[test]
 fn empty_directory_results_in_success() {
     let dir = tempdir().unwrap();
-    let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, _out, err) = run(Command::new(exe).arg(dir.path()));
+    // Bound discovery at the tempdir: the run-level `[output]` read climbs from the inputs,
+    // so a stray config in the shared temp root must not turn this clean run into an error.
+    let (code, _out, err) = run(ryl(dir.path()).arg(dir.path()));
     assert_eq!(code, 0, "expected success when no YAML files: {err}");
 }
 

--- a/tests/cli_format_options.rs
+++ b/tests/cli_format_options.rs
@@ -693,7 +693,7 @@ fn gitlab_format_reads_stdin_with_filename() {
 #[test]
 fn output_file_write_failure_is_reported() {
     // `/dev/full` opens successfully but fails every write with ENOSPC, exercising the
-    // destination-write error path (the one fallible step of the output pipeline).
+    // destination-write error path (the one fallible step once rendering is done).
     let dir = tempdir().unwrap();
     let cfg = disable_doc_start_config(dir.path());
     let file = dirty_yaml(dir.path());
@@ -758,6 +758,33 @@ fn stdin_diff_with_report_format_is_usage_error() {
 }
 
 #[test]
+fn stdin_output_file_without_format_is_usage_error() {
+    // The stdin path resolves output targets too, so an unpaired `--output-file` is the
+    // same usage error there as for file inputs.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let report = dir.path().join("out.txt");
+    let (code, _stdout, stderr) = run_stdin(
+        &[
+            "-",
+            "-o",
+            report.to_str().unwrap(),
+            "-c",
+            cfg.to_str().unwrap(),
+        ],
+        b"key: value",
+    );
+    assert_eq!(
+        code, 2,
+        "an unpaired --output-file is a usage error on stdin"
+    );
+    assert!(
+        stderr.contains("--output-file must follow a --format"),
+        "expected the unpaired-output message: {stderr}"
+    );
+}
+
+#[test]
 fn stdin_output_file_open_failure_is_usage_error() {
     let dir = tempdir().unwrap();
     let cfg = disable_doc_start_config(dir.path());
@@ -787,6 +814,8 @@ fn stdin_output_file_open_failure_is_usage_error() {
 #[cfg(target_os = "linux")]
 #[test]
 fn stdin_output_file_write_failure_is_reported() {
+    // The stdin path writes through the same commit step; `/dev/full` opens but fails the
+    // write, surfacing it on the stdin code path too.
     let dir = tempdir().unwrap();
     let cfg = disable_doc_start_config(dir.path());
     let (code, _stdout, stderr) = run_stdin(
@@ -997,6 +1026,227 @@ fn ignored_stdin_report_open_failure_is_usage_error() {
     );
 }
 
+// --- Multiple output targets (issue #285): repeatable --format, each paired to an
+// --output-file, so console diagnostics and report artifacts can be produced together. ---
+
+#[test]
+fn console_and_reports_emit_together() {
+    // The headline of the redesign: one run produces console diagnostics *and* two report
+    // files. Each `--output-file` binds to the most recent `--format` (RuboCop/Biome style).
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let xml = dir.path().join("report.xml");
+    let json = dir.path().join("report.json");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("standard")
+        .arg("--format")
+        .arg("junit")
+        .arg("-o")
+        .arg(&xml)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&json)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1, "any diagnostic keeps the error exit code");
+    assert!(
+        stdout.is_empty(),
+        "neither report defaulted to stdout (both have files): {stdout}"
+    );
+    assert!(
+        stderr.contains("1:11") && stderr.contains("new-line-at-end-of-file"),
+        "the standard console format still goes to stderr: {stderr}"
+    );
+    assert!(
+        fs::read_to_string(&xml).unwrap().contains("<testsuites"),
+        "the junit report file is written"
+    );
+    let issues: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&json).unwrap())
+            .expect("gitlab report file is JSON");
+    assert_eq!(
+        issues.as_array().unwrap().len(),
+        1,
+        "the gitlab report file holds the diagnostic"
+    );
+}
+
+#[test]
+fn console_and_report_use_distinct_default_streams() {
+    // With no --output-file, a console format defaults to stderr and a report format to
+    // stdout, so the two can coexist on their distinct default streams.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("standard")
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("new-line-at-end-of-file"),
+        "the console format goes to stderr: {stderr}"
+    );
+    let issues: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("the report format goes to stdout as JSON");
+    assert_eq!(issues.as_array().unwrap().len(), 1, "one issue on stdout");
+}
+
+#[test]
+fn output_file_dash_writes_report_to_stdout() {
+    // `-o -` is an explicit request for stdout (the streams convention), distinct from the
+    // default stream the format would otherwise pick.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, _stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg("-")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1);
+    let issues: serde_json::Value =
+        serde_json::from_str(&stdout).expect("`-o -` sends the report to stdout");
+    assert_eq!(issues.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn output_file_without_preceding_format_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let report = dir.path().join("out.txt");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("-o")
+        .arg(&report)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "an unpaired --output-file is a usage error");
+    assert!(
+        stderr.contains("--output-file must follow a --format"),
+        "expected the unpaired-output message: {stderr}"
+    );
+}
+
+#[test]
+fn format_with_two_output_files_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(dir.path().join("a.json"))
+        .arg("-o")
+        .arg(dir.path().join("b.json"))
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "binding two files to one --format is a usage error"
+    );
+    assert!(
+        stderr.contains("a --format takes at most one --output-file"),
+        "expected the one-output-per-format message: {stderr}"
+    );
+}
+
+#[test]
+fn two_formats_to_stdout_is_usage_error() {
+    // Two whole-document reports interleaved on stdout would be an unparsable artifact.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("--format")
+        .arg("junit")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "two reports defaulting to stdout is a usage error");
+    assert!(
+        stderr.contains("at most one output may go to stdout"),
+        "expected the duplicate-stdout message: {stderr}"
+    );
+}
+
+#[test]
+fn two_formats_to_console_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("standard")
+        .arg("--format")
+        .arg("parsable")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "two console formats on stderr is a usage error");
+    assert!(
+        stderr.contains("at most one output may go to the console"),
+        "expected the duplicate-stderr message: {stderr}"
+    );
+}
+
+#[test]
+fn two_formats_to_same_file_is_usage_error() {
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let same = dir.path().join("report.out");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&same)
+        .arg("--format")
+        .arg("junit")
+        .arg("-o")
+        .arg(&same)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "two reports to one file is a usage error");
+    assert!(
+        stderr.contains("is written by more than one format"),
+        "expected the colliding-output message: {stderr}"
+    );
+}
+
 #[test]
 fn empty_input_with_output_file_creates_file_for_streaming_format() {
     // --output-file uniformly produces the file even for an empty streaming-format run.
@@ -1191,5 +1441,360 @@ fn gitlab_path_uses_dotdot_for_files_outside_the_project_root() {
     assert_eq!(
         json[0]["location"]["path"], "../dirty.yaml",
         "a file above the project root uses a `..` segment: {stdout}"
+    );
+}
+
+// --- TOML [output] config (issue #285): a project's config can define output targets;
+// a CLI --format overrides them wholesale (CLI > config > default). ---
+
+/// Write a TOML config enabling new-line-at-end-of-file (so `dirty_yaml` trips) plus the
+/// given `[output]` body, and return its path.
+fn output_config(dir: &std::path::Path, output_body: &str) -> std::path::PathBuf {
+    let cfg = dir.join("ryl.toml");
+    fs::write(
+        &cfg,
+        format!(
+            "[rules]\nnew-line-at-end-of-file = \"enable\"\ndocument-start = \"disable\"\n{output_body}"
+        ),
+    )
+    .unwrap();
+    cfg
+}
+
+#[test]
+fn config_output_writes_report_to_file() {
+    let dir = tempdir().unwrap();
+    let cfg = output_config(dir.path(), "[output.gitlab]\npath = \"gl.json\"\n");
+    let file = dirty_yaml(dir.path());
+    let report = dir.path().join("gl.json");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    // Run from the project dir so the config's relative `path` lands beside the inputs.
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .current_dir(dir.path())
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1, "the diagnostic keeps the error exit code");
+    assert!(
+        stdout.is_empty() && stderr.is_empty(),
+        "the report went to the file"
+    );
+    let issues: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&report).unwrap())
+            .expect("config-driven gitlab report is JSON");
+    assert_eq!(
+        issues.as_array().unwrap().len(),
+        1,
+        "one diagnostic in the report"
+    );
+}
+
+#[test]
+fn config_output_console_and_report_together() {
+    // `[output.auto]` (no path) keeps the console on its default stream while a second
+    // entry writes a report file: the issue's simultaneous-output ask, set in config.
+    let dir = tempdir().unwrap();
+    let cfg = output_config(
+        dir.path(),
+        "[output.auto]\n\n[output.gitlab]\npath = \"gl.json\"\n",
+    );
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .current_dir(dir.path())
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("new-line-at-end-of-file"),
+        "the auto console format stays on stderr: {stderr}"
+    );
+    let issues: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("gl.json")).unwrap())
+            .expect("the gitlab report file is JSON");
+    assert_eq!(issues.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn config_output_dash_path_is_stdout() {
+    let dir = tempdir().unwrap();
+    let cfg = output_config(dir.path(), "[output.gitlab]\npath = \"-\"\n");
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, _stderr) = run(Command::new(exe).arg("-c").arg(&cfg).arg(&file));
+    assert_eq!(code, 1);
+    let issues: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("`path = \"-\"` sends the report to stdout");
+    assert_eq!(issues.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn cli_format_overrides_config_output() {
+    // A CLI --format replaces the config's [output] wholesale; the config report is not
+    // written.
+    let dir = tempdir().unwrap();
+    let cfg = output_config(dir.path(), "[output.gitlab]\npath = \"gl.json\"\n");
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("parsable")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("new-line-at-end-of-file"),
+        "the CLI format went to stderr: {stderr}"
+    );
+    assert!(
+        !dir.path().join("gl.json").exists(),
+        "the config's gitlab report must not be written when --format overrides it"
+    );
+}
+
+#[test]
+fn config_output_is_auto_discovered_from_project_config() {
+    // Without -c, the run reads [output] from the project config governing the inputs, so
+    // `ryl .` honors a project's `.ryl.toml [output]` (the run_output_config None branch).
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\nnew-line-at-end-of-file = \"enable\"\ndocument-start = \"disable\"\n\n[output.gitlab]\npath = \"gl.json\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("dirty.yaml"), "key: value").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, _stderr) =
+        run(Command::new(exe).current_dir(dir.path()).arg("."));
+    assert_eq!(code, 1, "the project config's rule still fires");
+    let issues: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("gl.json")).unwrap())
+            .expect("auto-discovered gitlab report is JSON");
+    assert_eq!(issues.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn yaml_config_rejects_output_table() {
+    let dir = tempdir().unwrap();
+    let cfg = dir.path().join("config.yaml");
+    fs::write(
+        &cfg,
+        "rules:\n  new-line-at-end-of-file: enable\noutput:\n  gitlab:\n    path: gl.json\n",
+    )
+    .unwrap();
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe).arg("-c").arg(&cfg).arg(&file));
+    assert_eq!(code, 2, "`output` in YAML config is a usage error");
+    assert!(
+        stderr.contains("output is only supported in TOML configuration"),
+        "expected the TOML-only message: {stderr}"
+    );
+}
+
+#[test]
+fn config_output_empty_path_is_error() {
+    let dir = tempdir().unwrap();
+    let cfg = output_config(dir.path(), "[output.gitlab]\npath = \"\"\n");
+    let file = dirty_yaml(dir.path());
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe).arg("-c").arg(&cfg).arg(&file));
+    assert_eq!(code, 2, "an empty output path is a config error");
+    assert!(
+        stderr.contains("output.gitlab.path must not be empty"),
+        "expected the empty-path message: {stderr}"
+    );
+}
+
+#[test]
+fn diff_ignores_config_output_report_format() {
+    // Regression: a project `[output.gitlab]` must not turn `--diff` into a usage error.
+    // `--diff` previews fixes with its own output and ignores output formatting, so a
+    // config-declared report target is irrelevant to it (only an explicit CLI
+    // `--format junit|gitlab` conflicts with `--diff`).
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ntrailing-spaces = \"enable\"\n\n[output.gitlab]\npath = \"gl.json\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("dirty.yaml"), "key: value  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .current_dir(dir.path())
+        .arg("--diff")
+        .arg("."));
+    assert_eq!(
+        code, 1,
+        "the trailing-spaces fix would change a file: {stderr}"
+    );
+    assert!(
+        !stderr.contains("cannot be combined with"),
+        "a config report format must not block --diff: {stderr}"
+    );
+    assert!(
+        stdout.contains("@@"),
+        "the unified diff preview is printed to stdout: {stdout}"
+    );
+    assert!(
+        !dir.path().join("gl.json").exists(),
+        "--diff writes no report file"
+    );
+}
+
+#[test]
+fn diff_with_multiple_streaming_formats_is_allowed() {
+    // --diff emits only its own unified diff and ignores --format, so multiple streaming
+    // formats (which would otherwise both default to stderr) must not be a usage error.
+    let dir = tempdir().unwrap();
+    let cfg = dir.path().join("c.toml");
+    fs::write(&cfg, "[rules]\ntrailing-spaces = \"enable\"\n").unwrap();
+    let file = dir.path().join("dirty.yaml");
+    fs::write(&file, "key: value  \n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .arg("--diff")
+        .arg("--format")
+        .arg("standard")
+        .arg("--format")
+        .arg("parsable")
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(
+        code, 1,
+        "the trailing-spaces fix would change the file: {stderr}"
+    );
+    assert!(
+        !stderr.contains("at most one output"),
+        "no duplicate-stream error on the --diff path: {stderr}"
+    );
+    assert!(
+        stdout.contains("@@"),
+        "the unified diff is printed: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn two_output_files_aliasing_the_same_file_are_rejected() {
+    // Two `--output-file` paths that resolve (via symlink) to one existing file must be
+    // rejected by file identity, not just lexical comparison, or the second report would
+    // clobber the first.
+    use std::os::unix::fs::symlink;
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let real = dir.path().join("real.json");
+    fs::write(&real, "stale").unwrap();
+    let link = dir.path().join("link.json");
+    symlink(&real, &link).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&real)
+        .arg("--format")
+        .arg("junit")
+        .arg("-o")
+        .arg(&link)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(code, 2, "two outputs aliasing one file is a usage error");
+    assert!(
+        stderr.contains("is written by more than one format"),
+        "expected the colliding-output message: {stderr}"
+    );
+}
+
+#[test]
+fn earlier_output_artifact_survives_a_later_unopenable_target() {
+    // Opening targets must not truncate an existing artifact before a later target fails to
+    // open: the earlier file's contents must be intact after the run errors.
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let keep = dir.path().join("keep.json");
+    fs::write(&keep, "STALE").unwrap();
+    let unopenable = dir.path().join("missing-dir").join("r.xml");
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(&keep)
+        .arg("--format")
+        .arg("junit")
+        .arg("-o")
+        .arg(&unopenable)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "an unopenable later target is a usage error: {stderr}"
+    );
+    assert!(
+        stderr.contains("cannot open --output-file"),
+        "expected the open-failure message: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(&keep).unwrap(),
+        "STALE",
+        "the earlier artifact must not be truncated when a later target fails to open"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn two_outputs_under_aliased_parent_dirs_are_rejected() {
+    // Two not-yet-created `--output-file` leaves under symlink-aliased parent directories
+    // resolve to the same file once opened. Their lexical paths differ and neither leaf
+    // exists beforehand, so only the post-open file-identity check catches the collision
+    // (before either report is written).
+    use std::os::unix::fs::symlink;
+    let dir = tempdir().unwrap();
+    let cfg = disable_doc_start_config(dir.path());
+    let file = dirty_yaml(dir.path());
+    let real = dir.path().join("real");
+    fs::create_dir(&real).unwrap();
+    let link = dir.path().join("link");
+    symlink(&real, &link).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("--format")
+        .arg("gitlab")
+        .arg("-o")
+        .arg(real.join("r.json"))
+        .arg("--format")
+        .arg("junit")
+        .arg("-o")
+        .arg(link.join("r.json"))
+        .arg("-c")
+        .arg(&cfg)
+        .arg(&file));
+    assert_eq!(
+        code, 2,
+        "outputs aliasing one file via a parent symlink is a usage error: {stderr}"
+    );
+    assert!(
+        stderr.contains("is written by more than one format"),
+        "expected the colliding-output message: {stderr}"
     );
 }

--- a/tests/cli_invalid_project_config.rs
+++ b/tests/cli_invalid_project_config.rs
@@ -1,15 +1,9 @@
 use std::fs;
-use std::process::Command;
 
 use tempfile::tempdir;
 
-fn run(cmd: &mut Command) -> (i32, String, String) {
-    let out = cmd.output().expect("failed to run ryl");
-    let code = out.status.code().unwrap_or(-1);
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    (code, stdout, stderr)
-}
+mod common;
+use common::cli::{run, ryl};
 
 #[test]
 fn invalid_project_config_in_dir_causes_exit_2() {
@@ -18,8 +12,9 @@ fn invalid_project_config_in_dir_causes_exit_2() {
     fs::create_dir(root.join(".yamllint")).unwrap();
     fs::write(root.join("a.yaml"), "a: 1\n").unwrap();
 
-    let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, _out, err) = run(Command::new(exe).arg("--list-files").arg(root));
+    // `ryl(root)` bounds discovery at the tempdir so the invalid `.yamllint` here — not a
+    // stray config in the shared temp root — is what gets discovered.
+    let (code, _out, err) = run(ryl(root).arg("--list-files").arg(root));
     assert_eq!(code, 2, "expected exit 2: {err}");
     assert!(err.contains("failed to read"));
 }
@@ -32,8 +27,35 @@ fn invalid_project_config_for_explicit_file_causes_exit_2() {
     let f = root.join("a.yaml");
     fs::write(&f, "a: 1\n").unwrap();
 
-    let exe = env!("CARGO_BIN_EXE_ryl");
-    let (code, _out, err) = run(Command::new(exe).arg("--list-files").arg(&f));
+    let (code, _out, err) = run(ryl(root).arg("--list-files").arg(&f));
     assert_eq!(code, 2, "expected exit 2: {err}");
     assert!(err.contains("failed to read"));
+}
+
+#[test]
+fn invalid_output_config_with_no_lintable_files_causes_exit_2() {
+    // Linting an empty subdirectory finds no files, so per-file discovery (which descends
+    // into the input) never reads the project config in the parent. The run-level
+    // `[output]` read climbs to it instead, and a malformed `[output]` there must still
+    // surface as an error rather than be silently ignored on an otherwise file-less run.
+    let td = tempdir().unwrap();
+    let root = td.path();
+    fs::write(
+        root.join("ryl.toml"),
+        "[rules]\ncolons = \"enable\"\n[output.gitlab]\npath = \"\"\n",
+    )
+    .unwrap();
+    let empty = root.join("empty");
+    fs::create_dir(&empty).unwrap();
+
+    // HOME = root so discovery climbs from `empty` to the parent's `ryl.toml` but no higher.
+    let (code, _out, err) = run(ryl(root).arg(&empty));
+    assert_eq!(
+        code, 2,
+        "a malformed [output] is an error even with no files to lint: {err}"
+    );
+    assert!(
+        err.contains("output.gitlab.path must not be empty"),
+        "expected the empty-path config error: {err}"
+    );
 }

--- a/tests/cli_list_files.rs
+++ b/tests/cli_list_files.rs
@@ -1,10 +1,9 @@
 use std::fs;
-use std::process::Command;
 
 use tempfile::tempdir;
 
 mod common;
-use common::cli::run;
+use common::cli::{run, ryl};
 
 #[test]
 fn list_files_outputs_expected_entries() {
@@ -12,9 +11,10 @@ fn list_files_outputs_expected_entries() {
     let file = dir.path().join("sample.yaml");
     fs::write(&file, "key: value\n").unwrap();
 
-    let exe = env!("CARGO_BIN_EXE_ryl");
+    // Bound discovery at the tempdir so a stray config in the shared temp root cannot
+    // change which files `--list-files` selects.
     let (code, stdout, stderr) =
-        run(Command::new(exe).arg("--list-files").arg(dir.path()));
+        run(ryl(dir.path()).arg("--list-files").arg(dir.path()));
     assert_eq!(code, 0, "list-files should succeed: stderr={stderr}");
     assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
     assert!(

--- a/tests/common/cli.rs
+++ b/tests/common/cli.rs
@@ -4,7 +4,24 @@
 //! that does `mod common;` compiles the whole module, but each uses only the
 //! helpers it needs (the same pattern `fake_env` follows).
 
+use std::path::Path;
 use std::process::Command;
+
+/// A `ryl` command whose config discovery is isolated from the shared temp root. Project
+/// discovery climbs from each input through its ancestors up to `HOME`, so a test whose
+/// inputs live under the system temp dir would otherwise walk into that shared dir, where
+/// a stray `ryl.toml`/`.yamllint`/etc. (left by another test, a concurrent process, or a
+/// manual smoke run) gets discovered and silently overrides the test's own setup — and
+/// TOML candidates outrank a tempdir's `.yamllint`, so an adjacent YAML config is not
+/// enough to shield it. Setting `HOME` to `home` stops the walk there. Any test that
+/// exercises discovery (does NOT pass `-c`/`-d`, and has no adjacent TOML config in its
+/// input's directory) must build its command with this, passing its own tempdir.
+#[allow(dead_code)]
+pub fn ryl(home: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_ryl"));
+    cmd.env("HOME", home);
+    cmd
+}
 
 /// Run `cmd` to completion, returning `(exit code, stdout, stderr)`.
 #[allow(dead_code)]


### PR DESCRIPTION
Closes #285.

Builds on #301 (which added `--format junit|gitlab` + `-o` in the ruff one-format-per-run
model) to deliver the issue's original ask: console diagnostics **and** report files in a
single run.

## CLI

`--format` is repeatable, and each `--output-file` (`-o`) binds to the most recent
`--format` (RuboCop/Biome order-pairing, recovered via clap `ArgMatches::indices_of`).
`-o -` is stdout; with no `-o` a console format defaults to stderr and a report format to
stdout.

```console
# console on stderr AND a GitLab report file, one run
ryl --format auto --format gitlab -o gl-code-quality-report.json .
```

## TOML `[output]` (ryl-only, TOML-only)

```toml
[output.auto]              # keep the console (default stream)
[output.gitlab]
path = "gl-code-quality-report.json"
```

Per-format destinations (absent `path` = default stream, `"-"` = stdout). Read run-level
from the governing config. Precedence **CLI > config > default**; rejected in YAML config.

## Guards (each exit 2)

Unpaired `-o`; two `-o` on one `--format`; two outputs on one stream; two outputs to one
file (lexical + `same_file::Handle`); an output file that is also a linted input.

## Notes

- Output writing is direct (correct umask permissions). Documented limitations: an empty
  artifact may be left on a *rejected* (exit-2) run; write-only-aliased outputs and a
  multi-root `[output]` differing across projects are matched conservatively; cross-file
  commit is per-file atomic (no OS multi-file atomicity).
- Source-of-truth links: Jenkins `junit-10.xsd` (JUnit) and Code Climate `SPEC.md` (GitLab).
- Config-discovery tests are HOME-isolated against shared-temp-dir config pollution.
- Iterated through several local Codex adversarial rounds; remaining findings are
  unexploitable/pre-existing TOCTOU races documented as limitations.

Green: clippy + prek clean, coverage zero uncovered regions, full suite (1524 tests).
Version bumped to 0.17.0.