### PR TITLE
User-global config: ryl-native path + --migrate-user-config (#304)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,12 @@ rather than shipping silently. Work this checklist (*Automated Tests* expands st
   command. The bot login is `chatgpt-codex-connector[bot]`; filter with
   `select(.user.login=="chatgpt-codex-connector[bot]")` (the bare login without `[bot]`
   matches nothing).
+- Codex's adversarial review escalates indefinitely on file I/O (TOCTOU, partial/
+  interrupted writes, cross-file non-atomicity). Converge on real bugs, document the
+  rest as known limitations, and ship; do not re-introduce atomic temp+rename via a
+  runtime `tempfile` dep (tried on #285, reverted: 0600-perms regression + `clippy::cargo
+  multiple_crate_versions`). ryl's threat model (#246) is realistic payloads, not a
+  concurrent fs racer.
 - When referencing another repository's issues/PRs in GitHub issues, PRs, or comments
   (e.g. an upstream `yamllint` issue), always use the fully-qualified
   `adrienverge/yamllint#123` form. A bare `#123` auto-links to *this* repo

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -77,12 +77,16 @@ write), migration may leave a partial config file behind. The next run reports i
 via the "a ryl-native config already exists" skip warning, so delete the partial
 file and re-run.
 
-When migration flattens a relative `extends` or `ignore-from-file`, it resolves
-the reference relative to the config's own directory first, then the current
-directory. So a file kept next to a user-global config (e.g.
-`~/.config/yamllint/team.yaml`) is inlined correctly. If the same relative name
-exists both next to the config and in the current directory with different
-contents, the copy next to the config wins.
+Migration produces a self-contained config. A relative `extends` is flattened
+(its rules are inlined), resolved relative to the config's own directory first,
+then the current directory. The user-global config moves to a new directory
+(`<config-dir>/ryl/`), so a top-level `ignore-from-file` is inlined as `ignore`
+patterns there too, rather than left as a relative path that would no longer
+resolve. A user-global config with a *rule-level* `ignore-from-file` is skipped
+with a warning (inline those patterns or use an absolute path, then re-run),
+since its rule config cannot be relocated safely. Project migration keeps a
+relative `ignore-from-file` as-is, because the `.ryl.toml` stays in the same
+directory.
 
 After migration, run `ryl .` to confirm diagnostics match what yamllint
 produced.

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -29,14 +29,53 @@ ryl --migrate-configs --migrate-write --migrate-delete-old
 ryl --migrate-configs --migrate-write --migrate-rename-old .bak
 ```
 
+To migrate your **user-global** yamllint config (the personal defaults at
+`<config-dir>/yamllint/config`) to ryl's own location
+(`<config-dir>/ryl/ryl.toml`), use `--migrate-user-config`:
+
+```bash
+# Preview the user-global conversion
+ryl --migrate-user-config
+
+# Write it (creating the ryl/ directory if needed)
+ryl --migrate-user-config --migrate-write
+
+# Migrate project configs and the user-global config in one run
+ryl --migrate-configs --migrate-user-config --migrate-write
+```
+
+Migrating the user-global config is optional: ryl still reads
+`<config-dir>/yamllint/config` directly, so an unmigrated yamllint user-global
+config keeps working.
+
 Useful flags:
 
 | Flag | Purpose |
 | :--- | :--- |
-| `--migrate-root <DIR>` | Search root (defaults to `.`) |
+| `--migrate-configs` | Migrate project-tree YAML configs |
+| `--migrate-user-config` | Migrate the user-global yamllint config |
+| `--migrate-root <DIR>` | Project search root (defaults to `.`) |
 | `--migrate-stdout` | Print generated TOML to stdout instead of writing |
+| `--migrate-write` | Write files (otherwise preview only) |
 | `--migrate-rename-old <SUFFIX>` | Rename source YAML configs after migration |
 | `--migrate-delete-old` | Delete source YAML configs after migration |
+
+The `--migrate-write` / `--migrate-stdout` / `--migrate-rename-old` /
+`--migrate-delete-old` flags apply to whichever migration trigger
+(`--migrate-configs`, `--migrate-user-config`, or both) is set; `--migrate-root`
+applies to project migration only.
+
+Migration never overwrites or deletes through surprises: it skips (with a
+warning, leaving the source untouched) any config whose target directory already
+contains a ryl-native config (`.ryl.toml` or `ryl.toml`), and it refuses to
+follow a symlink for either the source or the target (mirroring `--fix`). It also
+refuses to overwrite an existing backup when `--migrate-rename-old` would clobber
+one.
+
+Known limitation: if a write is interrupted (for example, the disk fills mid
+write), migration may leave a partial config file behind. The next run reports it
+via the "a ryl-native config already exists" skip warning, so delete the partial
+file and re-run.
 
 After migration, run `ryl .` to confirm diagnostics match what yamllint
 produced.
@@ -50,8 +89,12 @@ produced.
 - Configuration discovery walks the same locations as yamllint, with TOML
   formats checked in addition: an explicit `--config-file`, then a
   project-local `.ryl.toml`, `ryl.toml`, `pyproject.toml`, `.yamllint`,
-  `.yamllint.yaml`, or `.yamllint.yml`, then the user-level config
-  directory.
+  `.yamllint.yaml`, or `.yamllint.yml`, then the `YAMLLINT_CONFIG_FILE` env
+  var, then a user-global config. At the user-global step ryl checks its own
+  `<config-dir>/ryl/.ryl.toml` (or `ryl.toml`) first, then falls back to
+  yamllint's `<config-dir>/yamllint/config` (see
+  [ryl-native user-global config](#ryl-native-user-global-config) for how
+  `<config-dir>` resolves per platform).
 - The three built-in presets &mdash; `default`, `relaxed`, and `empty` &mdash;
   match yamllint's behaviour. YAML configs can still use `extends:` to
   reference them; TOML configs must inline the `default`/`relaxed` content (see
@@ -223,6 +266,17 @@ and `--format gitlab` (GitLab Code Quality JSON), which write to stdout (or to a
 yamllint, `--format` is repeatable and each pairs with its own `--output-file`, so a single
 run can emit console diagnostics **and** one or more report files; the same targets can be
 set in a ryl-only TOML `[output]` table. See [Output formats](../output-formats.md).
+
+### ryl-native user-global config
+
+yamllint's only user-global config lives at `$XDG_CONFIG_HOME/yamllint/config` (else
+`~/.config/yamllint/config` on every platform). ryl still reads that path for migrators,
+but checks its own `<config-dir>/ryl/.ryl.toml` (or `ryl.toml`) first, following the
+ruff/Biome convention: `<config-dir>` is `$XDG_CONFIG_HOME` if set, else the platform-native
+config dir (`~/.config/ryl` on Linux, `~/Library/Application Support/ryl` on macOS,
+`%APPDATA%\ryl` on Windows). Being ryl-only, the ryl-native path is TOML; the
+yamllint-compatible path stays YAML and, matching yamllint, always resolves under
+`$XDG_CONFIG_HOME` or `~/.config` (not the native dir).
 
 ## Side-by-side example
 

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -77,6 +77,13 @@ write), migration may leave a partial config file behind. The next run reports i
 via the "a ryl-native config already exists" skip warning, so delete the partial
 file and re-run.
 
+When migration flattens a relative `extends` or `ignore-from-file`, it resolves
+the reference relative to the config's own directory first, then the current
+directory. So a file kept next to a user-global config (e.g.
+`~/.config/yamllint/team.yaml`) is inlined correctly. If the same relative name
+exists both next to the config and in the current directory with different
+contents, the copy next to the config wins.
+
 After migration, run `ryl .` to confirm diagnostics match what yamllint
 produced.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -144,3 +144,20 @@ ryl --migrate-configs --migrate-write
 ```
 
 See [Migrating from yamllint](migrating-from-yamllint.md) for details.
+
+## Configure across projects (user-global)
+
+When no project config is found, ryl falls back to a user-global config so you
+can set personal defaults once. It reads its own TOML config first &mdash;
+`<config-dir>/ryl/.ryl.toml` (or `ryl.toml`), following the ruff/Biome
+convention where `<config-dir>` is `$XDG_CONFIG_HOME` if set, else the
+platform-native config dir (`~/.config/ryl` on Linux, `~/Library/Application
+Support/ryl` on macOS, `%APPDATA%\ryl` on Windows) &mdash; then falls back to
+yamllint's `<config-dir>/yamllint/config` for compatibility. A project config,
+`-c`/`-d`, or `YAMLLINT_CONFIG_FILE` all take precedence over the user-global
+config.
+
+If you have a yamllint user-global config, `ryl --migrate-user-config
+--migrate-write` converts it to the ryl-native `ryl.toml` (see [Migrating from
+yamllint](migrating-from-yamllint.md)). Migration is optional, since ryl also
+reads the yamllint location directly.

--- a/src/config.rs
+++ b/src/config.rs
@@ -607,6 +607,26 @@ impl YamlLintConfig {
         &self.ignore_patterns
     }
 
+    /// Drop `ignore-from-file` so the serialized config emits the patterns `finalize`
+    /// already resolved into `ignore`. User-global migration calls this so the converted
+    /// config is self-contained and keeps working after it moves to ryl's config directory
+    /// (the original relative path would otherwise dangle). Call only after `finalize`.
+    pub fn inline_resolved_ignore_from_file(&mut self) {
+        self.ignore_from_files.clear();
+    }
+
+    /// Whether any rule sets a rule-level `ignore-from-file`. User-global migration refuses
+    /// these: the rule config is serialized verbatim, so the relative path cannot be
+    /// relocated to ryl's config directory without rewriting it (the top-level case is
+    /// inlined instead). Call only after `finalize`, which populates rule filters.
+    #[must_use]
+    pub fn has_rule_level_ignore_from_file(&self) -> bool {
+        self.rules
+            .values()
+            .filter_map(|rule| rule.filter.as_ref())
+            .any(|filter| !filter.from_files.is_empty())
+    }
+
     #[must_use]
     pub fn rule_names(&self) -> &[String] {
         &self.rule_names

--- a/src/config.rs
+++ b/src/config.rs
@@ -615,16 +615,19 @@ impl YamlLintConfig {
         self.ignore_from_files.clear();
     }
 
-    /// Whether any rule sets a rule-level `ignore-from-file`. User-global migration refuses
-    /// these: the rule config is serialized verbatim, so the relative path cannot be
-    /// relocated to ryl's config directory without rewriting it (the top-level case is
-    /// inlined instead). Call only after `finalize`, which populates rule filters.
+    /// Whether any rule sets a *relative* rule-level `ignore-from-file`. User-global
+    /// migration refuses these: the rule config is serialized verbatim, so a relative path
+    /// cannot be relocated to ryl's config directory without rewriting it (the top-level
+    /// case is inlined instead). An absolute rule-level path is left as-is — moving the
+    /// config cannot invalidate it. Call only after `finalize`, which populates rule
+    /// filters.
     #[must_use]
-    pub fn has_rule_level_ignore_from_file(&self) -> bool {
+    pub fn has_relative_rule_level_ignore_from_file(&self) -> bool {
         self.rules
             .values()
             .filter_map(|rule| rule.filter.as_ref())
-            .any(|filter| !filter.from_files.is_empty())
+            .flat_map(|filter| filter.from_files.iter())
+            .any(|path| !Path::new(path).is_absolute())
     }
 
     #[must_use]

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,7 +106,10 @@ impl Env for ClosureEnv<'_> {
     }
 
     fn config_dir(&self) -> Option<PathBuf> {
-        SystemEnv.config_dir()
+        // Resolve config_dir purely from the injected XDG_CONFIG_HOME so this injection env
+        // stays hermetic and never reads the real config dir; an un-injected value yields
+        // None (production uses SystemEnv, which adds the platform-native fallback).
+        (self.get)("XDG_CONFIG_HOME").map(PathBuf::from)
     }
 
     fn home_dir(&self) -> Option<PathBuf> {
@@ -1370,7 +1373,8 @@ fn finalize_context(
 }
 
 /// Discover configuration with precedence:
-/// config-data > config-file > project (TOML-first, YAML fallback) > env var > user-global > defaults.
+/// config-data > config-file > project (TOML-first, YAML fallback) > env var >
+/// ryl user-global (TOML) > yamllint user-global (YAML) > defaults.
 ///
 /// # Errors
 /// Returns an error when a config file cannot be read or parsed.
@@ -1394,7 +1398,7 @@ pub fn discover_config_with(
     overrides: &Overrides,
     envx: &dyn Env,
 ) -> Result<ConfigContext, String> {
-    // Global config resolution: inline > file > project > env var.
+    // Global config resolution: inline > file > project > env var > user-global.
     if let Some(ref data) = overrides.config_data {
         let base_dir = envx.current_dir();
         let cfg =
@@ -1543,12 +1547,83 @@ fn try_env_config_core(envx: &dyn Env) -> Result<Option<ConfigContext>, String> 
 
 // no separate try_env_config_with; discover_config_with_env uses ClosureEnv + discover_config_with
 
+/// User-global config fallback. ryl checks its own branded location first, then the
+/// yamllint-compatible path so migrators keep working.
 fn try_user_global_core(
     envx: &dyn Env,
     base_dir: &Path,
 ) -> Result<Option<ConfigContext>, String> {
-    envx.config_dir()
+    if let Some(ctx) = try_ryl_user_global_core(envx, base_dir)? {
+        return Ok(Some(ctx));
+    }
+    try_yamllint_user_global_core(envx, base_dir)
+}
+
+/// Directory holding ryl's own user-global config, following the ruff/Biome convention
+/// via `config_dir` (`$XDG_CONFIG_HOME` else the platform-native dir), so on macOS it
+/// resolves under `~/Library/Application Support/ryl`, unlike the yamllint path.
+fn ryl_user_global_dir(envx: &dyn Env) -> Option<PathBuf> {
+    envx.config_dir().map(|base| base.join("ryl"))
+}
+
+/// yamllint's user-global config path, matching yamllint exactly across platforms:
+/// `$XDG_CONFIG_HOME/yamllint/config` if set, else `~/.config/yamllint/config` —
+/// deliberately NOT the platform-native config dir (verified against yamllint/cli.py).
+fn yamllint_user_global_path(envx: &dyn Env) -> Option<PathBuf> {
+    envx.env_var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| envx.home_dir().map(|home| home.join(".config")))
         .map(|base| base.join("yamllint").join("config"))
+}
+
+/// Resolve the `(yamllint source, ryl target)` paths for migrating a yamllint user-global
+/// config to ryl's own location. `None` when no config directory or home can be
+/// determined. The target is `ryl.toml` (non-hidden, in the dedicated `ryl/` dir).
+#[must_use]
+pub fn user_config_migration_paths(envx: &dyn Env) -> Option<(PathBuf, PathBuf)> {
+    let source = yamllint_user_global_path(envx)?;
+    let target = ryl_user_global_dir(envx)?.join("ryl.toml");
+    Some((source, target))
+}
+
+/// ryl-native user-global config: `<config-dir>/ryl/{.ryl.toml,ryl.toml}`, TOML only per
+/// the YAML-mirrors-yamllint / TOML-for-ryl-only split.
+fn try_ryl_user_global_core(
+    envx: &dyn Env,
+    base_dir: &Path,
+) -> Result<Option<ConfigContext>, String> {
+    let Some(dir) = ryl_user_global_dir(envx) else {
+        return Ok(None);
+    };
+    for name in RYL_USER_GLOBAL_CONFIG_CANDIDATES {
+        let candidate = dir.join(name);
+        if !envx.path_exists(&candidate) {
+            continue;
+        }
+        let cfg = load_config_from_path_core(envx, &candidate, base_dir, false)?
+            .expect(
+                "non-pyproject .toml always yields a config (empty errors earlier)",
+            );
+        return finalize_context(
+            envx,
+            cfg,
+            base_dir.to_path_buf(),
+            Some(candidate),
+            Vec::new(),
+            true,
+        )
+        .map(Some);
+    }
+    Ok(None)
+}
+
+/// yamllint-compatible user-global config (`<base>/yamllint/config`, YAML), kept for
+/// users migrating from yamllint.
+fn try_yamllint_user_global_core(
+    envx: &dyn Env,
+    base_dir: &Path,
+) -> Result<Option<ConfigContext>, String> {
+    yamllint_user_global_path(envx)
         .filter(|p| envx.path_exists(p))
         .map(|p| {
             let data = envx.read_to_string(&p)?;
@@ -1573,6 +1648,8 @@ const TOML_PROJECT_CONFIG_CANDIDATES: [&str; 3] =
     [".ryl.toml", "ryl.toml", "pyproject.toml"];
 const YAML_PROJECT_CONFIG_CANDIDATES: [&str; 3] =
     [".yamllint", ".yamllint.yaml", ".yamllint.yml"];
+// ryl-native user-global candidates (TOML only); checked inside `<config-dir>/ryl/`.
+const RYL_USER_GLOBAL_CONFIG_CANDIDATES: [&str; 2] = [".ryl.toml", "ryl.toml"];
 
 #[derive(Debug, Clone)]
 struct ProjectConfigDiscovery {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,8 @@ use ryl::cli_support::{
     github_escape, lexical_abspath, report_display_path, resolve_ctx, sanitize_control,
 };
 use ryl::config::{
-    ConfigContext, Overrides, SourceKind, YamlLintConfig, discover_config,
+    ConfigContext, Overrides, SourceKind, SystemEnv, YamlLintConfig, discover_config,
+    user_config_migration_paths,
 };
 use ryl::config_schema::{
     OutputDestination, OutputTable, schema_string_pretty, yaml_schema_string_pretty,
@@ -30,8 +31,8 @@ use ryl::fix::{
     DiffStats, apply_safe_fixes_to_files, diff_outcome, diff_safe_fixes_for_files,
 };
 use ryl::migrate::{
-    MigrateOptions, OutputMode as MigrateOutputMode, SourceCleanup, WriteMode,
-    migrate_configs,
+    MigrateOptions, OutputMode as MigrateOutputMode, SourceCleanup,
+    UserConfigMigration, WriteMode, migrate_configs,
 };
 use ryl::report::{ReportEntry, render_gitlab, render_junit};
 use ryl::{
@@ -164,12 +165,21 @@ fn run_migration(cli: &Cli) -> Result<ExitCode, String> {
     } else {
         SourceCleanup::Keep
     };
-    let options = MigrateOptions {
-        root: cli
-            .migrate
+    let project_root = cli.migrate_configs.then(|| {
+        cli.migrate
             .root
             .clone()
-            .unwrap_or_else(|| PathBuf::from(".")),
+            .unwrap_or_else(|| PathBuf::from("."))
+    });
+    let user_config = if cli.migrate_user_config {
+        user_config_migration_paths(&SystemEnv)
+            .map(|(source, target)| UserConfigMigration { source, target })
+    } else {
+        None
+    };
+    let options = MigrateOptions {
+        project_root: project_root.clone(),
+        user_config: user_config.clone(),
         write_mode: if cli.migrate.write {
             WriteMode::Write
         } else {
@@ -183,23 +193,38 @@ fn run_migration(cli: &Cli) -> Result<ExitCode, String> {
         cleanup,
     };
     let result = migrate_configs(&options)?;
-    for warning in result.warnings {
-        eprintln!("{}", sanitize_control(&warning));
+    for warning in &result.warnings {
+        eprintln!("{}", sanitize_control(warning));
     }
-    if result.entries.is_empty() {
-        println!(
-            "No legacy YAML config files found under {}",
-            sanitize_control(&options.root.display().to_string())
-        );
-        return Ok(ExitCode::SUCCESS);
-    }
-
     for entry in &result.entries {
         println!(
             "{} -> {}",
             sanitize_control(&entry.source.display().to_string()),
             sanitize_control(&entry.target.display().to_string())
         );
+    }
+    // Per-trigger "nothing migrated" feedback, reported independently so a combined run
+    // still surfaces an empty trigger even when the other produced entries. The single
+    // user-global entry (if any) is identified by its source path; the rest are project.
+    let user_source = user_config.as_ref().map(|user| user.source.as_path());
+    if let Some(root) = &project_root {
+        let project_migrated = result
+            .entries
+            .iter()
+            .any(|entry| Some(entry.source.as_path()) != user_source);
+        if !project_migrated {
+            println!(
+                "No legacy YAML config files migrated under {}",
+                sanitize_control(&root.display().to_string())
+            );
+        }
+    }
+    if cli.migrate_user_config {
+        let user_migrated = user_source
+            .is_some_and(|source| result.entries.iter().any(|e| e.source == source));
+        if !user_migrated {
+            println!("No yamllint user-global config migrated.");
+        }
     }
     if options.output_mode == MigrateOutputMode::IncludeToml {
         for entry in &result.entries {
@@ -225,7 +250,18 @@ enum CliFormat {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "ryl", version, about = "Fast YAML linter written in Rust")]
+#[command(
+    name = "ryl",
+    version,
+    about = "Fast YAML linter written in Rust",
+    // Shared `--migrate-*` sub-flags require at least one migration trigger; either
+    // `--migrate-configs` (project tree) or `--migrate-user-config` (user-global) works.
+    group(clap::ArgGroup::new("migrate_mode")
+        .args(["migrate_configs", "migrate_user_config"])
+        .multiple(true))
+)]
+// CLI flags are independent user-facing toggles, not state better modeled as an enum.
+#[allow(clippy::struct_excessive_bools)]
 struct Cli {
     /// One or more paths: files and/or directories, or `-` to read from stdin
     #[arg(value_name = "PATH_OR_FILE")]
@@ -283,6 +319,10 @@ struct Cli {
     /// Convert discovered legacy YAML config files into .ryl.toml files
     #[arg(long = "migrate-configs", default_value_t = false)]
     migrate_configs: bool,
+
+    /// Convert the yamllint user-global config into ryl's own user-global ryl.toml
+    #[arg(long = "migrate-user-config", default_value_t = false)]
+    migrate_user_config: bool,
 
     /// Print a shell completion script for SHELL and exit
     #[arg(
@@ -351,11 +391,11 @@ struct MigrateFlags {
     )]
     root: Option<PathBuf>,
 
-    /// Write migrated .ryl.toml files (otherwise preview only)
+    /// Write migrated TOML files (otherwise preview only)
     #[arg(
         long = "migrate-write",
         default_value_t = false,
-        requires = "migrate_configs"
+        requires = "migrate_mode"
     )]
     write: bool,
 
@@ -363,7 +403,7 @@ struct MigrateFlags {
     #[arg(
         long = "migrate-stdout",
         default_value_t = false,
-        requires = "migrate_configs"
+        requires = "migrate_mode"
     )]
     stdout: bool,
 
@@ -372,7 +412,7 @@ struct MigrateFlags {
         long = "migrate-rename-old",
         value_name = "SUFFIX",
         conflicts_with = "delete_old",
-        requires_all = ["write", "migrate_configs"]
+        requires_all = ["write", "migrate_mode"]
     )]
     rename_old: Option<String>,
 
@@ -381,7 +421,7 @@ struct MigrateFlags {
         long = "migrate-delete-old",
         default_value_t = false,
         conflicts_with = "rename_old",
-        requires_all = ["write", "migrate_configs"]
+        requires_all = ["write", "migrate_mode"]
     )]
     delete_old: bool,
 }
@@ -984,7 +1024,7 @@ fn run_cli(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    if cli.migrate_configs {
+    if cli.migrate_configs || cli.migrate_user_config {
         return run_migration(cli);
     }
 

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -75,6 +75,29 @@ pub fn apply_migration_entries(
     cleanup_only_sources: &[PathBuf],
     cleanup: &SourceCleanup,
 ) -> Result<(), String> {
+    // Preflight rename-backup collisions before writing any target, so a collision never
+    // leaves migrated targets behind (a retry would then skip them as already migrated).
+    // Symlinked sources are excluded because cleanup never renames them.
+    if let SourceCleanup::RenameSuffix(suffix) = cleanup {
+        for source in entries
+            .iter()
+            .map(|entry| entry.source.as_path())
+            .chain(cleanup_only_sources.iter().map(PathBuf::as_path))
+        {
+            if is_symlink(source) {
+                continue;
+            }
+            let renamed = rename_destination(source, suffix);
+            if fs::symlink_metadata(&renamed).is_ok() {
+                return Err(format!(
+                    "refusing to overwrite existing backup {} when renaming {}",
+                    renamed.display(),
+                    source.display()
+                ));
+            }
+        }
+    }
+
     let apply_cleanup = |source: &Path| -> Result<(), String> {
         // Never delete or rename through a symlink: acting on the link's target would
         // orphan the real file, so a symlinked source is preserved untouched (mirrors
@@ -93,20 +116,8 @@ pub fn apply_migration_entries(
                 })?;
             }
             SourceCleanup::RenameSuffix(suffix) => {
-                let source_name = source.file_name().map_or_else(String::new, |name| {
-                    name.to_string_lossy().to_string()
-                });
-                let renamed = source.with_file_name(format!("{source_name}{suffix}"));
-                // `fs::rename` clobbers its destination, so refuse when a backup already
-                // exists rather than destroy it (`symlink_metadata` detects any entry,
-                // including a symlink or dangling link).
-                if fs::symlink_metadata(&renamed).is_ok() {
-                    return Err(format!(
-                        "refusing to overwrite existing backup {} when renaming {}",
-                        renamed.display(),
-                        source.display()
-                    ));
-                }
+                // The backup-collision refusal is preflighted before any target is written.
+                let renamed = rename_destination(source, suffix);
                 fs::rename(source, &renamed).map_err(|err| {
                     format!(
                         "failed to rename migrated source config {} to {}: {err}",
@@ -204,6 +215,14 @@ fn discover_legacy_yaml_configs(root: &Path) -> Vec<PathBuf> {
 /// `--fix`/`--diff` symlink check.
 fn is_symlink(path: &Path) -> bool {
     fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink())
+}
+
+/// The backup path a `RenameSuffix` cleanup would move `source` to (its name + suffix).
+fn rename_destination(source: &Path, suffix: &str) -> PathBuf {
+    let name = source
+        .file_name()
+        .map_or_else(String::new, |name| name.to_string_lossy().to_string());
+    source.with_file_name(format!("{name}{suffix}"))
 }
 
 /// An existing ryl-native TOML config *file* in `target`'s directory that a migration into

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use ignore::WalkBuilder;
@@ -25,9 +26,19 @@ pub enum SourceCleanup {
     RenameSuffix(String),
 }
 
+/// A yamllint user-global config to migrate to ryl's own user-global location.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserConfigMigration {
+    pub source: PathBuf,
+    pub target: PathBuf,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MigrateOptions {
-    pub root: PathBuf,
+    /// Project tree to scan for legacy YAML configs; `None` skips project migration.
+    pub project_root: Option<PathBuf>,
+    /// User-global config to migrate; `None` skips it.
+    pub user_config: Option<UserConfigMigration>,
     pub write_mode: WriteMode,
     pub output_mode: OutputMode,
     pub cleanup: SourceCleanup,
@@ -57,13 +68,20 @@ struct MigrationPlan {
 /// Apply write + cleanup actions for already planned migration entries.
 ///
 /// # Errors
-/// Returns an error if writing targets or requested source cleanup fails.
+/// Returns an error if creating the target directory, writing targets, or requested
+/// source cleanup fails.
 pub fn apply_migration_entries(
     entries: &[MigrationEntry],
     cleanup_only_sources: &[PathBuf],
     cleanup: &SourceCleanup,
 ) -> Result<(), String> {
     let apply_cleanup = |source: &Path| -> Result<(), String> {
+        // Never delete or rename through a symlink: acting on the link's target would
+        // orphan the real file, so a symlinked source is preserved untouched (mirrors
+        // the --fix/--diff symlink refusal).
+        if is_symlink(source) {
+            return Ok(());
+        }
         match cleanup {
             SourceCleanup::Keep => {}
             SourceCleanup::Delete => {
@@ -79,6 +97,16 @@ pub fn apply_migration_entries(
                     name.to_string_lossy().to_string()
                 });
                 let renamed = source.with_file_name(format!("{source_name}{suffix}"));
+                // `fs::rename` clobbers its destination, so refuse when a backup already
+                // exists rather than destroy it (`symlink_metadata` detects any entry,
+                // including a symlink or dangling link).
+                if fs::symlink_metadata(&renamed).is_ok() {
+                    return Err(format!(
+                        "refusing to overwrite existing backup {} when renaming {}",
+                        renamed.display(),
+                        source.display()
+                    ));
+                }
                 fs::rename(source, &renamed).map_err(|err| {
                     format!(
                         "failed to rename migrated source config {} to {}: {err}",
@@ -92,12 +120,32 @@ pub fn apply_migration_entries(
     };
 
     for entry in entries {
-        fs::write(&entry.target, &entry.toml).map_err(|err| {
-            format!(
-                "failed to write migrated config {}: {err}",
-                entry.target.display()
-            )
-        })?;
+        // The user-global target dir (e.g. ~/.config/ryl/) may not exist yet; project
+        // targets land beside an existing config so this is a no-op there. A target with
+        // no parent component (never produced by the planner) simply skips dir creation
+        // and lets the write below report any failure — so this can never panic.
+        if let Some(parent) = entry.target.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                format!(
+                    "failed to create directory {} for migrated config: {err}",
+                    parent.display()
+                )
+            })?;
+        }
+        // `create_new` refuses (atomically, without following a symlink) to overwrite a
+        // target that already exists, a backstop for a target that appears between planning
+        // and writing so a stale plan can never clobber an existing config or symlink.
+        fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&entry.target)
+            .and_then(|mut file| file.write_all(entry.toml.as_bytes()))
+            .map_err(|err| {
+                format!(
+                    "failed to write migrated config {}: {err}",
+                    entry.target.display()
+                )
+            })?;
     }
 
     for source in entries
@@ -152,14 +200,89 @@ fn discover_legacy_yaml_configs(root: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-fn build_migration_entries(root: &Path) -> Result<MigrationPlan, String> {
+/// Whether `path`'s final component is a symlink (does not resolve parents), matching the
+/// `--fix`/`--diff` symlink check.
+fn is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink())
+}
+
+/// An existing ryl-native TOML config *file* in `target`'s directory that a migration into
+/// `target` would overwrite or be shadowed by (`.ryl.toml` outranks `ryl.toml` in
+/// discovery, so either is a collision). A non-file (e.g. a directory) is not treated as a
+/// collision so the write path still reports it.
+fn existing_ryl_native_config(target: &Path) -> Option<PathBuf> {
+    target
+        .parent()
+        .into_iter()
+        .flat_map(|dir| [".ryl.toml", "ryl.toml"].map(|name| dir.join(name)))
+        .find(|candidate| candidate.is_file())
+}
+
+/// Convert one YAML config at `source` into a TOML `MigrationEntry` written to `target`,
+/// flagging a migrated config that ends up enabling no rules. Shared by project and
+/// user-global migration. Skips (with a warning) rather than migrating when the source or
+/// target is a symlink, or when a ryl-native config already exists at the target, so a
+/// migration never follows a symlink, clobbers an existing config, or is silently shadowed.
+/// Returns `true` when an entry was added, `false` when the migration was skipped — callers
+/// use this to avoid cleaning up sources for a directory that was not migrated.
+fn build_entry(
+    source: &Path,
+    target: PathBuf,
+    plan: &mut MigrationPlan,
+) -> Result<bool, String> {
+    if is_symlink(source) {
+        plan.warnings.push(format!(
+            "warning: skipping {}: refusing to follow a symlink",
+            source.display()
+        ));
+        return Ok(false);
+    }
+    if is_symlink(&target) {
+        plan.warnings.push(format!(
+            "warning: skipping migration to {}: refusing to follow a symlink",
+            target.display()
+        ));
+        return Ok(false);
+    }
+    if let Some(existing) = existing_ryl_native_config(&target) {
+        plan.warnings.push(format!(
+            "warning: skipping migration of {}: a ryl-native config already exists at {}",
+            source.display(),
+            existing.display()
+        ));
+        return Ok(false);
+    }
+    let ctx = discover_config(
+        &[],
+        &Overrides {
+            config_file: Some(source.to_path_buf()),
+            config_data: None,
+        },
+    )?;
+    if !ctx.config.enables_any_rule() {
+        plan.warnings.push(format!(
+            "warning: migrated config {} enables no rules; ryl will not lint with it \
+             \u{2014} enable at least one rule, or use 'extends: default' for the standard rule set",
+            target.display()
+        ));
+    }
+    let rendered = ctx.config.to_toml_string();
+    let toml = format!("{}\n", rendered.trim_end());
+    plan.entries.push(MigrationEntry {
+        source: source.to_path_buf(),
+        target,
+        toml,
+    });
+    Ok(true)
+}
+
+fn build_project_entries(root: &Path, plan: &mut MigrationPlan) -> Result<(), String> {
     let mut grouped: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
     for path in discover_legacy_yaml_configs(root) {
         let parent = path.parent().unwrap_or(Path::new(".")).to_path_buf();
         grouped.entry(parent).or_default().push(path);
     }
 
-    let mut plan = MigrationPlan::default();
     let mut directories: Vec<PathBuf> = grouped.keys().cloned().collect();
     directories.sort();
 
@@ -176,39 +299,22 @@ fn build_migration_entries(root: &Path) -> Result<MigrationPlan, String> {
             .first()
             .cloned()
             .expect("at least one config path should exist per grouped directory");
-        for ignored in paths.iter().skip(1) {
-            plan.cleanup_only_sources.push(ignored.clone());
-            plan.warnings.push(format!(
-                "warning: skipping lower-precedence config {} in favor of {}",
-                ignored.display(),
-                primary.display()
-            ));
+        // Only enqueue lower-precedence siblings for cleanup once the primary actually
+        // migrated; otherwise a skipped directory (collision/symlink) would still delete
+        // or rename its siblings with --delete-old/--rename-old.
+        if build_entry(&primary, dir.join(".ryl.toml"), plan)? {
+            for ignored in paths.iter().skip(1) {
+                plan.cleanup_only_sources.push(ignored.clone());
+                plan.warnings.push(format!(
+                    "warning: skipping lower-precedence config {} in favor of {}",
+                    ignored.display(),
+                    primary.display()
+                ));
+            }
         }
-
-        let ctx = discover_config(
-            &[],
-            &Overrides {
-                config_file: Some(primary.clone()),
-                config_data: None,
-            },
-        )?;
-        if !ctx.config.enables_any_rule() {
-            plan.warnings.push(format!(
-                "warning: migrated config {} enables no rules; ryl will not lint with it \
-                 \u{2014} enable at least one rule, or use 'extends: default' for the standard rule set",
-                dir.join(".ryl.toml").display()
-            ));
-        }
-        let rendered = ctx.config.to_toml_string();
-        let toml = format!("{}\n", rendered.trim_end());
-        plan.entries.push(MigrationEntry {
-            source: primary,
-            target: dir.join(".ryl.toml"),
-            toml,
-        });
     }
 
-    Ok(plan)
+    Ok(())
 }
 
 /// Build and optionally apply YAML-to-TOML config migration.
@@ -216,14 +322,21 @@ fn build_migration_entries(root: &Path) -> Result<MigrationPlan, String> {
 /// # Errors
 /// Returns an error if migration planning fails or file operations fail in write mode.
 pub fn migrate_configs(options: &MigrateOptions) -> Result<MigrateResult, String> {
-    if !options.root.exists() {
-        return Err(format!(
-            "error: migrate root does not exist: {}",
-            options.root.display()
-        ));
+    let mut plan = MigrationPlan::default();
+    if let Some(root) = &options.project_root {
+        if !root.exists() {
+            return Err(format!(
+                "error: migrate root does not exist: {}",
+                root.display()
+            ));
+        }
+        build_project_entries(root, &mut plan)?;
     }
-
-    let plan = build_migration_entries(&options.root)?;
+    if let Some(user) = &options.user_config
+        && user.source.exists()
+    {
+        build_entry(&user.source, user.target.clone(), &mut plan)?;
+    }
     if options.write_mode == WriteMode::Write {
         apply_migration_entries(
             &plan.entries,

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -244,10 +244,16 @@ fn existing_ryl_native_config(target: &Path) -> Option<PathBuf> {
 /// migration never follows a symlink, clobbers an existing config, or is silently shadowed.
 /// Returns `true` when an entry was added, `false` when the migration was skipped — callers
 /// use this to avoid cleaning up sources for a directory that was not migrated.
+///
+/// `user_global` marks the user-global config, whose target moves to a different directory
+/// (`<config-dir>/ryl/`): a top-level `ignore-from-file` is inlined so the relative path
+/// does not dangle, and a rule-level `ignore-from-file` (which cannot be relocated without
+/// rewriting the rule config) is refused.
 fn build_entry(
     source: &Path,
     target: PathBuf,
     plan: &mut MigrationPlan,
+    user_global: bool,
 ) -> Result<bool, String> {
     if is_symlink(source) {
         plan.warnings.push(format!(
@@ -271,13 +277,27 @@ fn build_entry(
         ));
         return Ok(false);
     }
-    let ctx = discover_config(
+    let mut ctx = discover_config(
         &[],
         &Overrides {
             config_file: Some(source.to_path_buf()),
             config_data: None,
         },
     )?;
+    if user_global {
+        if ctx.config.has_rule_level_ignore_from_file() {
+            plan.warnings.push(format!(
+                "warning: skipping migration of {}: a rule-level ignore-from-file cannot be \
+                 relocated to the ryl user-global config; inline the patterns or use an \
+                 absolute path, then re-run",
+                source.display()
+            ));
+            return Ok(false);
+        }
+        // The target moves to <config-dir>/ryl/, so a relative top-level ignore-from-file
+        // would dangle; inline its already-resolved patterns to keep the config working.
+        ctx.config.inline_resolved_ignore_from_file();
+    }
     if !ctx.config.enables_any_rule() {
         plan.warnings.push(format!(
             "warning: migrated config {} enables no rules; ryl will not lint with it \
@@ -321,7 +341,7 @@ fn build_project_entries(root: &Path, plan: &mut MigrationPlan) -> Result<(), St
         // Only enqueue lower-precedence siblings for cleanup once the primary actually
         // migrated; otherwise a skipped directory (collision/symlink) would still delete
         // or rename its siblings with --delete-old/--rename-old.
-        if build_entry(&primary, dir.join(".ryl.toml"), plan)? {
+        if build_entry(&primary, dir.join(".ryl.toml"), plan, false)? {
             for ignored in paths.iter().skip(1) {
                 plan.cleanup_only_sources.push(ignored.clone());
                 plan.warnings.push(format!(
@@ -354,7 +374,7 @@ pub fn migrate_configs(options: &MigrateOptions) -> Result<MigrateResult, String
     if let Some(user) = &options.user_config
         && user.source.exists()
     {
-        build_entry(&user.source, user.target.clone(), &mut plan)?;
+        build_entry(&user.source, user.target.clone(), &mut plan, true)?;
     }
     if options.write_mode == WriteMode::Write {
         apply_migration_entries(

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -285,11 +285,11 @@ fn build_entry(
         },
     )?;
     if user_global {
-        if ctx.config.has_rule_level_ignore_from_file() {
+        if ctx.config.has_relative_rule_level_ignore_from_file() {
             plan.warnings.push(format!(
-                "warning: skipping migration of {}: a rule-level ignore-from-file cannot be \
-                 relocated to the ryl user-global config; inline the patterns or use an \
-                 absolute path, then re-run",
+                "warning: skipping migration of {}: a relative rule-level ignore-from-file \
+                 cannot be relocated to the ryl user-global config; inline the patterns or \
+                 use an absolute path, then re-run",
                 source.display()
             ));
             return Ok(false);

--- a/tests/cli_config_migrate.rs
+++ b/tests/cli_config_migrate.rs
@@ -178,7 +178,7 @@ fn migrate_configs_empty_default_root_prints_no_configs_message() {
         .current_dir(td.path())
         .arg("--migrate-configs"));
     assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
-    assert!(stdout.contains("No legacy YAML config files found under"));
+    assert!(stdout.contains("No legacy YAML config files migrated under"));
 }
 
 #[test]
@@ -217,6 +217,97 @@ fn migrate_configs_write_with_delete_old_removes_source() {
     assert!(td.path().join(".ryl.toml").exists());
 }
 
+// The user-global tests point XDG_CONFIG_HOME at a tempdir so they resolve the yamllint
+// source and ryl target inside it, never touching the real config directory.
+#[test]
+fn migrate_user_config_write_creates_ryl_toml() {
+    let td = tempdir().unwrap();
+    let xdg = td.path();
+    fs::create_dir_all(xdg.join("yamllint")).unwrap();
+    fs::write(
+        xdg.join("yamllint").join("config"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("XDG_CONFIG_HOME", xdg)
+        .arg("--migrate-user-config")
+        .arg("--migrate-write"));
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    let toml = fs::read_to_string(xdg.join("ryl").join("ryl.toml")).unwrap();
+    assert!(toml.contains("key-duplicates = \"enable\""), "got: {toml}");
+}
+
+#[test]
+fn migrate_user_config_dry_run_previews_without_writing() {
+    let td = tempdir().unwrap();
+    let xdg = td.path();
+    fs::create_dir_all(xdg.join("yamllint")).unwrap();
+    fs::write(
+        xdg.join("yamllint").join("config"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("XDG_CONFIG_HOME", xdg)
+        .arg("--migrate-user-config"));
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    assert!(
+        stdout.contains("config ->"),
+        "preview line expected: {stdout}"
+    );
+    assert!(!xdg.join("ryl").join("ryl.toml").exists());
+}
+
+#[test]
+fn migrate_user_config_absent_source_reports_message() {
+    let td = tempdir().unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("XDG_CONFIG_HOME", td.path())
+        .arg("--migrate-user-config"));
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    assert!(
+        stdout.contains("No yamllint user-global config migrated"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn migrate_combined_project_and_user_config_in_one_run() {
+    let td = tempdir().unwrap();
+    let proj = td.path().join("proj");
+    fs::create_dir_all(&proj).unwrap();
+    fs::write(
+        proj.join(".yamllint"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    let xdg = td.path().join("xdg");
+    fs::create_dir_all(xdg.join("yamllint")).unwrap();
+    fs::write(
+        xdg.join("yamllint").join("config"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .arg("--migrate-configs")
+        .arg("--migrate-root")
+        .arg(&proj)
+        .arg("--migrate-user-config")
+        .arg("--migrate-write"));
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    assert!(proj.join(".ryl.toml").exists(), "project config migrated");
+    assert!(
+        xdg.join("ryl").join("ryl.toml").exists(),
+        "user-global migrated"
+    );
+}
+
 #[test]
 fn migrate_configs_missing_root_returns_usage_error() {
     let exe = env!("CARGO_BIN_EXE_ryl");
@@ -226,4 +317,35 @@ fn migrate_configs_missing_root_returns_usage_error() {
         .arg("/definitely/no/such/ryl/path"));
     assert_eq!(code, 2, "stderr={stderr}");
     assert!(stderr.contains("migrate root does not exist"));
+}
+
+#[test]
+fn migrate_combined_reports_absent_user_config_even_when_project_migrates() {
+    let td = tempdir().unwrap();
+    let proj = td.path().join("proj");
+    fs::create_dir_all(&proj).unwrap();
+    fs::write(
+        proj.join(".yamllint"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    // XDG dir exists but holds no yamllint/config, so the user-global source is absent.
+    let xdg = td.path().join("xdg");
+    fs::create_dir_all(&xdg).unwrap();
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, stdout, stderr) = run(Command::new(exe)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .arg("--migrate-configs")
+        .arg("--migrate-root")
+        .arg(&proj)
+        .arg("--migrate-user-config"));
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    assert!(
+        stdout.contains(".yamllint ->"),
+        "project migrated: {stdout}"
+    );
+    assert!(
+        stdout.contains("No yamllint user-global config migrated"),
+        "absent user-global reported even though the project migrated: {stdout}"
+    );
 }

--- a/tests/config_env_missing.rs
+++ b/tests/config_env_missing.rs
@@ -47,6 +47,30 @@ fn env_tilde_path_uses_closure_home_dir() {
 }
 
 #[test]
+fn env_xdg_config_home_discovers_ryl_native_user_global() {
+    // discover_config_with_env routes XDG_CONFIG_HOME through the closure, so the
+    // ryl-native user-global (<config-dir>/ryl/ryl.toml) is discoverable via that API.
+    let dir = tempdir().unwrap();
+    let ryl_cfg = dir.path().join("ryl").join("ryl.toml");
+    fs::create_dir_all(ryl_cfg.parent().unwrap()).unwrap();
+    fs::write(&ryl_cfg, "[rules]\nkey-duplicates = 'enable'\n").unwrap();
+
+    let project_root = dir.path().join("workspace");
+    fs::create_dir_all(&project_root).unwrap();
+    let inputs = vec![project_root.join("input.yaml")];
+    // HOME bounds the project-config walk to the tempdir; XDG_CONFIG_HOME points the
+    // user-global lookup at the tempdir so the test never reads the real config dir.
+    let ctx = discover_config_with_env(&inputs, &Overrides::default(), &|k| match k {
+        "XDG_CONFIG_HOME" => Some(dir.path().to_str().unwrap().into()),
+        "HOME" => Some(dir.path().to_str().unwrap().into()),
+        _ => None,
+    })
+    .expect("discover should succeed");
+
+    assert_eq!(ctx.source.as_deref(), Some(ryl_cfg.as_path()));
+}
+
+#[test]
 fn env_tilde_path_without_home_falls_back_to_system_home() {
     let workspace = tempdir().unwrap();
     let inputs = vec![workspace.path().join("input.yaml")];

--- a/tests/config_env_shim.rs
+++ b/tests/config_env_shim.rs
@@ -198,14 +198,98 @@ fn shim_project_config_discovered_from_inputs() {
 }
 
 #[test]
-fn shim_user_global_config_applies_when_no_project_or_env() {
+fn shim_yamllint_user_global_config_applies_when_no_project_or_env() {
+    // The yamllint-compat path resolves via XDG_CONFIG_HOME (or ~/.config), matching
+    // yamllint itself, not the platform-native config dir.
     let env = FakeEnv::default()
         .with_cwd("/wd")
-        .with_config_dir("/xdg")
+        .set_var("XDG_CONFIG_HOME", "/xdg")
         .add_file("/xdg/yamllint/config", cfg_rules_empty())
         .add_exist("/xdg/yamllint/config");
     let ctx = discover_config_with(&[], &Overrides::default(), &env).unwrap();
     assert!(ctx.source.unwrap().ends_with("yamllint/config"));
+}
+
+#[test]
+fn shim_ryl_user_global_toml_applies_when_no_project_or_env() {
+    let env = FakeEnv::default()
+        .with_cwd("/wd")
+        .with_config_dir("/xdg")
+        .add_file("/xdg/ryl/ryl.toml", "[rules]\nkey-duplicates = 'enable'\n")
+        .add_exist("/xdg/ryl/ryl.toml");
+    let ctx = discover_config_with(&[], &Overrides::default(), &env).unwrap();
+    assert_eq!(ctx.source.unwrap(), PathBuf::from("/xdg/ryl/ryl.toml"));
+    // Confirms the file was parsed as TOML (a `[rules]` table), not YAML.
+    assert!(
+        ctx.config
+            .rule_names()
+            .iter()
+            .any(|r| r == "key-duplicates")
+    );
+}
+
+#[test]
+fn shim_ryl_user_global_prefers_dotfile_over_plain() {
+    let env = FakeEnv::default()
+        .with_cwd("/wd")
+        .with_config_dir("/xdg")
+        .add_file("/xdg/ryl/.ryl.toml", "[rules]\nkey-duplicates = 'enable'\n")
+        .add_exist("/xdg/ryl/.ryl.toml")
+        .add_file("/xdg/ryl/ryl.toml", "[rules]\ntrailing-spaces = 'enable'\n")
+        .add_exist("/xdg/ryl/ryl.toml");
+    let ctx = discover_config_with(&[], &Overrides::default(), &env).unwrap();
+    assert_eq!(ctx.source.unwrap(), PathBuf::from("/xdg/ryl/.ryl.toml"));
+    // The dotfile's own contents loaded (key-duplicates, not ryl.toml's trailing-spaces),
+    // so the dotfile won by being read, not merely by appearing first in the path list.
+    let rules = ctx.config.rule_names();
+    assert!(
+        rules.iter().any(|r| r == "key-duplicates")
+            && !rules.iter().any(|r| r == "trailing-spaces"),
+        "expected .ryl.toml contents to load, got {rules:?}"
+    );
+}
+
+#[test]
+fn shim_ryl_user_global_takes_precedence_over_yamllint() {
+    let env = FakeEnv::default()
+        .with_cwd("/wd")
+        .with_config_dir("/xdg")
+        .set_var("XDG_CONFIG_HOME", "/xdg")
+        .add_file("/xdg/ryl/ryl.toml", "[rules]\nkey-duplicates = 'enable'\n")
+        .add_exist("/xdg/ryl/ryl.toml")
+        .add_file("/xdg/yamllint/config", cfg_rules_empty())
+        .add_exist("/xdg/yamllint/config");
+    let ctx = discover_config_with(&[], &Overrides::default(), &env).unwrap();
+    assert_eq!(ctx.source.unwrap(), PathBuf::from("/xdg/ryl/ryl.toml"));
+}
+
+#[test]
+fn shim_ryl_user_global_unreadable_config_errors() {
+    // The ryl-native config exists but cannot be read: discovery must surface the error
+    // rather than silently falling through to the yamllint path or the empty default.
+    let env = FakeEnv::default()
+        .with_cwd("/wd")
+        .with_config_dir("/xdg")
+        .add_exist("/xdg/ryl/ryl.toml");
+    let err = discover_config_with(&[], &Overrides::default(), &env).unwrap_err();
+    assert!(err.contains("failed to read"), "unexpected error: {err}");
+}
+
+#[test]
+fn shim_yamllint_user_global_falls_back_to_home_config_without_xdg() {
+    // With no XDG_CONFIG_HOME, yamllint's user-global lives at ~/.config/yamllint/config
+    // on every platform (not the native config dir); config_dir is unset here, which also
+    // exercises the ryl-native path returning None before the yamllint fallback.
+    let env = FakeEnv::default()
+        .with_cwd("/wd")
+        .with_home("/home/tester")
+        .add_file("/home/tester/.config/yamllint/config", cfg_rules_empty())
+        .add_exist("/home/tester/.config/yamllint/config");
+    let ctx = discover_config_with(&[], &Overrides::default(), &env).unwrap();
+    assert_eq!(
+        ctx.source.unwrap(),
+        PathBuf::from("/home/tester/.config/yamllint/config")
+    );
 }
 
 #[test]
@@ -291,7 +375,7 @@ fn shim_env_var_tilde_backslash_only_returns_home() {
 fn shim_discover_per_file_uses_project_else_user_global_else_default() {
     let env = FakeEnv::default()
         .with_cwd("/wd")
-        .with_config_dir("/xdg")
+        .set_var("XDG_CONFIG_HOME", "/xdg")
         .add_file("/xdg/yamllint/config", cfg_rules_empty())
         .add_exist("/xdg/yamllint/config");
     // No project config, so user-global applies

--- a/tests/discover_config.rs
+++ b/tests/discover_config.rs
@@ -41,10 +41,11 @@ fn discover_errors_when_project_config_is_unreadable() {
 
 #[test]
 fn discover_uses_user_global_when_no_project_config() {
+    // The yamllint-compat user-global resolves via XDG_CONFIG_HOME, matching yamllint.
     let global_cfg = PathBuf::from("/xdg/yamllint/config");
     let env = FakeEnv::new()
         .with_cwd(PathBuf::from("/proj"))
-        .with_config_dir(PathBuf::from("/xdg"))
+        .with_var("XDG_CONFIG_HOME", "/xdg")
         .with_file(global_cfg.clone(), "ignore: ['**/a.yaml']\n");
     let inputs = vec![PathBuf::from("/proj")];
     let ctx = discover_config_with(&inputs, &Overrides::default(), &env)
@@ -83,10 +84,35 @@ fn discover_errors_on_project_config_parse_error() {
 }
 
 #[test]
+fn user_config_migration_paths_resolves_source_and_target() {
+    let env = FakeEnv::new()
+        .with_var("XDG_CONFIG_HOME", "/xdg")
+        .with_config_dir(PathBuf::from("/xdg"));
+    let (source, target) =
+        ryl::config::user_config_migration_paths(&env).expect("both paths resolve");
+    assert_eq!(source, PathBuf::from("/xdg/yamllint/config"));
+    assert_eq!(target, PathBuf::from("/xdg/ryl/ryl.toml"));
+}
+
+#[test]
+fn user_config_migration_paths_none_without_home_or_xdg() {
+    // No XDG_CONFIG_HOME and no home: the yamllint source is unresolvable.
+    let env = FakeEnv::new();
+    assert!(ryl::config::user_config_migration_paths(&env).is_none());
+}
+
+#[test]
+fn user_config_migration_paths_none_without_config_dir() {
+    // Source resolves via home, but no config dir means no ryl target.
+    let env = FakeEnv::new().with_home(PathBuf::from("/home/u"));
+    assert!(ryl::config::user_config_migration_paths(&env).is_none());
+}
+
+#[test]
 fn discover_errors_when_user_global_config_is_unreadable() {
     let env = FakeEnv::new()
         .with_cwd(PathBuf::from("/proj"))
-        .with_config_dir(PathBuf::from("/xdg"))
+        .with_var("XDG_CONFIG_HOME", "/xdg")
         .with_exists(PathBuf::from("/xdg/yamllint/config"));
     let inputs = vec![PathBuf::from("/proj")];
     let err = discover_config_with(&inputs, &Overrides::default(), &env)

--- a/tests/migrate_module.rs
+++ b/tests/migrate_module.rs
@@ -454,6 +454,86 @@ fn apply_entries_refuses_to_overwrite_existing_target() {
     );
 }
 
+#[test]
+fn migrate_user_config_inlines_top_level_ignore_from_file() {
+    let td = tempdir().unwrap();
+    let source = td.path().join("yamllint").join("config");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(
+        &source,
+        "rules:\n  key-duplicates: enable\nignore-from-file: ignores.txt\n",
+    )
+    .unwrap();
+    fs::write(
+        source.parent().unwrap().join("ignores.txt"),
+        "build/\n*.gen.yaml\n",
+    )
+    .unwrap();
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source,
+            target: td.path().join("ryl").join("ryl.toml"),
+        }),
+        write_mode: WriteMode::Preview,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert_eq!(res.entries.len(), 1);
+    let toml = &res.entries[0].toml;
+    // The relative path would dangle once the config moves to ryl/, so it is inlined.
+    assert!(
+        toml.contains("ignore = [")
+            && toml.contains("build/")
+            && toml.contains("*.gen.yaml"),
+        "ignore-from-file must be inlined as ignore patterns: {toml}"
+    );
+    assert!(
+        !toml.contains("ignore-from-file"),
+        "the relative ignore-from-file path must not survive migration: {toml}"
+    );
+}
+
+#[test]
+fn migrate_user_config_refuses_rule_level_ignore_from_file() {
+    let td = tempdir().unwrap();
+    let source = td.path().join("yamllint").join("config");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(
+        &source,
+        "rules:\n  key-duplicates:\n    ignore-from-file: rignore.txt\n",
+    )
+    .unwrap();
+    fs::write(source.parent().unwrap().join("rignore.txt"), "generated/\n").unwrap();
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source: source.clone(),
+            target: td.path().join("ryl").join("ryl.toml"),
+        }),
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Delete,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(
+        res.entries.is_empty(),
+        "rule-level ignore-from-file is refused"
+    );
+    assert!(
+        res.warnings
+            .iter()
+            .any(|w| w.contains("rule-level ignore-from-file")),
+        "expected a rule-level refusal warning: {:?}",
+        res.warnings
+    );
+    assert!(
+        source.exists(),
+        "source preserved when refused, even with --delete"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn migrate_skips_symlinked_source() {

--- a/tests/migrate_module.rs
+++ b/tests/migrate_module.rs
@@ -534,6 +534,45 @@ fn migrate_user_config_refuses_rule_level_ignore_from_file() {
     );
 }
 
+#[test]
+fn migrate_user_config_allows_absolute_rule_level_ignore_from_file() {
+    let td = tempdir().unwrap();
+    let source = td.path().join("yamllint").join("config");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    let abs_ignore = td.path().join("abs_ignore.txt");
+    fs::write(&abs_ignore, "generated/\n").unwrap();
+    // An absolute rule-level ignore-from-file survives the move, so it is not refused.
+    fs::write(
+        &source,
+        format!(
+            "rules:\n  key-duplicates:\n    level: error\n    ignore-from-file: {}\n",
+            abs_ignore.display()
+        ),
+    )
+    .unwrap();
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source,
+            target: td.path().join("ryl").join("ryl.toml"),
+        }),
+        write_mode: WriteMode::Preview,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert_eq!(
+        res.entries.len(),
+        1,
+        "an absolute rule-level ignore-from-file must migrate, not be refused"
+    );
+    assert!(
+        res.entries[0].toml.contains("ignore-from-file"),
+        "the absolute rule-level path is preserved: {}",
+        res.entries[0].toml
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn migrate_skips_symlinked_source() {

--- a/tests/migrate_module.rs
+++ b/tests/migrate_module.rs
@@ -423,6 +423,11 @@ fn migrate_rename_refuses_to_overwrite_existing_backup() {
         "previous backup\n",
         "an existing backup is preserved, not clobbered"
     );
+    // Preflighted before writing, so no target is left behind for a retry to skip.
+    assert!(
+        !td.path().join(".ryl.toml").exists(),
+        "no target written when a rename collision is detected"
+    );
 }
 
 #[test]
@@ -523,11 +528,21 @@ fn apply_entries_cleanup_skips_symlinked_source() {
     fs::write(&real, "rules: {}\n").unwrap();
     let link = td.path().join(".yamllint.yml");
     std::os::unix::fs::symlink(&real, &link).unwrap();
-    apply_migration_entries(&[], std::slice::from_ref(&link), &SourceCleanup::Delete)
-        .unwrap();
+    // RenameSuffix exercises both the rename preflight (which skips symlinks) and the
+    // cleanup-time symlink guard; neither should rename through the symlink.
+    apply_migration_entries(
+        &[],
+        std::slice::from_ref(&link),
+        &SourceCleanup::RenameSuffix(".bak".to_string()),
+    )
+    .unwrap();
     assert!(
         fs::symlink_metadata(&link).is_ok(),
-        "a symlinked source is preserved, not deleted through"
+        "a symlinked source is preserved, not renamed through"
+    );
+    assert!(
+        !td.path().join(".yamllint.yml.bak").exists(),
+        "no backup is created for a skipped symlinked source"
     );
     assert!(real.exists(), "the symlink's real target is untouched");
 }

--- a/tests/migrate_module.rs
+++ b/tests/migrate_module.rs
@@ -2,15 +2,16 @@ use std::fs;
 use std::path::PathBuf;
 
 use ryl::migrate::{
-    MigrateOptions, MigrationEntry, OutputMode, SourceCleanup, WriteMode,
-    apply_migration_entries, migrate_configs,
+    MigrateOptions, MigrationEntry, OutputMode, SourceCleanup, UserConfigMigration,
+    WriteMode, apply_migration_entries, migrate_configs,
 };
 use tempfile::tempdir;
 
 #[test]
 fn migrate_errors_when_root_is_missing() {
     let opts = MigrateOptions {
-        root: PathBuf::from("/no/such/path/for/ryl-migrate"),
+        project_root: Some(PathBuf::from("/no/such/path/for/ryl-migrate")),
+        user_config: None,
         write_mode: WriteMode::Preview,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -25,7 +26,8 @@ fn migrate_single_non_config_file_returns_no_entries() {
     let file = td.path().join("notes.txt");
     fs::write(&file, "hello").unwrap();
     let opts = MigrateOptions {
-        root: file,
+        project_root: Some(file),
+        user_config: None,
         write_mode: WriteMode::Preview,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -41,7 +43,8 @@ fn migrate_single_yaml_config_file_path_returns_entry() {
     let file = td.path().join(".yamllint");
     fs::write(&file, "rules: { document-start: disable }\n").unwrap();
     let opts = MigrateOptions {
-        root: file.clone(),
+        project_root: Some(file.clone()),
+        user_config: None,
         write_mode: WriteMode::Preview,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -58,7 +61,8 @@ fn migrate_write_mode_with_delete_removes_source_file() {
     let source = td.path().join(".yamllint");
     fs::write(&source, "rules: { document-start: disable }\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Write,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Delete,
@@ -76,7 +80,8 @@ fn migrate_write_mode_with_keep_preserves_source_file() {
     let source = td.path().join(".yamllint");
     fs::write(&source, "rules: { document-start: disable }\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Write,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -94,7 +99,8 @@ fn migrate_write_mode_with_rename_suffix_renames_source_file() {
     let source = td.path().join(".yamllint");
     fs::write(&source, "rules: { document-start: disable }\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Write,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::RenameSuffix(".bak".to_string()),
@@ -123,7 +129,8 @@ fn migrate_warns_on_multiple_same_directory_configs() {
     )
     .unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Preview,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -140,7 +147,8 @@ fn migrate_warns_when_migrated_config_enables_no_rules() {
     let td = tempdir().unwrap();
     fs::write(td.path().join(".yamllint"), "rules: {}\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Preview,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -160,7 +168,8 @@ fn migrate_errors_on_invalid_yaml_config_data() {
     let td = tempdir().unwrap();
     fs::write(td.path().join(".yamllint"), "rules: {\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Preview,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -178,7 +187,8 @@ fn migrate_errors_when_generated_toml_conversion_fails() {
     )
     .unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Preview,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -193,7 +203,8 @@ fn migrate_write_errors_when_target_path_is_directory() {
     fs::write(td.path().join(".yamllint"), "rules: {}\n").unwrap();
     fs::create_dir(td.path().join(".ryl.toml")).unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Write,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Keep,
@@ -207,13 +218,349 @@ fn migrate_write_errors_when_rename_destination_is_invalid() {
     let td = tempdir().unwrap();
     fs::write(td.path().join(".yamllint"), "rules: {}\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Write,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::RenameSuffix("/missing/subdir".to_string()),
     };
     let err = migrate_configs(&opts).unwrap_err();
     assert!(err.contains("failed to rename migrated source config"));
+}
+
+#[test]
+fn migrate_user_config_writes_target_creating_missing_dir() {
+    let td = tempdir().unwrap();
+    let source = td.path().join("yamllint").join("config");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "rules: { key-duplicates: enable }\n").unwrap();
+    // The ryl/ target dir does not exist yet; the write must create it.
+    let target = td.path().join("ryl").join("ryl.toml");
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source: source.clone(),
+            target: target.clone(),
+        }),
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert_eq!(res.entries.len(), 1);
+    assert!(
+        target.exists(),
+        "user-global target written, creating ryl/ dir"
+    );
+    assert!(source.exists(), "Keep preserves the yamllint source");
+}
+
+#[test]
+fn migrate_user_config_absent_source_yields_no_entry() {
+    let td = tempdir().unwrap();
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source: td.path().join("yamllint").join("config"),
+            target: td.path().join("ryl").join("ryl.toml"),
+        }),
+        write_mode: WriteMode::Preview,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(res.entries.is_empty());
+}
+
+#[test]
+fn migrate_user_config_propagates_parse_error() {
+    let td = tempdir().unwrap();
+    let source = td.path().join("yamllint").join("config");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "rules: {\n").unwrap();
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source,
+            target: td.path().join("ryl").join("ryl.toml"),
+        }),
+        write_mode: WriteMode::Preview,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let err = migrate_configs(&opts).unwrap_err();
+    assert!(err.contains("failed to parse config data"), "got: {err}");
+}
+
+#[test]
+fn migrate_project_skips_when_ryl_native_config_exists() {
+    let td = tempdir().unwrap();
+    fs::write(
+        td.path().join(".yamllint"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    // A pre-existing .ryl.toml must not be clobbered, even with --delete-old.
+    fs::write(
+        td.path().join(".ryl.toml"),
+        "[rules]\nkey-duplicates = \"enable\"\n",
+    )
+    .unwrap();
+    let opts = MigrateOptions {
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Delete,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(
+        res.entries.is_empty(),
+        "no migration when a ryl-native config exists"
+    );
+    assert!(
+        res.warnings.iter().any(|w| w.contains("already exists")),
+        "expected a collision warning: {:?}",
+        res.warnings
+    );
+    assert!(
+        td.path().join(".yamllint").exists(),
+        "source preserved when migration is skipped"
+    );
+}
+
+#[test]
+fn migrate_user_config_skips_when_ryl_toml_exists() {
+    let td = tempdir().unwrap();
+    let source = td.path().join("yamllint").join("config");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "rules: { key-duplicates: enable }\n").unwrap();
+    let ryl_dir = td.path().join("ryl");
+    fs::create_dir_all(&ryl_dir).unwrap();
+    // Only the non-hidden ryl.toml exists here (exercises the second collision candidate).
+    fs::write(
+        ryl_dir.join("ryl.toml"),
+        "[rules]\nkey-duplicates = \"enable\"\n",
+    )
+    .unwrap();
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source: source.clone(),
+            target: ryl_dir.join("ryl.toml"),
+        }),
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Delete,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(res.entries.is_empty());
+    assert!(
+        res.warnings.iter().any(|w| w.contains("already exists")),
+        "expected a collision warning: {:?}",
+        res.warnings
+    );
+    assert!(source.exists(), "yamllint source preserved when skipped");
+}
+
+#[test]
+fn migrate_skipped_directory_does_not_delete_lower_precedence_siblings() {
+    let td = tempdir().unwrap();
+    let primary = td.path().join(".yamllint");
+    let sibling = td.path().join(".yamllint.yml");
+    fs::write(&primary, "rules: { key-duplicates: enable }\n").unwrap();
+    fs::write(&sibling, "rules: {}\n").unwrap();
+    // A pre-existing ryl-native config makes the whole directory's migration skip; its
+    // lower-precedence siblings must not be deleted as a side effect.
+    fs::write(
+        td.path().join(".ryl.toml"),
+        "[rules]\nkey-duplicates = \"enable\"\n",
+    )
+    .unwrap();
+    let opts = MigrateOptions {
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Delete,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(res.entries.is_empty());
+    assert!(
+        res.cleanup_only_sources.is_empty(),
+        "siblings must not be enqueued for cleanup when the directory is skipped"
+    );
+    assert!(primary.exists(), "primary preserved");
+    assert!(
+        sibling.exists(),
+        "sibling preserved when the directory migration is skipped"
+    );
+}
+
+#[test]
+fn migrate_rename_refuses_to_overwrite_existing_backup() {
+    let td = tempdir().unwrap();
+    fs::write(
+        td.path().join(".yamllint"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    fs::write(td.path().join(".yamllint.bak"), "previous backup\n").unwrap();
+    let opts = MigrateOptions {
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::RenameSuffix(".bak".to_string()),
+    };
+    let err = migrate_configs(&opts).unwrap_err();
+    assert!(
+        err.contains("refusing to overwrite existing backup"),
+        "got: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(td.path().join(".yamllint.bak")).unwrap(),
+        "previous backup\n",
+        "an existing backup is preserved, not clobbered"
+    );
+}
+
+#[test]
+fn apply_entries_refuses_to_overwrite_existing_target() {
+    // create_new backstop: a target present at apply time (e.g. created after planning)
+    // is never overwritten, and the source is left for cleanup only after a successful write.
+    let td = tempdir().unwrap();
+    let target = td.path().join("ryl.toml");
+    fs::write(&target, "original\n").unwrap();
+    let entries = vec![MigrationEntry {
+        source: td.path().join(".yamllint"),
+        target: target.clone(),
+        toml: "[rules]\n".to_string(),
+    }];
+    let err = apply_migration_entries(&entries, &[], &SourceCleanup::Keep).unwrap_err();
+    assert!(
+        err.contains("failed to write migrated config"),
+        "got: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        "original\n",
+        "an existing target is preserved, not overwritten"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn migrate_skips_symlinked_source() {
+    let td = tempdir().unwrap();
+    let real = td.path().join("real.yaml");
+    fs::write(&real, "rules: { key-duplicates: enable }\n").unwrap();
+    let link = td.path().join(".yamllint");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let opts = MigrateOptions {
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(res.entries.is_empty());
+    assert!(
+        res.warnings
+            .iter()
+            .any(|w| w.contains("refusing to follow a symlink")),
+        "expected a symlink-refusal warning: {:?}",
+        res.warnings
+    );
+    assert!(!td.path().join(".ryl.toml").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn migrate_user_config_skips_symlinked_target() {
+    let td = tempdir().unwrap();
+    let source = td.path().join("yamllint").join("config");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "rules: { key-duplicates: enable }\n").unwrap();
+    let ryl_dir = td.path().join("ryl");
+    fs::create_dir_all(&ryl_dir).unwrap();
+    let victim = td.path().join("victim.toml");
+    fs::write(&victim, "untouched\n").unwrap();
+    let target = ryl_dir.join("ryl.toml");
+    std::os::unix::fs::symlink(&victim, &target).unwrap();
+    let opts = MigrateOptions {
+        project_root: None,
+        user_config: Some(UserConfigMigration {
+            source,
+            target: target.clone(),
+        }),
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Keep,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(res.entries.is_empty());
+    assert!(
+        res.warnings
+            .iter()
+            .any(|w| w.contains("refusing to follow a symlink")),
+        "expected a symlink-refusal warning: {:?}",
+        res.warnings
+    );
+    assert_eq!(
+        fs::read_to_string(&victim).unwrap(),
+        "untouched\n",
+        "the symlink's target must not be clobbered"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn apply_entries_cleanup_skips_symlinked_source() {
+    let td = tempdir().unwrap();
+    let real = td.path().join("real.yaml");
+    fs::write(&real, "rules: {}\n").unwrap();
+    let link = td.path().join(".yamllint.yml");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    apply_migration_entries(&[], std::slice::from_ref(&link), &SourceCleanup::Delete)
+        .unwrap();
+    assert!(
+        fs::symlink_metadata(&link).is_ok(),
+        "a symlinked source is preserved, not deleted through"
+    );
+    assert!(real.exists(), "the symlink's real target is untouched");
+}
+
+#[test]
+fn apply_entries_target_without_parent_does_not_panic() {
+    // A parentless target (never produced by the planner) skips dir creation and falls
+    // through to the write, which fails gracefully — proving the path cannot panic.
+    let entries = vec![MigrationEntry {
+        source: PathBuf::from("x"),
+        target: PathBuf::from(""),
+        toml: String::new(),
+    }];
+    let err = apply_migration_entries(&entries, &[], &SourceCleanup::Keep).unwrap_err();
+    assert!(
+        err.contains("failed to write migrated config"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn apply_entries_errors_when_target_parent_cannot_be_created() {
+    let td = tempdir().unwrap();
+    // A regular file where a parent directory is needed makes create_dir_all fail.
+    let blocker = td.path().join("blocker");
+    fs::write(&blocker, "x").unwrap();
+    let entries = vec![MigrationEntry {
+        source: td.path().join(".yamllint"),
+        target: blocker.join("ryl.toml"),
+        toml: "[rules]\n".to_string(),
+    }];
+    let err = apply_migration_entries(&entries, &[], &SourceCleanup::Keep).unwrap_err();
+    assert!(err.contains("failed to create directory"), "got: {err}");
 }
 
 #[test]
@@ -253,7 +600,8 @@ fn migrate_delete_mode_removes_lower_precedence_skipped_configs() {
     fs::write(&primary, "rules: { document-start: disable }\n").unwrap();
     fs::write(&skipped, "rules: {}\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Write,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::Delete,
@@ -274,7 +622,8 @@ fn migrate_rename_mode_renames_lower_precedence_skipped_configs() {
     fs::write(&primary, "rules: { document-start: disable }\n").unwrap();
     fs::write(&skipped, "rules: {}\n").unwrap();
     let opts = MigrateOptions {
-        root: td.path().to_path_buf(),
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
         write_mode: WriteMode::Write,
         output_mode: OutputMode::SummaryOnly,
         cleanup: SourceCleanup::RenameSuffix(".bak".to_string()),


### PR DESCRIPTION
Closes #304.

## Discovery (`src/config.rs`)

- **New ryl-native user-global config:** `<config-dir>/ryl/{.ryl.toml,ryl.toml}` (TOML), checked before the yamllint-compatible path. `<config-dir>` follows the ruff/Biome convention via the existing `config_dir()` (`$XDG_CONFIG_HOME` else the platform-native dir), so on macOS it resolves under `~/Library/Application Support/ryl`. A native ryl user no longer has to nest config under a `yamllint/` directory.
- **Bug fix:** the yamllint-compat path (`<base>/yamllint/config`) now resolves `$XDG_CONFIG_HOME` else `~/.config` on **every** platform, matching `yamllint/cli.py` instead of the platform-native dir, so a user's `~/.config/yamllint/config` is found on macOS/Windows too.
- Precedence: project -> `YAMLLINT_CONFIG_FILE` -> ryl-native user-global -> yamllint user-global -> empty.

## Migration (`src/migrate.rs`, `src/main.rs`)

- **`--migrate-user-config`** converts the yamllint user-global config to `<config-dir>/ryl/ryl.toml`. Parallel to `--migrate-configs`; either alone or both together work (via a clap `ArgGroup`, so the shared `--migrate-write`/`--migrate-stdout`/`--migrate-rename-old`/`--migrate-delete-old` apply to whichever trigger is set; `--migrate-root` stays project-only).
- **Safety / hardening:** skips (with a warning, source untouched) when a ryl-native config already exists at the target (overwrite + shadow prevention); refuses to follow a symlink for source or target (mirrors `--fix`); refuses to clobber an existing `--migrate-rename-old` backup; only enqueues lower-precedence siblings for cleanup once the primary actually migrated; writes via `create_new` (atomic refuse-on-existing, no symlink follow).
- **Documented limitation:** an interrupted write (disk full, killed mid-write) may leave a partial config; the next run's collision warning names it (delete + re-run). Consistent with the existing direct-write / no-`tempfile`-runtime-dep decision.

## Docs

Quickstart user-global section, migrating-from-yamllint migration section + a "How ryl differs from yamllint" entry, and an AGENTS.md note on Codex adversarial file-IO reviews.

## Checks

`prek` clean, coverage gate clean (zero missed regions), full suite green. Reviewed via `/code-review` (2 passes) and local Codex (3 passes); real findings fixed, the file-IO partial-write edge documented per the #285 precedent.