### PR TITLE
v0.17.0: version bump, DRY cleanup, and retrospective-driven dev-process improvements

### DIFF
--- a/.agents/skills/adding-a-rule/SKILL.md
+++ b/.agents/skills/adding-a-rule/SKILL.md
@@ -39,4 +39,26 @@ rather than shipping silently. Work this checklist (the `property-tests` and
    a CLI test `tests/cli_<rule>_rule.rs` (use the shared `common::cli` harness) and an
    embedded-markdown regression test in `tests/cli_markdown_embed.rs`.
 6. **Docs**: a `docs/rules/<rule>.md` page + the index, and a "How ryl differs from
-   yamllint" entry for any deliberate divergence.
+   yamllint" entry for any deliberate divergence. When a doc page shows example CLI
+   output, produce the `line:col`/message by **running ryl** on the shown input — not by
+   hand (hand-written examples have shipped with wrong columns).
+
+## granit event/span gotchas (pinned 0.0.1)
+
+Verified facts that each cost a throwaway probe to rediscover — re-verify on a granit bump:
+
+- `Span.indent` is always `None`; recover a column/indent from `marker_byte_offset` (+ the
+  source), not from the span.
+- A **tagged or anchored block** collection reports `MappingStart`/`SequenceStart` at the
+  **key/value column, not the tag column** — don't assume the event marks the tag.
+- Any rule reading granit token/event line numbers must index lines split the
+  granit-aligned way (`\r\n|\r|\n`, via `line_syntax`), never `\n`-only: a bare `\r`
+  is a line break to granit, so a `\n`-only split desyncs and can panic out-of-bounds.
+- For an indentation/column-sensitive rule, derive structure from granit events from the
+  start; a line-based `classify_mapping` is YAML-unsound on colons-in-scalars, quoted
+  escapes, and multiline plain scalars (the comments-indentation rewrite learned this over
+  ~5 review rounds).
+- Matching a core-schema tag (`!!int`, …): use `crate::yaml_dom::core_schema_suffix` /
+  `is_core_schema`, **never** granit's handle-only `Tag::is_yaml_core_schema` (a verbatim
+  `!<tag:yaml.org,2002:int>` slips past it); compare the full resolved URI when a `%TAG`
+  can split it, as `support::merge_key` does.

--- a/.agents/skills/adding-a-rule/SKILL.md
+++ b/.agents/skills/adding-a-rule/SKILL.md
@@ -43,14 +43,13 @@ rather than shipping silently. Work this checklist (the `property-tests` and
    output, produce the `line:col`/message by **running ryl** on the shown input — not by
    hand (hand-written examples have shipped with wrong columns).
 
-## granit event/span gotchas (pinned 0.0.1)
+## granit event/span gotchas (granit-parser 0.0.5)
 
-Verified facts that each cost a throwaway probe to rediscover — re-verify on a granit bump:
+Facts the codebase relies on; re-verify on a granit bump:
 
-- `Span.indent` is always `None`; recover a column/indent from `marker_byte_offset` (+ the
-  source), not from the span.
-- A **tagged or anchored block** collection reports `MappingStart`/`SequenceStart` at the
-  **key/value column, not the tag column** — don't assume the event marks the tag.
+- Derive a token's position from `marker.byte_offset()` via
+  `crate::rules::support::span_utils` (the pattern every span-using rule follows), rather
+  than reading offsets off the raw `Span` by hand.
 - Any rule reading granit token/event line numbers must index lines split the
   granit-aligned way (`\r\n|\r|\n`, via `line_syntax`), never `\n`-only: a bare `\r`
   is a line break to granit, so a `\n`-only split desyncs and can panic out-of-bounds.

--- a/.agents/skills/codex-review-watch/SKILL.md
+++ b/.agents/skills/codex-review-watch/SKILL.md
@@ -82,6 +82,14 @@ a preflight (or via `--quota-only`):
 - If a future Codex CLI adds a live non-consuming usage command, prefer it over the
   cached snapshot.
 
+**Never sleep until a "reset time."** The snapshot's reset timestamp is just where the
+rolling window currently lands, not a fixed clock alarm — it moves. Do not schedule a
+wait against a derived reset time (this cost ~23 idle minutes once); poll for the
+verdict, or hand back to the user. And a **dropped trigger** (no 👀 in the first ~2 min,
+no verdict) is **not** the same as rate-limited — re-trigger once immediately rather than
+waiting out the full poll window, and confirm a real wall with `--quota-only` before
+assuming quota.
+
 ## Acting on findings
 
 Codex reviews the **code**, not the PR comment threads — it does **not** read replies
@@ -94,3 +102,7 @@ to its comments. So:
   record — but don't expect Codex to acknowledge it, and a re-review may re-raise it.
 - Don't loop re-refuting an already-refuted by-design item; defer to the maintainer's
   merge call.
+- When Codex re-raises the **same theme** with progressively narrower edges (common on
+  prose/docs, not only file-I/O), state the full precise behaviour **once**
+  comprehensively — or scope the bullet down — rather than patching per-edge, round by
+  round. Hitting the daily review quota is a legitimate convergence stop.

--- a/.agents/skills/coverage/SKILL.md
+++ b/.agents/skills/coverage/SKILL.md
@@ -18,8 +18,9 @@ hunting through scattered tips:
    (cross-platform; needs `uv` + a Rust toolchain with `cargo-llvm-cov`). It reruns the
    coverage suite and prints any uncovered ranges, or explicitly confirms when coverage
    is complete.
-3. If the coverage script itself fails, run the relevant test suite manually first,
-   fix the failing tests, then rerun the coverage script.
+3. If the coverage script itself fails, it prints the failing nextest output (the FAIL
+   lines + panic tails); fix those tests, then rerun. Fall back to a manual
+   `cargo nextest run` only when you need the full log.
 4. If the script reports files, extend CLI/system tests targeting those ranges until
    the script produces no output.
 5. For richer artifacts (HTML/LCOV), see the cargo-llvm-cov docs (HTML isn't easily
@@ -31,7 +32,11 @@ hunting through scattered tips:
    `cargo test --no-run` and then
    `rust-lldb target/debug/deps/<test-binary> -- <filter args>` to set breakpoints
    on the problematic lines.
-8. If cached coverage lingers, clear `target/llvm-cov-target` and rerun.
+8. If cached coverage lingers, clear `target/llvm-cov-target` and rerun. But **a single
+   stubborn uncovered region is usually an unreachable branch, not stale cache** — before
+   clearing, confirm the missed line is reachable by *some* input. An unhit `if let`
+   else / error arm looks identical to a cache miss but is closed by a test (or an
+   `expect`), not a rebuild; chasing the cache first has burned multiple rebuilds.
 
 ## Coverage-Friendly Rust Idioms
 
@@ -53,6 +58,9 @@ Windows/MSVC: ensure the `llvm-tools-preview` component is installed (already li
 
 ## Common hotspots
 
+- A CLI/system test that sets a subprocess working dir via `Command::current_dir` can stop
+  the instrumented child writing its `.profraw` (so its lines read as uncovered). Drive
+  coverage-sensitive dedup/path tests with absolute paths instead of changing cwd.
 - Configuration discovery: use the `Env` abstraction (`discover_config_with`) and fake
   envs to hit inline data, explicit files (success and YAML failure), and env-var paths.
 - Project configuration search: cover empty inputs, single files without parents, and

--- a/.agents/skills/coverage/coverage-missing.py
+++ b/.agents/skills/coverage/coverage-missing.py
@@ -95,15 +95,27 @@ def generate_report_json(root: Path) -> dict:
     summary = subprocess.run(
         ["cargo", "llvm-cov", "nextest", "--summary-only"],
         cwd=root,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
         check=False,
     )
     if summary.returncode != 0:
-        sys.exit(
-            "cargo llvm-cov nextest --summary-only failed; "
-            "rerun it directly to see the error."
-        )
+        # Surface the failing tests in one shot rather than forcing a manual re-run:
+        # nextest's FAIL/panic lines are in the captured stream (only `--summary-only`'s
+        # coverage table is suppressed, not the test output), so highlight them and fall
+        # back to a tail.
+        lines = (summary.stdout or "").splitlines()
+        highlights = [
+            line
+            for line in lines
+            if "FAIL" in line
+            or "panicked" in line
+            or "assertion" in line
+            or line.startswith("error")
+        ]
+        detail = "\n".join(highlights[:40]) if highlights else "\n".join(lines[-40:])
+        sys.exit(f"cargo llvm-cov nextest failed:\n{detail}")
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
         tmp_path = Path(handle.name)
     try:

--- a/.agents/skills/coverage/coverage-missing.py
+++ b/.agents/skills/coverage/coverage-missing.py
@@ -103,8 +103,9 @@ def generate_report_json(root: Path) -> dict:
     if summary.returncode != 0:
         # Surface the failing tests in one shot rather than forcing a manual re-run:
         # nextest's FAIL/panic lines are in the captured stream (only `--summary-only`'s
-        # coverage table is suppressed, not the test output), so highlight them and fall
-        # back to a tail.
+        # coverage table is suppressed, not the test output). Show which tests failed
+        # (highlights) AND the output tail — the tail carries the panic/assertion context
+        # that the highlight lines alone omit, so the failure is diagnosable here.
         lines = (summary.stdout or "").splitlines()
         highlights = [
             line
@@ -114,8 +115,11 @@ def generate_report_json(root: Path) -> dict:
             or "assertion" in line
             or line.startswith("error")
         ]
-        detail = "\n".join(highlights[:40]) if highlights else "\n".join(lines[-40:])
-        sys.exit(f"cargo llvm-cov nextest failed:\n{detail}")
+        tail = lines[-60:]
+        parts = (
+            [*highlights[:40], "", "--- output tail ---", *tail] if highlights else tail
+        )
+        sys.exit("cargo llvm-cov nextest failed:\n" + "\n".join(parts))
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
         tmp_path = Path(handle.name)
     try:

--- a/.agents/skills/filing-issues/SKILL.md
+++ b/.agents/skills/filing-issues/SKILL.md
@@ -30,8 +30,9 @@ These go out under the maintainer's name, so they are higher-stakes:
    tool, its docs, the spec, or memory. (A granit issue was filed on an unverified
    assumption and had to be fully retracted.) Treat memory notes about third-party
    behaviour as hypotheses to re-verify.
-3. **Ship a one-command reproduction**, pinned to the dependency's current version,
-   printing observed-vs-expected. No repro, no report.
+3. **Ship a one-command reproduction**, pinned to the dependency's **latest** version
+   (so the report can't be for a bug already fixed upstream), printing
+   observed-vs-expected. No repro, no report.
 4. **Include verified, clickable Sources** (a "Sources" section: spec quote /
    play.yaml.com event stream / upstream issue links) on the *first* pass — not bare
    prose mentions — to avoid a verify-then-re-push cycle on an already-published issue.

--- a/.agents/skills/filing-issues/SKILL.md
+++ b/.agents/skills/filing-issues/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: filing-issues
+description: >-
+  Use when filing or editing a GitHub issue/PR for ryl or, especially, for another
+  project (yamllint, granit, SchemaStore). Covers the cross-repo reference footgun,
+  the draft-locally-then-file gate for other people's repos, the never-on-an-assumption
+  rule, and the verified-Sources requirement — so a published issue does not need a
+  verify-then-re-push cycle.
+---
+
+# Filing Issues and PRs
+
+## Cross-repo references (silent footgun)
+
+- ryl's own issues/PRs: a bare `#123` is correct.
+- **Any other project** (yamllint, granit, SchemaStore, …): use the fully-qualified
+  `owner/repo#123` form, e.g. `adrienverge/yamllint#123`. A bare `#123` silently
+  auto-links to *this* repo (`owenlamont/ryl#123`) and points at the wrong issue — a past
+  batch of 11 issues had to be re-edited and re-pushed over this.
+
+## Filing on another project's repo
+
+These go out under the maintainer's name, so they are higher-stakes:
+
+1. **Draft locally first** for proof-read; do not open it directly. Ask where drafts
+   live (do not hardcode a contributor's local path); the convention is a
+   `<repo>-<topic>` Markdown file one directory up from the ryl clone.
+2. **Never report on an assumption.** Verify every behavioural claim by *running the
+   actual target* at the version in use — never inferred from its lineage, a sibling
+   tool, its docs, the spec, or memory. (A granit issue was filed on an unverified
+   assumption and had to be fully retracted.) Treat memory notes about third-party
+   behaviour as hypotheses to re-verify.
+3. **Ship a one-command reproduction**, pinned to the dependency's current version,
+   printing observed-vs-expected. No repro, no report.
+4. **Include verified, clickable Sources** (a "Sources" section: spec quote /
+   play.yaml.com event stream / upstream issue links) on the *first* pass — not bare
+   prose mentions — to avoid a verify-then-re-push cycle on an already-published issue.
+
+Keep it succinct: concrete ask, runnable repro, then authoritative evidence.
+
+## Triage hygiene
+
+- To assert a verdict on a reported bug, reproduce the reporter's posted output through
+  the **same code path** they ran (e.g. run `--fix` and diff byte-for-byte against the
+  pasted output, not just `--diff`), and read the cited source/docs directly rather than
+  inferring from a grep.
+- Reading a PR's inline review comments: list `.../pulls/<n>/comments` and filter by id
+  (`--jq 'select(.id==<id>)'`); the per-id single-comment endpoint 404s in this workflow.
+
+## Codifying a lesson into always-on docs
+
+When a one-off incident becomes an AGENTS.md rule, **generalize** it: never hardcode a
+local filesystem path, and state the durable principle (reproduce against the current
+version once) rather than transcribing the one-off steps.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -42,12 +42,14 @@ description: >-
   `ryl.toml.schema.json` into SchemaStore's draft-07 format, updates the user's
   SchemaStore fork, and prints a manual upstream PR handoff for
   `owenlamont/schemastore:ryl-schema-update`.
-  - Known failure: if the sync job errors with "refusing to allow an OAuth App to
-    create or update workflow", the fork's `master` is stale and/or the GitHub App
-    lacks workflow-write scope. Sync the fork from upstream via the GitHub web
-    "Sync fork" button (`gh repo sync` hits the same OAuth wall), and grant the App
-    Workflows: Read and write. PR #265 added `permissions: workflows: write` to the
-    workflow as the durable fix.
+  - Known failure: the sync branch is built directly on `upstream/master`
+    (`git checkout -B … upstream/master`), so it carries upstream's `.github/workflows/`
+    files; pushing them needs the App token's **workflows: write** scope. If the job
+    errors with "refusing to allow an OAuth App to create or update workflow", that scope
+    is missing — confirm the `actions/create-github-app-token` step requests
+    `permission-workflows: write` (added in PR #265) and that the GitHub App installation
+    actually grants Workflows: Read and write. The fork's `master` state is *not*
+    involved (the branch never derives from it).
 - Publishing uses Trusted Publishing on all registries (crates.io via GitHub OIDC, PyPI
   via `pypa/gh-action-pypi-publish`, NPM via `actions/setup-node` OIDC). GitHub release
   creation is deferred until after crates.io/PyPI/NPM publishing succeeds, kept as a

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -8,13 +8,18 @@ description: >-
 
 # Release Checklist
 
-- Bump versions in lockstep:
+- Bump versions in lockstep, in the release feature branch (never a separate post-merge
+  bump PR — a forgotten bump has forced one before):
   - Cargo: update `Cargo.toml` `version`.
   - Python: update `pyproject.toml` `[project].version`.
   - NPM: update `package.json` `version`.
-- Refresh lockfile and validate:
-  - Run `cargo generate-lockfile` (or `cargo check`) to refresh `Cargo.lock`.
-  - Stage: `git add Cargo.toml Cargo.lock pyproject.toml package.json`.
+- Refresh both lockfiles and validate (five version-bearing files in total):
+  - Run `cargo generate-lockfile` to refresh `Cargo.lock`. This deliberately sweeps in
+    semver-compatible transitive bumps — the maintainer prefers staying current, so do
+    **not** revert that churn as "separate-PR noise" (a recurring past mistake). Reach
+    for a frozen `cargo check` only when keeping the lockfile pinned is explicitly wanted.
+  - Run `uv lock` to refresh `uv.lock` (it carries the project version too).
+  - Stage: `git add Cargo.toml Cargo.lock pyproject.toml package.json uv.lock`.
   - Run `prek run --all-files` (re-run if files were auto-fixed).
 - Docs and notes:
   - Update README/AGENTS for behavior changes.
@@ -37,6 +42,12 @@ description: >-
   `ryl.toml.schema.json` into SchemaStore's draft-07 format, updates the user's
   SchemaStore fork, and prints a manual upstream PR handoff for
   `owenlamont/schemastore:ryl-schema-update`.
+  - Known failure: if the sync job errors with "refusing to allow an OAuth App to
+    create or update workflow", the fork's `master` is stale and/or the GitHub App
+    lacks workflow-write scope. Sync the fork from upstream via the GitHub web
+    "Sync fork" button (`gh repo sync` hits the same OAuth wall), and grant the App
+    Workflows: Read and write. PR #265 added `permissions: workflows: write` to the
+    workflow as the durable fix.
 - Publishing uses Trusted Publishing on all registries (crates.io via GitHub OIDC, PyPI
   via `pypa/gh-action-pypi-publish`, NPM via `actions/setup-node` OIDC). GitHub release
   creation is deferred until after crates.io/PyPI/NPM publishing succeeds, kept as a

--- a/.agents/skills/retrospective/SKILL.md
+++ b/.agents/skills/retrospective/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: retrospective
+description: >-
+  Use to run a development-friction retrospective over recent Claude Code
+  sessions: a cheap deterministic extractor digests the transcripts (tool errors,
+  wall-clock waits, retry clusters, corrections), then a small number of classifier
+  agents tag the digests against a fixed taxonomy. Prefer this over fanning a
+  classifier agent at each raw transcript (far cheaper, less noise).
+---
+
+# Retrospective Workflow
+
+Goal: quantify development friction across recent sessions so process fixes (AGENTS.md,
+dev skills, settings, tooling) target the biggest costs — not anecdotes.
+
+**Cost lesson.** The first pass fanned one classifier agent at each of 30 raw multi-MB
+transcripts: ~1.95M agent tokens, and the single largest finding category was
+self-correcting noise. Do the measurable work *deterministically first*, then classify
+small digests. That is ~10-20x cheaper and re-runnable every release.
+
+## Workflow
+
+1. **Extract (no LLM).** Run the helper over the sessions since the last release:
+
+   ```bash
+   uv run .agents/skills/retrospective/retro-extract.py --since 2026-06-01 \
+       --out-dir <durable-dir>/retro-digests
+   ```
+
+   It streams each transcript once and emits per-session digests plus a summary:
+   tool-error counts, **wall-clock waits** (the `tool_use`->`tool_result` gap; long waits
+   that *ended in an error/cancellation* are surfaced first — a long block on a broken
+   tool, the most frustrating friction and one pure text classification misses), retry
+   clusters, and correction snippets. By default it covers the top-level (user-facing)
+   sessions and reports the count of nested subagent/workflow transcripts it skipped;
+   pass `--include-nested` to fold those in. Use a **durable** `--out-dir` (not `/tmp`,
+   which is wiped between phases). Skim the summary first — it alone answers a lot.
+
+2. **Iterate on one.** Before any fan-out, run a *single* classifier agent over *one*
+   digest with the taxonomy below, eyeball its output, and tune the taxonomy/prompt
+   (drop a noisy category, sharpen a definition). This catches a bad prompt for the cost
+   of one agent, not N.
+
+3. **Fan out small.** Then classify the digests with a *handful* of agents — group
+   several digests per agent (not one agent per session, and never per raw transcript).
+   Force a structured schema so the output is countable.
+
+4. **Aggregate.** Tally by category, severity, and fix-target; rank by count x severity;
+   separate already-closed gaps (verify they stayed) from still-open ones.
+
+## Taxonomy
+
+`failed_tool_call` (often self-correcting Edit-before-Read / post-`cargo fmt`
+stale-string slips — **down-weight**, ~1 turn each), `long_wait_on_broken_tool` (from the
+extractor's wall-clock data), `permission_or_sandbox_block`, `trial_and_error`,
+`rediscovery`, `doc_gap`, `doc_stale`, `third_party_tool_friction`, `user_correction`,
+`coverage_gate_struggle`, `proptest_struggle`, `schema_regen_churn`, `rework_after_review`,
+`process_inefficiency`. Per finding capture severity, recurring?, root cause, and a
+specific fix-target (which AGENTS.md section / skill / new skill / setting / tool).
+
+The transcript JSONL: one event per line, each ISO-timestamped; assistant messages carry
+`tool_use` blocks, tool results return as user-role messages whose content blocks have
+`is_error`. The extractor handles the parsing — agents read the digests, not the raw files.

--- a/.agents/skills/retrospective/retro-extract.py
+++ b/.agents/skills/retrospective/retro-extract.py
@@ -41,6 +41,7 @@ signal). Prints a cross-session summary; with ``--out-dir`` it also writes one
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 import json
@@ -222,6 +223,16 @@ def scan_correction(digest: SessionDigest, text: str) -> None:
         digest.correction_samples.append(text.strip().replace("\n", " ")[:200])
 
 
+def stream_lines(path: Path) -> Iterator[str]:
+    """Yield the transcript's lines lazily, closing the file when the iterator is done.
+
+    Yields:
+        Each raw JSONL line, without materializing the whole multi-MB file at once.
+    """
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        yield from handle
+
+
 def extract(path: Path, label: str, threshold: float) -> SessionDigest:
     """Stream one transcript and build its digest in a single pass.
 
@@ -233,7 +244,7 @@ def extract(path: Path, label: str, threshold: float) -> SessionDigest:
     last_command: str | None = None
     cluster: dict | None = None  # the open back-to-back retry cluster, if any
     seen_human = False  # the first human turn is the initial request, not a correction
-    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    for raw in stream_lines(path):
         try:
             event = json.loads(raw)
         except json.JSONDecodeError:
@@ -473,11 +484,14 @@ def main(
                 prior = []
             resolved_root = out_dir.resolve()
             for relative in prior:
-                if not isinstance(relative, str):
+                if not isinstance(relative, str) or not relative.endswith(
+                    ".digest.json"
+                ):
                     continue
                 candidate = (out_dir / relative).resolve()
-                # Only unlink entries that stay under out_dir, so a tampered or foreign
-                # manifest (absolute or `..` entries) cannot reach an unrelated file.
+                # Unlink only this tool's digest files that stay under out_dir, so a
+                # tampered/foreign manifest can't delete an unrelated file — neither a
+                # non-digest path (e.g. Cargo.toml) nor one escaping via absolute/`..`.
                 if candidate.is_relative_to(resolved_root):
                     candidate.unlink(missing_ok=True)
         written: list[str] = []

--- a/.agents/skills/retrospective/retro-extract.py
+++ b/.agents/skills/retrospective/retro-extract.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.14"
+# dependencies = ["typer"]
+#
+# [tool.uv]
+# # One-week dependency cooldown (rolling): ignore releases newer than one week
+# # before each run as a supply-chain-safety buffer.
+# exclude-newer = "1 week ago"
+# ///
+
+"""Cheap, deterministic friction extraction from Claude Code session transcripts.
+
+The brute-force retrospective (one classifier agent per raw multi-MB transcript) is
+expensive and noisy. This script does the *measurable* work with no LLM: it streams each
+JSONL transcript once and emits a compact per-session digest of only the candidate
+friction — hard counts plus the few lines worth classifying — so a small number of
+classifier agents can run over the digests instead of the raw transcripts (~10-20x
+cheaper).
+
+Signals (all derived from the transcript, no model needed):
+
+- tool errors: ``tool_result`` blocks with ``is_error: true``.
+- **wall-clock waits**: every event is ISO-timestamped, so the gap between a ``tool_use``
+  and its ``tool_result`` is the tool's real duration. A long wait that ends in an
+  error/cancellation is the worst friction (a long block on a broken tool) and is
+  reported first — a signal pure text classification cannot see.
+- retry clusters: the same Bash command issued repeatedly (trial-and-error).
+- user corrections: human turns carrying redirection markers ("no", "actually", "wrong",
+  "instead", "revert", ...).
+
+With no ``--project-dir`` it derives the transcript directory from the current working
+directory the way Claude Code names it (``~/.claude/projects/<cwd with / and . replaced
+by ->``). By default it analyzes the top-level (user-facing) session transcripts and
+reports how many nested subagent/workflow transcripts it skipped; ``--include-nested``
+adds those (their autonomous tool-churn would otherwise dominate the user-friction
+signal). Prints a cross-session summary; with ``--out-dir`` it also writes one
+``<session>.digest.json`` per session for the classifier-agent fan-out.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import json
+from operator import itemgetter
+from pathlib import Path
+from typing import Annotated, Final
+
+import typer
+
+
+# Lower-cased substrings that mark a human turn as a course-correction.
+CORRECTION_MARKERS: Final = (
+    "no,",
+    "don't",
+    "do not",
+    "actually",
+    "that's not",
+    "thats not",
+    "wrong",
+    "instead",
+    "revert",
+    "i meant",
+    "should be",
+    "not quite",
+    "stop",
+)
+
+# Default wall-clock gap (seconds) at or above which a tool_use->result wait is flagged.
+DEFAULT_WAIT_THRESHOLD: Final = 120.0
+
+# Tools whose wait is the human responding, not the tool running. Their gaps measure
+# how long you were away — not friction — so they are excluded from the wait analysis.
+INTERACTIVE_TOOLS: Final = frozenset({"AskUserQuestion", "ExitPlanMode"})
+
+
+def parse_ts(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 transcript timestamp (``...Z``) to a datetime.
+
+    Returns:
+        The parsed ``datetime``, or ``None`` when absent or unparsable.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+@dataclass
+class SessionDigest:
+    """The compact, classifiable summary of one transcript."""
+
+    session: str
+    first_ts: str | None = None
+    last_ts: str | None = None
+    events: int = 0
+    tool_uses: int = 0
+    tool_errors: int = 0
+    long_waits: list[dict] = field(default_factory=list)
+    retries: list[dict] = field(default_factory=list)
+    error_samples: list[str] = field(default_factory=list)
+    correction_samples: list[str] = field(default_factory=list)
+
+    def as_json(self) -> dict:
+        """Render the digest as a JSON-serializable dict.
+
+        Returns:
+            The digest with its long-wait/retry lists sorted by impact and every
+            sample list capped, so the written file stays small.
+        """
+        return {
+            "session": self.session,
+            "first_ts": self.first_ts,
+            "last_ts": self.last_ts,
+            "events": self.events,
+            "tool_uses": self.tool_uses,
+            "tool_errors": self.tool_errors,
+            "long_waits": sorted(
+                self.long_waits, key=itemgetter("seconds"), reverse=True
+            )[:15],
+            "retries": sorted(self.retries, key=itemgetter("count"), reverse=True)[:10],
+            "error_samples": self.error_samples[:20],
+            "correction_samples": self.correction_samples[:20],
+        }
+
+
+def blocks(message: dict) -> list[dict]:
+    """Return a message's content as a list of blocks.
+
+    Returns:
+        The content list, or ``[]`` when the content is plain text (a string).
+    """
+    content = message.get("content")
+    return content if isinstance(content, list) else []
+
+
+def text_of(message: dict) -> str:
+    """Extract the plain text of a user message.
+
+    Returns:
+        The string content, or the joined text blocks, or ``""``.
+    """
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    return " ".join(
+        block.get("text", "")
+        for block in blocks(message)
+        if block.get("type") == "text"
+    )
+
+
+def bump_retry(digest: SessionDigest, command: str) -> None:
+    """Increment (or start) the retry counter for a repeated Bash command."""
+    snippet = command.strip().replace("\n", " ")[:120]
+    for entry in digest.retries:
+        if entry["cmd"] == snippet:
+            entry["count"] += 1
+            return
+    digest.retries.append({"cmd": snippet, "count": 2})  # the original + this repeat
+
+
+def add_error_sample(digest: SessionDigest, block: dict) -> None:
+    """Capture a short, single-line snippet of an errored tool result."""
+    content = block.get("content")
+    if isinstance(content, list):
+        content = " ".join(
+            part.get("text", "") for part in content if isinstance(part, dict)
+        )
+    snippet = str(content).strip().replace("\n", " ")[:200]
+    if snippet:
+        digest.error_samples.append(snippet)
+
+
+def record_wait(
+    digest: SessionDigest,
+    pending: dict[str, tuple[datetime, str]],
+    block: dict,
+    end: datetime | None,
+    *,
+    is_error: bool,
+    threshold: float,
+) -> None:
+    """Record a tool_use->tool_result wall-clock gap that meets ``threshold``."""
+    start_entry = pending.pop(block.get("tool_use_id", ""), None)
+    if start_entry is None or end is None:
+        return
+    start, tool = start_entry
+    if tool in INTERACTIVE_TOOLS:  # the wait is the human, not the tool
+        return
+    seconds = (end - start).total_seconds()
+    if seconds >= threshold:
+        digest.long_waits.append(
+            {
+                "tool": tool,
+                "seconds": round(seconds, 1),
+                "ended_in_error": is_error,
+                "at": start.isoformat(),
+            }
+        )
+
+
+def scan_correction(digest: SessionDigest, text: str) -> None:
+    """Capture a short snippet of a human turn that looks like a course-correction."""
+    lowered = text.lower()
+    if any(marker in lowered for marker in CORRECTION_MARKERS):
+        digest.correction_samples.append(text.strip().replace("\n", " ")[:200])
+
+
+def extract(path: Path, label: str, threshold: float) -> SessionDigest:
+    """Stream one transcript and build its digest in a single pass.
+
+    Returns:
+        The populated [`SessionDigest`] for ``path``, identified by ``label``.
+    """
+    digest = SessionDigest(session=label)
+    pending: dict[str, tuple[datetime, str]] = {}  # tool_use_id -> (start, tool name)
+    last_command: str | None = None
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):  # a valid-JSON non-object line has no .get
+            continue
+        digest.events += 1
+        timestamp = parse_ts(event.get("timestamp"))
+        if event.get("timestamp"):
+            digest.first_ts = digest.first_ts or event["timestamp"]
+            digest.last_ts = event["timestamp"]
+        message = event.get("message")
+        if not isinstance(message, dict):
+            continue
+        for block in blocks(message):
+            kind = block.get("type")
+            if kind == "tool_use":
+                digest.tool_uses += 1
+                block_id = block.get("id")
+                if (
+                    timestamp is not None and block_id
+                ):  # skip id-less blocks (no "" key)
+                    pending[block_id] = (timestamp, block.get("name", "?"))
+                if block.get("name") == "Bash":
+                    command = (block.get("input") or {}).get("command", "")
+                    if command and command == last_command:
+                        bump_retry(digest, command)
+                    last_command = command or last_command
+            elif kind == "tool_result":
+                is_error = bool(block.get("is_error"))
+                if is_error:
+                    digest.tool_errors += 1
+                    add_error_sample(digest, block)
+                record_wait(
+                    digest,
+                    pending,
+                    block,
+                    timestamp,
+                    is_error=is_error,
+                    threshold=threshold,
+                )
+        if event.get("type") == "user":
+            scan_correction(digest, text_of(message))
+    return digest
+
+
+def default_project_dir() -> Path:
+    """Locate Claude Code's transcript directory for the current working directory.
+
+    Returns:
+        ``~/.claude/projects/<cwd with every non-alphanumeric char replaced by ->``
+        (Claude Code's naming: ``/``, ``.``, ``_`` all become ``-``).
+    """
+    mangled = "".join(c if c.isalnum() else "-" for c in str(Path.cwd()))
+    return Path.home() / ".claude" / "projects" / mangled
+
+
+def label_for(path: Path, project_dir: Path) -> str:
+    """Build a collision-free session label from ``path`` relative to ``project_dir``.
+
+    Returns:
+        The forward-slashed relative path — a bare filename for a top-level session, or
+        ``<session>/subagents/...`` for a nested one — unique across the tree.
+    """
+    return path.relative_to(project_dir).as_posix()
+
+
+def select_transcripts(
+    project_dir: Path, since: str | None, *, include_nested: bool
+) -> tuple[list[Path], int]:
+    """Find the transcripts to analyze under ``project_dir``.
+
+    Top-level ``*.jsonl`` are the user-facing sessions. Nested transcripts (under
+    ``<session>/subagents/`` and ``<session>/workflows/``) are autonomous sub-agent and
+    workflow runs, included only with ``include_nested`` — their churn would otherwise
+    dominate the user-friction signal (a hung sub-agent already shows as an ``Agent``
+    wait in its parent).
+
+    Returns:
+        ``(files, skipped_nested)`` — the selected files (optionally only those modified
+        on/after ``since``, oldest-modified first) and the count of nested transcripts
+        skipped when ``include_nested`` is false (0 otherwise), so the omission is
+        reported rather than silent.
+
+    Raises:
+        typer.Exit: code 1 when ``project_dir`` does not exist or ``since`` is not a
+            valid ISO date.
+    """
+    if not project_dir.is_dir():
+        typer.echo(f"transcript directory not found: {project_dir}", err=True)
+        raise typer.Exit(code=1)
+    # `since` is a date in local time (its epoch is compared to st_mtime); a typo gets a
+    # clean exit, matching the rest of the script rather than a raw traceback.
+    cutoff: float | None = None
+    if since:
+        try:
+            cutoff = datetime.fromisoformat(since).timestamp()
+        except ValueError:
+            typer.echo(
+                f"invalid --since (use an ISO date, e.g. 2026-06-01): {since}", err=True
+            )
+            raise typer.Exit(code=1) from None
+    matched = [
+        path
+        for path in project_dir.rglob("*.jsonl")
+        if cutoff is None or path.stat().st_mtime >= cutoff
+    ]
+    by_mtime = sorted(matched, key=lambda path: path.stat().st_mtime)
+    if include_nested:
+        return by_mtime, 0
+    top_level = [p for p in by_mtime if len(p.relative_to(project_dir).parts) == 1]
+    return top_level, len(by_mtime) - len(top_level)
+
+
+def summary_lines(digests: list[SessionDigest]) -> list[str]:
+    """Build the cross-session friction summary.
+
+    Returns:
+        The summary as a list of lines (totals, then the longest waits, with the
+        error-ending waits — the most frustrating — called out first).
+    """
+    waits = [{**wait, "session": d.session} for d in digests for wait in d.long_waits]
+    broken = [wait for wait in waits if wait["ended_in_error"]]
+    lines = [
+        f"Sessions: {len(digests)}   tool_uses: {sum(d.tool_uses for d in digests)}",
+        (
+            f"Tool errors: {sum(d.tool_errors for d in digests)}   "
+            f"retry clusters: {sum(len(d.retries) for d in digests)}"
+        ),
+        (
+            f"Long waits (>=threshold): {len(waits)}   "
+            f"of which ended in error/cancel: {len(broken)}"
+        ),
+    ]
+    if broken:
+        lines.append("\nLongest waits that ended in an error/cancellation (worst):")
+        lines.extend(
+            f"  {wait['seconds']:>8}s  {wait['tool']:<12} {wait['session']}"
+            for wait in sorted(broken, key=itemgetter("seconds"), reverse=True)[:10]
+        )
+    if waits:
+        lines.append("\nLongest waits overall:")
+        for wait in sorted(waits, key=itemgetter("seconds"), reverse=True)[:10]:
+            flag = " (errored)" if wait["ended_in_error"] else ""
+            lines.append(
+                f"  {wait['seconds']:>8}s  {wait['tool']:<12} {wait['session']}{flag}"
+            )
+    return lines
+
+
+def main(
+    *,
+    since: Annotated[
+        str | None,
+        typer.Option(
+            help="Only sessions modified on/after this local ISO date (YYYY-MM-DD)."
+        ),
+    ] = None,
+    project_dir: Annotated[
+        Path | None,
+        typer.Option(help="Transcript directory (default: derived from the cwd)."),
+    ] = None,
+    out_dir: Annotated[
+        Path | None,
+        typer.Option(
+            help="Write one <session>.digest.json here for the agent fan-out."
+        ),
+    ] = None,
+    wait_threshold: Annotated[
+        float,
+        typer.Option(help="Flag tool_use->result gaps at or above this many seconds."),
+    ] = DEFAULT_WAIT_THRESHOLD,
+    include_nested: Annotated[
+        bool,
+        typer.Option(
+            help="Also analyze nested subagent/workflow transcripts "
+            "(default: top-level sessions only)."
+        ),
+    ] = False,
+) -> None:
+    """Extract per-session friction digests and print a cross-session summary.
+
+    Raises:
+        typer.Exit: code 1 when the transcript directory or matching sessions are
+            missing (via [`select_transcripts`] or the empty-match guard).
+    """
+    root = project_dir or default_project_dir()
+    transcripts, skipped_nested = select_transcripts(
+        root, since, include_nested=include_nested
+    )
+    if not transcripts:
+        if skipped_nested:
+            typer.echo(
+                f"no top-level transcripts matched, but {skipped_nested} nested "
+                "subagent/workflow transcript(s) exist; pass --include-nested to "
+                "analyze them",
+                err=True,
+            )
+        else:
+            typer.echo("no transcripts matched", err=True)
+        raise typer.Exit(code=1)
+
+    digests = [
+        extract(path, label_for(path, root), wait_threshold) for path in transcripts
+    ]
+    typer.echo("\n".join(summary_lines(digests)))
+    if skipped_nested:
+        typer.echo(
+            f"\n(skipped {skipped_nested} nested subagent/workflow transcript(s); "
+            "pass --include-nested to analyze them)"
+        )
+
+    if out_dir is not None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        # Clear a prior run's digests so the directory reflects exactly this run's
+        # selection — a wider --include-nested/--since run must not leave stale,
+        # now-excluded digests behind for a downstream fan-out to misclassify.
+        for stale in out_dir.rglob("*.digest.json"):
+            stale.unlink()
+        for digest in digests:
+            # Mirror the transcript's relative path under out_dir so nested sessions
+            # cannot collide (flattening `/`->`-` is not injective). `digest.session`
+            # is the forward-slashed relative path; pathlib splits it into components.
+            target = out_dir / f"{digest.session}.digest.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(digest.as_json(), indent=2), encoding="utf-8")
+        typer.echo(f"\nWrote {len(digests)} digests to {out_dir}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/.agents/skills/retrospective/retro-extract.py
+++ b/.agents/skills/retrospective/retro-extract.py
@@ -75,6 +75,10 @@ DEFAULT_WAIT_THRESHOLD: Final = 120.0
 # how long you were away — not friction — so they are excluded from the wait analysis.
 INTERACTIVE_TOOLS: Final = frozenset({"AskUserQuestion", "ExitPlanMode"})
 
+# Manifest this tool writes under --out-dir listing the digests it produced, so a later
+# run removes only its own files and never an unrelated *.digest.json kept there.
+MANIFEST_NAME: Final = ".retro-manifest.json"
+
 
 def parse_ts(value: str | None) -> datetime | None:
     """Parse an ISO-8601 transcript timestamp (``...Z``) to a datetime.
@@ -154,14 +158,21 @@ def text_of(message: dict) -> str:
     )
 
 
-def bump_retry(digest: SessionDigest, command: str) -> None:
-    """Increment (or start) the retry counter for a repeated Bash command."""
-    snippet = command.strip().replace("\n", " ")[:120]
-    for entry in digest.retries:
-        if entry["cmd"] == snippet:
-            entry["count"] += 1
-            return
-    digest.retries.append({"cmd": snippet, "count": 2})  # the original + this repeat
+def note_retry(digest: SessionDigest, command: str, cluster: dict | None) -> dict:
+    """Record one back-to-back repeat of ``command``, extending or opening a cluster.
+
+    Each maximal run of consecutive identical Bash commands is its own cluster, so two
+    runs of the same command separated by a break are counted separately, not merged.
+
+    Returns:
+        The open cluster dict, to thread into the next call.
+    """
+    if cluster is not None:
+        cluster["count"] += 1
+        return cluster
+    opened = {"cmd": command.strip().replace("\n", " ")[:120], "count": 2}
+    digest.retries.append(opened)
+    return opened
 
 
 def add_error_sample(digest: SessionDigest, block: dict) -> None:
@@ -220,6 +231,8 @@ def extract(path: Path, label: str, threshold: float) -> SessionDigest:
     digest = SessionDigest(session=label)
     pending: dict[str, tuple[datetime, str]] = {}  # tool_use_id -> (start, tool name)
     last_command: str | None = None
+    cluster: dict | None = None  # the open back-to-back retry cluster, if any
+    seen_human = False  # the first human turn is the initial request, not a correction
     for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
         try:
             event = json.loads(raw)
@@ -247,12 +260,15 @@ def extract(path: Path, label: str, threshold: float) -> SessionDigest:
                 if block.get("name") == "Bash":
                     command = (block.get("input") or {}).get("command", "")
                     if command and command == last_command:
-                        bump_retry(digest, command)
+                        cluster = note_retry(digest, command, cluster)
+                    else:
+                        cluster = None  # a different command ends the current cluster
                     last_command = command or None
                 else:
                     # A non-Bash tool between two identical Bash commands breaks the
                     # back-to-back run, so the later one is iteration, not a blind retry.
                     last_command = None
+                    cluster = None
             elif kind == "tool_result":
                 is_error = bool(block.get("is_error"))
                 if is_error:
@@ -270,7 +286,11 @@ def extract(path: Path, label: str, threshold: float) -> SessionDigest:
             text = text_of(message)
             if text.strip():  # a human turn (not a tool_result delivery) ends a run
                 last_command = None
-            scan_correction(digest, text)
+                cluster = None
+                # Skip the first human turn: it is the initial request, not a correction.
+                if seen_human:
+                    scan_correction(digest, text)
+                seen_human = True
     return digest
 
 
@@ -442,18 +462,28 @@ def main(
 
     if out_dir is not None:
         out_dir.mkdir(parents=True, exist_ok=True)
-        # Clear a prior run's digests so the directory reflects exactly this run's
-        # selection — a wider --include-nested/--since run must not leave stale,
-        # now-excluded digests behind for a downstream fan-out to misclassify.
-        for stale in out_dir.rglob("*.digest.json"):
-            stale.unlink()
+        # Remove only the digests a PRIOR run recorded in its manifest, so the directory
+        # reflects exactly this run's selection without ever deleting unrelated
+        # *.digest.json a user may keep under out_dir (e.g. --out-dir .).
+        manifest = out_dir / MANIFEST_NAME
+        if manifest.is_file():
+            try:
+                prior = json.loads(manifest.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                prior = []
+            for relative in prior:
+                (out_dir / relative).unlink(missing_ok=True)
+        written: list[str] = []
         for digest in digests:
             # Mirror the transcript's relative path under out_dir so nested sessions
             # cannot collide (flattening `/`->`-` is not injective). `digest.session`
             # is the forward-slashed relative path; pathlib splits it into components.
-            target = out_dir / f"{digest.session}.digest.json"
+            relative = f"{digest.session}.digest.json"
+            target = out_dir / relative
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(json.dumps(digest.as_json(), indent=2), encoding="utf-8")
+            written.append(relative)
+        manifest.write_text(json.dumps(written, indent=2), encoding="utf-8")
         typer.echo(f"\nWrote {len(digests)} digests to {out_dir}")
 
 

--- a/.agents/skills/retrospective/retro-extract.py
+++ b/.agents/skills/retrospective/retro-extract.py
@@ -25,7 +25,8 @@ Signals (all derived from the transcript, no model needed):
   and its ``tool_result`` is the tool's real duration. A long wait that ends in an
   error/cancellation is the worst friction (a long block on a broken tool) and is
   reported first — a signal pure text classification cannot see.
-- retry clusters: the same Bash command issued repeatedly (trial-and-error).
+- retry clusters: the same Bash command re-issued back-to-back, with no intervening
+  tool or human turn (a blind retry — trial-and-error, not normal edit-then-rerun).
 - user corrections: human turns carrying redirection markers ("no", "actually", "wrong",
   "instead", "revert", ...).
 
@@ -247,7 +248,11 @@ def extract(path: Path, label: str, threshold: float) -> SessionDigest:
                     command = (block.get("input") or {}).get("command", "")
                     if command and command == last_command:
                         bump_retry(digest, command)
-                    last_command = command or last_command
+                    last_command = command or None
+                else:
+                    # A non-Bash tool between two identical Bash commands breaks the
+                    # back-to-back run, so the later one is iteration, not a blind retry.
+                    last_command = None
             elif kind == "tool_result":
                 is_error = bool(block.get("is_error"))
                 if is_error:
@@ -262,7 +267,10 @@ def extract(path: Path, label: str, threshold: float) -> SessionDigest:
                     threshold=threshold,
                 )
         if event.get("type") == "user":
-            scan_correction(digest, text_of(message))
+            text = text_of(message)
+            if text.strip():  # a human turn (not a tool_result delivery) ends a run
+                last_command = None
+            scan_correction(digest, text)
     return digest
 
 

--- a/.agents/skills/retrospective/retro-extract.py
+++ b/.agents/skills/retrospective/retro-extract.py
@@ -471,8 +471,15 @@ def main(
                 prior = json.loads(manifest.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 prior = []
+            resolved_root = out_dir.resolve()
             for relative in prior:
-                (out_dir / relative).unlink(missing_ok=True)
+                if not isinstance(relative, str):
+                    continue
+                candidate = (out_dir / relative).resolve()
+                # Only unlink entries that stay under out_dir, so a tampered or foreign
+                # manifest (absolute or `..` entries) cannot reach an unrelated file.
+                if candidate.is_relative_to(resolved_root):
+                    candidate.unlink(missing_ok=True)
         written: list[str] = []
         for digest in digests:
             # Mirror the transcript's relative path under out_dir so nested sessions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,8 @@ ryl is a CLI tool for linting yaml files
 Task-scoped procedures live as on-demand skills in `.agents/skills/` (the shared
 project-scope skills dir most non-Claude agents auto-load); load the matching one when
 its task comes up rather than carrying it in this always-on file. Each is a
-self-contained `SKILL.md`; the `coverage` and `codex-review-watch` skills also carry a
-`uv`-runnable helper script.
+self-contained `SKILL.md`; the `coverage`, `codex-review-watch`, and `retrospective`
+skills also carry a `uv`-runnable helper script.
 
 - **`adding-a-rule`** (`.agents/skills/adding-a-rule/SKILL.md`) — the multi-site
   checklist for adding a new lint rule or changing an existing rule's wiring.
@@ -108,6 +108,12 @@ self-contained `SKILL.md`; the `coverage` and `codex-review-watch` skills also c
   tag/push gate, and post-release SchemaStore + publishing flow.
 - **`codex-review-watch`** (`.agents/skills/codex-review-watch/SKILL.md`) — trigger and
   monitor a Codex CI review on a PR and classify the verdict.
+- **`filing-issues`** (`.agents/skills/filing-issues/SKILL.md`) — filing/editing issues
+  and PRs for ryl or another repo: the cross-repo `#NNN` footgun, the draft-locally gate,
+  the never-on-an-assumption rule, and verified Sources.
+- **`retrospective`** (`.agents/skills/retrospective/SKILL.md`) — quantify development
+  friction across recent sessions with a deterministic transcript extractor
+  (`retro-extract.py`) feeding a small classifier-agent fan-out.
 
 Claude Code does not auto-load `.agents/skills/`, so this list is the cross-tool
 fallback: any agent that reads `AGENTS.md` is pointed here, and even a skill-unaware
@@ -177,6 +183,11 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
 - Linters/tests may write outside the workspace (e.g. `~/.cache/prek`); if sandboxed,
   request permission escalation for `prek`/`cargo test`/coverage. Allow ≥1-minute
   timeouts per invocation (more for larger runs/CI).
+- Wait on long-running work (tests, coverage, CI, a Codex review) via the harness's
+  background-task notifications or the Monitor tool: launch it with `run_in_background`
+  and act on the completion event. Don't hand-roll `for i in $(seq …); sleep` poll loops
+  — they burn turns, and a stalled or broken job dead-polls to its timeout instead of
+  surfacing the failure (see the `codex-review-watch` skill for the Codex-specific poll).
 
 ## Automated Tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2284,9 +2284,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -2302,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2315,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2325,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2348,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2699,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.16.0"
+  "version": "0.17.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.16.0"
+version = "0.17.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1198,13 +1198,7 @@ fn apply_fixes_reporting_skips(
         count_reported_problems(&lint_files(files), no_warnings);
     let fix_stats = apply_safe_fixes_to_files(files)?;
     for (path, problem) in &fix_stats.skipped {
-        eprintln!(
-            "{}:{}:{} skipped by --fix: {}",
-            sanitize_control(&path.display().to_string()),
-            problem.line,
-            problem.column,
-            sanitize_control(&problem.message),
-        );
+        eprint_skip_notice(path, problem, "--fix");
     }
     Ok(initial_problem_count)
 }
@@ -1217,6 +1211,19 @@ fn summary_to_exit(summary: &LintSummary, strict: bool) -> ExitCode {
     } else {
         ExitCode::SUCCESS
     }
+}
+
+/// Stderr notice for a file `--fix`/`--diff` left untouched (it does not parse, is a
+/// symlink, or is non-UTF-8): `<path>:L:C skipped by <action>: <message>`. Both path and
+/// message are user-controlled, so both are sanitized; `action` is the literal flag name.
+fn eprint_skip_notice(path: &Path, problem: &LintProblem, action: &str) {
+    eprintln!(
+        "{}:{}:{} skipped by {action}: {}",
+        sanitize_control(&path.display().to_string()),
+        problem.line,
+        problem.column,
+        sanitize_control(&problem.message),
+    );
 }
 
 fn run_stdin_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
@@ -1356,13 +1363,7 @@ fn run_stdin_diff(
 /// diagnostics are neither printed nor counted here.
 fn emit_diff(stats: &DiffStats) -> ExitCode {
     for (path, problem) in &stats.skipped {
-        eprintln!(
-            "{}:{}:{} skipped by --diff: {}",
-            sanitize_control(&path.display().to_string()),
-            problem.line,
-            problem.column,
-            sanitize_control(&problem.message),
-        );
+        eprint_skip_notice(path, problem, "--diff");
     }
     // Each diff already carries the trailing newline similar emits, so concatenating
     // and printing once keeps stdout a clean sequence of `--- / +++ / @@` blocks.
@@ -1442,57 +1443,43 @@ fn gather_lint_files(
     // block that fails to apply on the second copy). Unlike yamllint, which keeps
     // duplicates.
     let mut seen: HashSet<PathBuf> = HashSet::new();
-    for f in candidates {
+    // Directory candidates first (a file matching no source kind is silently skipped),
+    // then explicit args (a no-kind file is a hard error, since the user named it);
+    // `explicit` selects which. `seen` spans both, so a file reached via the walk and
+    // also named on the command line is linted exactly once, in walk order.
+    let tagged = candidates
+        .iter()
+        .map(|path| (path, false))
+        .chain(explicit_files.iter().map(|path| (path, true)));
+    for (path, explicit) in tagged {
         let (base_dir, cfg, notices, found) =
-            resolve_ctx(f, global_cfg, markdown, cache)?;
+            resolve_ctx(path, global_cfg, markdown, cache)?;
         for notice in notices {
             if emitted_notices.insert(notice.clone()) {
                 eprintln!("{}", sanitize_control(notice.as_str()));
             }
         }
-        if cfg.is_file_ignored(f, &base_dir) {
+        if cfg.is_file_ignored(path, &base_dir) {
             continue;
         }
-        if let Some(kind) = cfg.source_kind(f, &base_dir)? {
-            if !seen.insert(lexical_abspath(f)) {
-                continue;
-            }
-            if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
-                ruleless_config_found = Some(found);
-            }
-            files.push((f.clone(), base_dir, cfg, kind));
-        }
-    }
-
-    for ef in explicit_files {
-        let (base_dir, cfg, notices, found) =
-            resolve_ctx(ef, global_cfg, markdown, cache)?;
-        for notice in notices {
-            if emitted_notices.insert(notice.clone()) {
-                eprintln!("{}", sanitize_control(notice.as_str()));
-            }
-        }
-        if cfg.is_file_ignored(ef, &base_dir) {
-            continue;
-        }
-        match cfg.source_kind(ef, &base_dir)? {
-            Some(kind) => {
-                if !seen.insert(lexical_abspath(ef)) {
-                    continue;
-                }
-                if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
-                    ruleless_config_found = Some(found);
-                }
-                files.push((ef.clone(), base_dir, cfg, kind));
-            }
-            None => {
+        let kind = match cfg.source_kind(path, &base_dir)? {
+            Some(kind) => kind,
+            None if explicit => {
                 return Err(format!(
                     "{}: no source kind matches; add a matching glob under \
                      [files].yaml or [files].markdown",
-                    ef.display()
+                    path.display()
                 ));
             }
+            None => continue,
+        };
+        if !seen.insert(lexical_abspath(path)) {
+            continue;
         }
+        if !cfg.enables_any_rule() && ruleless_config_found.is_none() {
+            ruleless_config_found = Some(found);
+        }
+        files.push((path.clone(), base_dir, cfg, kind));
     }
 
     Ok(ruleless_config_found)

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## v0.17.0

Cuts the **v0.17.0** release over the unreleased `0.16.0..HEAD` work, plus a release-cleanup DRY pass and a batch of dev-process improvements from a quantitative friction retrospective.

### Release contents (already on `main`, shipping in 0.17.0)
#300 shell completions · #301 JUnit/GitLab output formats · #303 multi-target output + `[output]` TOML · #307 user-global config · #308 explicit-config + unknown-key rejection · #309 dev skills · #310 agent-friendly.

### Version bump
0.17.0 across `Cargo.toml`, `pyproject.toml`, `package.json`, `Cargo.lock`, `uv.lock` (transitive deps refreshed via `cargo generate-lockfile`).

### DRY cleanup (`src/main.rs`, net −13 lines)
- Collapsed `gather_lint_files`' two near-identical candidate/explicit loops into one chained-iterator loop with an `explicit` flag (behavior-neutral).
- Extracted `eprint_skip_notice`, shared by the `--fix`/`--diff` skip paths.

### Dev-process improvements (retrospective-driven)
A quantitative friction retrospective over recent sessions surfaced recurring costs; addressed here:
- **`release` skill** — add `uv.lock`, the `generate-lockfile`/keep-transitive-bumps policy, a SchemaStore OAuth-workflow known-failure note, and bump-in-branch.
- **`codex-review-watch` skill** — never wait against a derived quota reset time; re-trigger on NOT-ACKED; state recurring prose findings once.
- **`adding-a-rule` skill** — granit event/span gotchas (`Span.indent`=None, tagged-block column, CR-aware line indexing, core-schema-tag helper) + run-doc-examples.
- **`coverage` skill + `coverage-missing.py`** — reachability-before-stale-cache, the `current_dir` profile-write gotcha, and surfacing failing nextest output instead of swallowing it.
- **New `filing-issues` skill** — cross-repo `#NNN` footgun, draft-locally gate, never-on-an-assumption, verified Sources.
- **New `retrospective` skill + `retro-extract.py`** — a deterministic transcript friction extractor (tool errors, wall-clock waits incl. error-ending, retry clusters) feeding a small classifier-agent fan-out; far cheaper than the brute-force pass that produced these findings.
- **AGENTS.md** — harness-notifications-over-poll-loops note; both new skills wired into the Dev Skills list.

### Verification
- `prek run --all-files` clean
- **1558/1558 tests pass**; coverage zero-missed
- `retro-extract.py` hardened across a local Codex adversarial review (4 rounds → final `approve`)