### PR TITLE
Document the explicit+local config model and reject unrecognised top-level TOML keys

### DIFF
--- a/docs/config-presets.md
+++ b/docs/config-presets.md
@@ -2,24 +2,29 @@
 
 ## Applying a preset
 
-ryl applies one configuration file to each file it lints. The nearest
-config in that file's directory or a parent wins, and any configs further
-up are ignored; ryl never merges several together. A monorepo can hold
-many `ryl.toml` files (one per subtree), each governed by exactly one of
-them. Every rule is enabled explicitly, so the config that applies fully
-describes what is checked, with no default-on rules.
+ryl's TOML config (recommended) is the single, explicit source of a file's
+rules: it has no `preset` or `extends` key, inherits nothing, and merges
+nothing, so what it enables is the file's whole ruleset, with no default-on
+rules.
 
-Presets are starting points for a config, not something ryl inherits behind
+ryl resolves one config per file by searching upward from the file. A TOML
+config (`.ryl.toml`, `ryl.toml`, or `pyproject.toml` `[tool.ryl]`) found
+anywhere up the tree is preferred over a `.yamllint`, even a nearer one;
+among configs of the same kind the nearest wins. A monorepo can therefore
+hold many `ryl.toml` files, one per subtree, each governing its own files.
+
+Presets are starting points for that config, not something ryl inherits behind
 the scenes:
 
 - **TOML config (recommended):** there is no `preset` or `extends` key. The
   tables below *are* the presets, so copy the one you want into your
   `.ryl.toml` (or `ryl.toml`) and customise from there. That copy is then your
   one explicit config.
-- **YAML config (yamllint parity):** a yamllint-style config may use
-  `extends: default`, `extends: relaxed`, or `extends: empty` to start from a
-  preset and override individual rules under `rules:`. This exists for
-  compatibility with yamllint; the TOML format has no equivalent by design.
+- **YAML config (yamllint parity):** a yamllint-style config may `extends:` a
+  built-in preset (`default`, `relaxed`, `empty`) or another config file, and
+  ryl merges the inherited settings in (with overrides under `rules:`). This
+  inheritance is the yamllint behaviour the recommended TOML format omits by
+  design.
 
 These TOML presets mirror the built-in YAML presets in `ryl` (`default`,
 `relaxed`, `empty`) from

--- a/docs/config-presets.md
+++ b/docs/config-presets.md
@@ -22,7 +22,8 @@ the scenes:
   compatibility with yamllint; the TOML format has no equivalent by design.
 
 These TOML presets mirror the built-in YAML presets in `ryl` (`default`,
-`relaxed`, `empty`) from [src/conf/mod.rs](/home/owen/Code/ryl_repos/ryl/src/conf/mod.rs).
+`relaxed`, `empty`) from
+[src/conf/mod.rs](https://github.com/owenlamont/ryl/blob/main/src/conf/mod.rs).
 
 ## `default` (TOML equivalent)
 

--- a/docs/config-presets.md
+++ b/docs/config-presets.md
@@ -1,4 +1,25 @@
-# ryl config presets (TOML)
+# ryl config presets
+
+## Applying a preset
+
+ryl applies one configuration file to each file it lints. The nearest
+config in that file's directory or a parent wins, and any configs further
+up are ignored; ryl never merges several together. A monorepo can hold
+many `ryl.toml` files (one per subtree), each governed by exactly one of
+them. Every rule is enabled explicitly, so the config that applies fully
+describes what is checked, with no default-on rules.
+
+Presets are starting points for a config, not something ryl inherits behind
+the scenes:
+
+- **TOML config (recommended):** there is no `preset` or `extends` key. The
+  tables below *are* the presets, so copy the one you want into your
+  `.ryl.toml` (or `ryl.toml`) and customise from there. That copy is then your
+  one explicit config.
+- **YAML config (yamllint parity):** a yamllint-style config may use
+  `extends: default`, `extends: relaxed`, or `extends: empty` to start from a
+  preset and override individual rules under `rules:`. This exists for
+  compatibility with yamllint; the TOML format has no equivalent by design.
 
 These TOML presets mirror the built-in YAML presets in `ryl` (`default`,
 `relaxed`, `empty`) from [src/conf/mod.rs](/home/owen/Code/ryl_repos/ryl/src/conf/mod.rs).

--- a/docs/config-presets.md
+++ b/docs/config-presets.md
@@ -11,7 +11,10 @@ ryl resolves one config per file by searching upward from the file. A TOML
 config (`.ryl.toml`, `ryl.toml`, or `pyproject.toml` `[tool.ryl]`) found
 anywhere up the tree is preferred over a `.yamllint`, even a nearer one;
 among configs of the same kind the nearest wins. A monorepo can therefore
-hold many `ryl.toml` files, one per subtree, each governing its own files.
+hold many `ryl.toml` files, one per subtree, each governing its own files. If
+the upward search finds no project config, ryl falls back to a single
+user-global config; see the
+[quick start](getting-started/quickstart.md).
 
 Presets are starting points for that config, not something ryl inherits behind
 the scenes:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -112,13 +112,15 @@ host-file level (one diff per `.md`).
 
 ## Configure for your project
 
-ryl's configuration is deliberately **explicit** and **local**: every rule is
-enabled explicitly, and each file's rules come from a single config file that
-ryl finds by searching upward (a TOML config anywhere up the tree is preferred
-over a `.yamllint`). The recommended TOML config inherits and merges nothing,
-so what it enables is the whole ruleset, and a monorepo can have many
-`ryl.toml` files, each governing its subtree. There are no default-on rules, so
-a config that enables nothing exits `2` rather than silently linting nothing.
+The recommended TOML config is deliberately **explicit** and **local**: it has
+no default-on rules and no `extends`/inheritance, so a single `.ryl.toml`
+(discovered by searching upward, and preferred over a `.yamllint`) is the
+entire ruleset for the files beneath it; a monorepo can have many, each
+governing its subtree. A yamllint-style YAML config instead keeps yamllint
+semantics, where `extends:` merges in a preset or another file. When no
+project config is found, ryl falls back to a single user-global config (see
+below). Either way there are no default-on rules, so a config that enables
+nothing exits `2` rather than silently linting nothing.
 
 Drop a `.ryl.toml` (or `ryl.toml`) at the root of your repo. TOML
 configuration is flat &mdash; copy the preset you want from

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -112,11 +112,13 @@ host-file level (one diff per `.md`).
 
 ## Configure for your project
 
-ryl's configuration is deliberately **explicit** and **local**: every rule
-is enabled explicitly, and each file's rules come from a single config file
-(the nearest one wins, so a monorepo can have many `ryl.toml` files without
-ryl merging them). There are no default-on rules, so a config that enables
-nothing exits `2` rather than silently linting nothing.
+ryl's configuration is deliberately **explicit** and **local**: every rule is
+enabled explicitly, and each file's rules come from a single config file that
+ryl finds by searching upward (a TOML config anywhere up the tree is preferred
+over a `.yamllint`). The recommended TOML config inherits and merges nothing,
+so what it enables is the whole ruleset, and a monorepo can have many
+`ryl.toml` files, each governing its subtree. There are no default-on rules, so
+a config that enables nothing exits `2` rather than silently linting nothing.
 
 Drop a `.ryl.toml` (or `ryl.toml`) at the root of your repo. TOML
 configuration is flat &mdash; copy the preset you want from

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -112,6 +112,12 @@ host-file level (one diff per `.md`).
 
 ## Configure for your project
 
+ryl's configuration is deliberately **explicit** and **local**: every rule
+is enabled explicitly, and each file's rules come from a single config file
+(the nearest one wins, so a monorepo can have many `ryl.toml` files without
+ryl merging them). There are no default-on rules, so a config that enables
+nothing exits `2` rather than silently linting nothing.
+
 Drop a `.ryl.toml` (or `ryl.toml`) at the root of your repo. TOML
 configuration is flat &mdash; copy the preset you want from
 [Configuration presets](../config-presets.md) and customise from there:

--- a/ryl.toml.schema.json
+++ b/ryl.toml.schema.json
@@ -2161,6 +2161,7 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
   "description": "JSON Schema root for `ryl` TOML configuration.",
   "properties": {
     "files": {

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -846,9 +846,21 @@ pub enum TruthyAllowedValue {
     OffLower,
 }
 
+/// Build the JSON Schema for `ryl` TOML configuration.
+///
+/// # Panics
+/// Panics if schemars stops emitting an object schema root for `TomlConfig`.
 #[must_use]
 pub fn schema() -> Schema {
-    schema_for!(TomlConfig)
+    let mut schema = schema_for!(TomlConfig);
+    // The CLI rejects unrecognised top-level keys (`validate_toml_config`), but schemars
+    // cannot emit `additionalProperties: false` on the root because the flattened `extra`
+    // catch-all is skipped; set it here so editors flag the same typos the CLI does.
+    schema
+        .as_object_mut()
+        .expect("schema root should be an object")
+        .insert("additionalProperties".to_string(), Value::Bool(false));
+    schema
 }
 
 /// Build the JSON Schema for yamllint-compatible YAML configuration.

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -1025,6 +1025,21 @@ pub fn validate_toml_config(config: &TomlConfig) -> Result<(), String> {
         );
     }
 
+    // Top-level unknown keys cannot use `deny_unknown_fields` (serde forbids it
+    // alongside the flattened `extra`), so the same strictness the nested tables
+    // get is enforced manually here. `extends`/`yaml-files` are handled above.
+    if !config.extra.is_empty() {
+        let keys = config
+            .extra
+            .keys()
+            .map(|key| format!("`{key}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(format!(
+            "invalid config: unrecognised TOML configuration key(s): {keys}"
+        ));
+    }
+
     if let Some(entries) = config.per_line_ignores.as_deref() {
         validation::validate_per_line_ignores(entries)?;
     }

--- a/tests/cli_toml_config.rs
+++ b/tests/cli_toml_config.rs
@@ -59,6 +59,38 @@ fn explicit_pyproject_without_tool_ryl_errors() {
 }
 
 #[test]
+fn unrecognised_top_level_toml_key_is_rejected() {
+    // A valid rule is present so the failure is specifically the unknown key, not the
+    // "no rules enabled" guard. ryl's TOML config is the single explicit source of a
+    // file's rules, so a stray/typo'd top-level key (here `preset`) must error rather
+    // than be silently ignored.
+    let td = tempdir().unwrap();
+    let root = td.path();
+    let cfg = root.join("ryl.toml");
+    fs::write(
+        &cfg,
+        "preset = 'relaxed'\n[rules]\ndocument-start = 'enable'\n",
+    )
+    .unwrap();
+    fs::write(root.join("a.yaml"), "a: 1\n").unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_ryl");
+    let (code, _stdout, stderr) = run(Command::new(exe)
+        .arg("-c")
+        .arg(&cfg)
+        .arg(root.join("a.yaml")));
+    assert_eq!(
+        code, 2,
+        "an unrecognised top-level TOML key must error: {stderr}"
+    );
+    assert!(
+        stderr.contains("unrecognised TOML configuration key")
+            && stderr.contains("`preset`"),
+        "error should name the unknown key: {stderr}"
+    );
+}
+
+#[test]
 fn discovered_empty_toml_config_is_rejected() {
     let td = tempdir().unwrap();
     let root = td.path();

--- a/tests/config_fix.rs
+++ b/tests/config_fix.rs
@@ -118,14 +118,17 @@ fn toml_config_parses_exact_typed_fix_variants() {
 }
 
 #[test]
-fn toml_config_with_datetime_extra_parses_fix_policy() {
+fn toml_config_with_unrecognised_top_level_key_is_rejected() {
+    // A stray top-level key (here a datetime-valued `stamp`) is not silently absorbed:
+    // ryl's TOML config is the single explicit source of rules, so it errors and names
+    // the key. The datetime value also exercises a non-string value in the `extra` map.
     let cfg = PathBuf::from("/repo/.ryl.toml");
     let env = common::fake_env::FakeEnv::new().with_file(
         cfg.clone(),
         "stamp = 1979-05-27T07:32:00Z\n[fix]\nfixable = ['ALL']\nunfixable = ['brackets', 'commas', 'comments-indentation']\n",
     );
 
-    let ctx = discover_config_with(
+    let err = discover_config_with(
         &[],
         &Overrides {
             config_file: Some(cfg),
@@ -133,16 +136,11 @@ fn toml_config_with_datetime_extra_parses_fix_policy() {
         },
         &env,
     )
-    .expect("TOML config with datetime extra should still parse fix policy");
+    .expect_err("an unrecognised top-level TOML key must be rejected");
 
-    assert_eq!(ctx.config.fix().fixable(), [FixRuleSelector::All]);
-    assert_eq!(
-        ctx.config.fix().unfixable(),
-        [
-            FixRule::Brackets,
-            FixRule::Commas,
-            FixRule::CommentsIndentation
-        ]
+    assert!(
+        err.contains("unrecognised TOML configuration key") && err.contains("`stamp`"),
+        "error should name the unknown key: {err}"
     );
 }
 

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -209,9 +209,11 @@ fn generated_schema_accepts_valid_sample_config() {
     let validator = validator_for(&schema).expect("generated schema should compile");
     let instance = toml_to_json(
         r#"
-yaml-files = ["*.yaml", "*.yml"]
 ignore = ["vendor/**", "generated/**"]
 locale = "en_US.UTF-8"
+
+[files]
+yaml = ["*.yaml", "*.yml"]
 
 [per-file-ignores]
 "**/values.yaml" = ["document-start"]
@@ -1078,5 +1080,31 @@ fn every_rule_round_trips_through_toml_serialization() {
     assert!(
         dropped.is_empty(),
         "rules dropped from rules_table_to_value serialization: {dropped:?}"
+    );
+}
+
+#[test]
+fn toml_schema_root_rejects_unknown_top_level_keys() {
+    // The CLI rejects unrecognised top-level TOML keys (validate_toml_config); the
+    // published schema must agree so editors flag the same typos rather than accepting a
+    // key the CLI then errors on.
+    let schema = schema_value();
+    assert_eq!(
+        schema.get("additionalProperties"),
+        Some(&json!(false)),
+        "TOML schema root must forbid unknown top-level keys"
+    );
+
+    let validator = validator_for(&schema).expect("generated schema should compile");
+    let unknown =
+        json!({ "preset": "relaxed", "rules": { "document-start": "enable" } });
+    assert!(
+        !validator.is_valid(&unknown),
+        "schema should reject an unknown top-level key like `preset`"
+    );
+    let valid = json!({ "rules": { "document-start": "enable" } });
+    assert!(
+        validator.is_valid(&valid),
+        "a config using only known top-level keys should pass"
     );
 }

--- a/tests/config_toml_coverage.rs
+++ b/tests/config_toml_coverage.rs
@@ -4,14 +4,10 @@ use ryl::config::{Overrides, discover_config, discover_per_file};
 use tempfile::tempdir;
 
 #[test]
-fn discover_config_uses_project_toml_and_parses_float_values() {
+fn discover_config_uses_project_toml() {
     let td = tempdir().unwrap();
     let root = td.path();
-    fs::write(
-        root.join(".ryl.toml"),
-        "flag = true\nratio = 1.25\nstamp = 1979-05-27T07:32:00Z\n[rules]\nanchors = 'disable'\n",
-    )
-    .unwrap();
+    fs::write(root.join(".ryl.toml"), "[rules]\nanchors = 'disable'\n").unwrap();
     let file = root.join("file.yaml");
     fs::write(&file, "a: 1\n").unwrap();
 

--- a/tests/config_toml_discovery.rs
+++ b/tests/config_toml_discovery.rs
@@ -236,13 +236,16 @@ fn explicit_toml_parse_error_is_reported() {
 }
 
 #[test]
-fn toml_scalar_types_are_accepted_for_unknown_keys() {
+fn toml_scalar_typed_unknown_keys_are_rejected() {
+    // Unknown top-level keys are rejected regardless of TOML value type; the bool, float,
+    // and datetime values here also exercise non-string entries in `extra` and the
+    // multi-key listing in the error.
     let cfg = PathBuf::from("/repo/.ryl.toml");
     let env = FakeEnv::new().with_cwd(PathBuf::from("/repo")).with_file(
         cfg.clone(),
         "flag = true\nratio = 1.5\nstamp = 1979-05-27T07:32:00Z\n[rules]\nanchors = 'disable'\n",
     );
-    discover_config_with(
+    let err = discover_config_with(
         &[],
         &Overrides {
             config_file: Some(cfg),
@@ -250,16 +253,23 @@ fn toml_scalar_types_are_accepted_for_unknown_keys() {
         },
         &env,
     )
-    .expect("scalar conversion should parse");
+    .expect_err("unrecognised top-level keys must be rejected");
+    assert!(
+        err.contains("unrecognised TOML configuration key")
+            && err.contains("`flag`")
+            && err.contains("`ratio`")
+            && err.contains("`stamp`"),
+        "error should name all unknown keys: {err}"
+    );
 }
 
 #[test]
-fn toml_integer_scalar_is_accepted_for_unknown_keys() {
+fn toml_integer_unknown_key_is_rejected() {
     let cfg = PathBuf::from("/repo/.ryl.toml");
     let env = FakeEnv::new()
         .with_cwd(PathBuf::from("/repo"))
         .with_file(cfg.clone(), "answer = 42\n[rules]\nanchors = 'disable'\n");
-    discover_config_with(
+    let err = discover_config_with(
         &[],
         &Overrides {
             config_file: Some(cfg),
@@ -267,7 +277,11 @@ fn toml_integer_scalar_is_accepted_for_unknown_keys() {
         },
         &env,
     )
-    .expect("integer conversion should parse");
+    .expect_err("an unrecognised integer-valued top-level key must be rejected");
+    assert!(
+        err.contains("unrecognised TOML configuration key") && err.contains("`answer`"),
+        "error should name the unknown key: {err}"
+    );
 }
 
 #[test]

--- a/tests/fixtures/schemastore/ryl-valid.toml
+++ b/tests/fixtures/schemastore/ryl-valid.toml
@@ -1,6 +1,8 @@
 #:schema ../../schemas/json/ryl.json
-yaml-files = ["*.yaml", "*.yml"]
 ignore = ["vendor/**"]
+
+[files]
+yaml = ["*.yaml", "*.yml"]
 
 [per-file-ignores]
 "**/values.yaml" = ["document-start"]


### PR DESCRIPTION
## Summary

This started as a docs clarification (prompted by #291, where a user expected a `preset:` / `extends:` key to work in TOML) and grew to also close the gap it exposed: ryl silently ignored unrecognised top-level keys in TOML config, which contradicts its fail-loudly philosophy.

## Docs

- **`docs/config-presets.md`**: new "Applying a preset" intro explaining the model: each file's rules resolve from a single config found by searching upward, a TOML config anywhere up the tree is preferred over a nearer `.yamllint`, the recommended TOML config inherits/merges nothing, and the preset tables are copy-templates (TOML has no `preset`/`extends` key by design). Notes that YAML `extends:` (a preset **or** another file) *does* merge, for yamllint parity. Title de-scoped from "(TOML)"; fixed a dead absolute-path source link.
- **`docs/getting-started/quickstart.md`**: states the **explicit + local** configuration philosophy in "Configure for your project".

## Behaviour: reject unrecognised top-level keys in TOML config

- **CLI** (`validate_toml_config`): an unrecognised top-level key in a TOML config (`.ryl.toml` / `ryl.toml` / `pyproject.toml` `[tool.ryl]`) is now an error naming the key (`invalid config: unrecognised TOML configuration key(s): \`preset\``), exit 2, instead of being silently ignored. Nested tables already rejected unknown keys via serde `deny_unknown_fields`; the top-level struct cannot (serde forbids it alongside the flattened `extra` catch-all), so the check is enforced there, after the existing tailored `extends` / `yaml-files` messages. This matches Ruff and Biome (both hard-error on unknown config keys). **TOML-only**: YAML config stays yamllint-tolerant of unknown top-level keys (verified yamllint accepts them).
- **Schema**: the `ryl.toml.schema.json` root now sets `additionalProperties: false` (post-processed in `schema()`, mirroring `yaml_schema()`), so editors flag the same typos the CLI rejects rather than accepting a key the CLI then errors on. Regenerated the committed schema; corrected two test fixtures that used `yaml-files` at the TOML top level (which the CLI rejects: use `[files].yaml`).

## Tests

- A CLI rejection test, a schema-root rejection test, and the pre-existing "unknown keys accepted" tests flipped to assert rejection (covering string / int / bool / float / datetime keys and the multi-key listing). Full suite and the zero-missed-regions coverage gate are green.

Addresses the preset confusion from #291; the yamlfix-preset request there is a separate thread.
