### PR TITLE
Publish ryl to winget via wingetcreate on release

### DIFF
--- a/.agents/skills/codex-review-watch/watch.py
+++ b/.agents/skills/codex-review-watch/watch.py
@@ -32,6 +32,7 @@ import json
 from pathlib import Path
 import re
 import subprocess
+import sys
 import time
 from typing import Annotated
 
@@ -209,6 +210,10 @@ def main(
     ] = 15,
 ) -> None:
     """Watch a Codex CI review on a GitHub PR and classify the verdict."""
+    # Windows stdout/stderr default to cp1252; the Codex verdict and quota text
+    # carry non-ASCII (emoji, P-badges), so force UTF-8 to avoid an encode crash.
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
     quota = read_quota()
     if quota_only:
         report_quota(quota)

--- a/.agents/skills/codex-review-watch/watch.py
+++ b/.agents/skills/codex-review-watch/watch.py
@@ -43,7 +43,9 @@ DASHBOARD = "https://chatgpt.com/codex/settings/usage"
 
 
 def gh(*args: str) -> str:
-    result = subprocess.run(["gh", *args], capture_output=True, text=True)
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8"
+    )
     if result.returncode != 0:
         # A swallowed gh failure (auth, transient API error, rejected post) would let an
         # old verdict look new or reuse a stale trigger, so abort loudly instead.

--- a/.agents/skills/codex-review-watch/watch.py
+++ b/.agents/skills/codex-review-watch/watch.py
@@ -107,7 +107,7 @@ def read_quota() -> dict | None:
     for path in files[:10]:
         found = None
         try:
-            text = path.read_text()
+            text = path.read_text(encoding="utf-8")
         except OSError:
             continue
         for line in text.splitlines():

--- a/.agents/skills/coverage/coverage-missing.py
+++ b/.agents/skills/coverage/coverage-missing.py
@@ -98,6 +98,7 @@ def generate_report_json(root: Path) -> dict:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     if summary.returncode != 0:

--- a/.agents/skills/coverage/coverage-missing.py
+++ b/.agents/skills/coverage/coverage-missing.py
@@ -165,4 +165,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # Windows stdio defaults to cp1252; cargo output (e.g. unicode test names)
+    # printed on failure would crash the encode, so force UTF-8.
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
     main()

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -55,3 +55,10 @@ description: >-
   creation is deferred until after crates.io/PyPI/NPM publishing succeeds, kept as a
   draft until assets upload, with auto-generated notes; reruns skip publish steps for a
   version that already exists.
+- After the release is un-drafted, the `publish-winget` job submits a winget-pkgs PR via
+  `wingetcreate update owenlamont.ryl` (token: the classic `public_repo` `WINGET_PAT`
+  secret in the `automation` environment). It requires the package to already exist in
+  winget-pkgs from the one-time `wingetcreate new` bootstrap; `update` preserves the
+  nested-portable config and `Microsoft.VCRedist.2015+` dependencies, swapping only
+  version, URLs, and SHA256. Re-running a published version would attempt a duplicate
+  winget PR (no existence guard, unlike the crates/PyPI/NPM steps).

--- a/.agents/skills/retrospective/retro-extract.py
+++ b/.agents/skills/retrospective/retro-extract.py
@@ -47,6 +47,7 @@ from datetime import datetime
 import json
 from operator import itemgetter
 from pathlib import Path
+import sys
 from typing import Annotated, Final
 
 import typer
@@ -509,4 +510,8 @@ def main(
 
 
 if __name__ == "__main__":
+    # Windows stdio defaults to cp1252; transcript text in the printed summary
+    # carries non-ASCII, so force UTF-8 to avoid an encode crash.
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
     typer.run(main)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -863,6 +863,37 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: gh release edit "$RELEASE_TAG" -R "${GITHUB_REPOSITORY}" --draft=false
 
+  publish-winget:
+    name: Publish to winget
+    # Must follow finalize-github-release: wingetcreate downloads each release
+    # asset to recompute its SHA256, so the assets have to be publicly
+    # downloadable (un-drafted) first.
+    needs:
+      - finalize-github-release
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') &&
+      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
+    runs-on: windows-latest
+    environment: automation
+    permissions:
+      contents: read
+    steps:
+      - name: Submit ryl to winget-pkgs
+        shell: pwsh
+        env:
+          # wingetcreate reads the classic public_repo PAT from this env var (its
+          # documented CI path), keeping the token out of argv and process logs.
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+        run: |-
+          $ErrorActionPreference = 'Stop'
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $version = ${env:GITHUB_REF_NAME} -replace '^v', ''
+          $base = "https://github.com/${env:GITHUB_REPOSITORY}/releases/download/${env:GITHUB_REF_NAME}"
+          .\wingetcreate.exe update owenlamont.ryl `
+            --version $version `
+            --submit `
+            --urls "${base}/ryl-x86_64-pc-windows-msvc.zip|x64" "${base}/ryl-aarch64-pc-windows-msvc.zip|arm64"
+
   sync-schemastore:
     name: Sync SchemaStore
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -878,6 +878,24 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Download and verify wingetcreate
+        shell: pwsh
+        # Pin to a reviewed release and verify its published SHA256 before the next
+        # step runs it with WINGET_PAT in scope, so a mutated download (or a
+        # compromised redirect) can never execute against the token. Bump the
+        # version and hash together; the hash is the `wingetcreate.exe.txt` checksum
+        # published alongside the release asset.
+        env:
+          WINGETCREATE_VERSION: v1.12.8.0
+          WINGETCREATE_SHA256: 8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D
+        run: |-
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/microsoft/winget-create/releases/download/${env:WINGETCREATE_VERSION}/wingetcreate.exe"
+          Invoke-WebRequest $url -OutFile wingetcreate.exe
+          $actual = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash
+          if ($actual -ne ${env:WINGETCREATE_SHA256}) {
+            throw "wingetcreate.exe SHA256 mismatch: expected ${env:WINGETCREATE_SHA256}, got $actual"
+          }
       - name: Submit ryl to winget-pkgs
         shell: pwsh
         env:
@@ -886,7 +904,6 @@ jobs:
           WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
         run: |-
           $ErrorActionPreference = 'Stop'
-          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           $version = ${env:GITHUB_REF_NAME} -replace '^v', ''
           $base = "https://github.com/${env:GITHUB_REPOSITORY}/releases/download/${env:GITHUB_REF_NAME}"
           .\wingetcreate.exe update owenlamont.ryl `

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ uv tool install ryl                 # uv
 npm install -g @owenlamont/ryl      # npm
 pip install ryl                     # pip
 cargo install ryl                   # cargo
+winget install owenlamont.ryl       # winget (Windows)
 ```
 
 ## Status and scope

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,6 +21,12 @@ toolchain.
     npm install --global @owenlamont/ryl
     ```
 
+=== "winget (Windows)"
+
+    ```powershell
+    winget install owenlamont.ryl
+    ```
+
 === "Prebuilt binary"
 
     Download a release artifact from the

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,9 @@ pip install ryl
 # Or with npm
 npm install --global @owenlamont/ryl
 
+# Or with winget (Windows)
+winget install owenlamont.ryl
+
 # Lint a file or directory
 ryl path/to/file.yaml
 ryl .

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -29,6 +29,12 @@ toolchain.
     npm install --global @owenlamont/ryl
     ```
 
+=== "winget (Windows)"
+
+    ```powershell
+    winget install owenlamont.ryl
+    ```
+
 === "Prebuilt binary"
 
     Download a release artifact from the

--- a/scripts/benchmark_perf_vs_yamllint.py
+++ b/scripts/benchmark_perf_vs_yamllint.py
@@ -61,7 +61,9 @@ def quote_shell(text: str) -> str:
 def run_checked(
     args: list[str], *, cwd: Path | None = None
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, cwd=cwd, check=True, text=True, capture_output=True)
+    return subprocess.run(
+        args, cwd=cwd, check=True, text=True, capture_output=True, encoding="utf-8"
+    )
 
 
 def require_command(name: str) -> None:

--- a/scripts/print_ryl_schemastore_schema.py
+++ b/scripts/print_ryl_schemastore_schema.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import sys
 
 
 SCHEMASTORE_ID = "https://json.schemastore.org/ryl.json"
@@ -55,4 +56,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # Windows stdio defaults to cp1252; the ensure_ascii=False JSON may carry
+    # non-ASCII, so force UTF-8 to avoid an encode crash.
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
     main()

--- a/scripts/print_ryl_schemastore_schema.py
+++ b/scripts/print_ryl_schemastore_schema.py
@@ -46,7 +46,7 @@ def main() -> None:
     Raises:
         SystemExit: If the transformed schema root is not a JSON object.
     """
-    transformed = transform_schema(json.loads(SOURCE_PATH.read_text()))
+    transformed = transform_schema(json.loads(SOURCE_PATH.read_text(encoding="utf-8")))
     if not isinstance(transformed, dict):
         raise SystemExit("transformed schema root must be an object")
     transformed["$schema"] = SCHEMASTORE_META_SCHEMA

--- a/scripts/update_yamllint_schemastore_snapshot.py
+++ b/scripts/update_yamllint_schemastore_snapshot.py
@@ -44,7 +44,11 @@ def main() -> None:
     output = SNAPSHOT_PATH.resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
     data = fetch_json(DEFAULT_URL)
-    output.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    output.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
     print(f"Updated {output}")
 
 


### PR DESCRIPTION
Part of #297 (winget packaging, under #152).

## What this PR does

- Adds a `publish-winget` job to `.github/workflows/release.yml`. After
  `finalize-github-release` un-drafts the release, a first step downloads a
  pinned, SHA256-verified `wingetcreate` (v1.12.8.0) and a second step (the only
  one holding the PAT) runs `wingetcreate update owenlamont.ryl --version <ver>
  --submit` with the x64 + arm64 release-zip URLs (`|x64` / `|arm64` overrides),
  opening a winget-pkgs PR. The PAT is read from `WINGET_CREATE_GITHUB_TOKEN`
  (secret `WINGET_PAT` in the `automation` environment) so it never reaches
  argv, and the verify step has no token in scope so a tampered download can
  never execute against it.
- The job depends on `finalize-github-release` because that is where the assets
  become publicly downloadable (a draft release's assets are not), which
  `wingetcreate` needs to recompute each `InstallerSha256`.
- Documents `winget install owenlamont.ryl` in the README, the installation
  page, and the index quick-start, and notes the winget step in the `release`
  dev skill.

## Also folded in: Windows cp1252 fixes for the Python tooling

Dogfooding this work on Windows surfaced three classes of `cp1252`-default bug
in the dev tooling (Python defaults text I/O to the locale codepage on Windows,
not UTF-8). Each is now pinned to UTF-8:

1. **File I/O** — `read_text()`/`write_text()` without an encoding (crashed
   `codex-review-watch`'s quota preflight on UTF-8 Codex rollouts; would break
   the SchemaStore JSON scripts). Pass `encoding="utf-8"`, plus `newline="\n"`
   on the yamllint-snapshot writer so it stays LF on Windows.
2. **Subprocess decode** — `subprocess.run(text=True)` decodes captured output
   as cp1252, so non-ASCII (e.g. ryl's own `café`/`å` test names) leaves
   `stdout=None`. Pass `encoding="utf-8"` to each captured-output call.
3. **Stdout/stderr encode** — printing non-ASCII (the Codex verdict's emoji and
   P-badges, transcript text, `ensure_ascii=False` JSON) to a redirected stream
   crashes the encode. Reconfigure stdout/stderr to UTF-8 at each entry point.

## Not in this PR (manual, one-time)

The package must already exist in winget-pkgs before CI can `update` it. The
one-time `wingetcreate new` bootstrap (the three manifests plus a classic
`public_repo` PAT) is prepared separately and submitted to
`microsoft/winget-pkgs` out of band. The CI job only fires on the next tagged
release and requires both that bootstrap to have merged and the `WINGET_PAT`
secret to exist.

## Verification

- `ryl` (dogfood) + `zizmor` + `rumdl` + `ruff` + `cargo audit` + the rest of
  `prek` are green.
- No `${{ github.* }}` interpolation in the `run:` scripts (uses built-in
  `$env:GITHUB_*`); the token lives only in the submit step's `env:`; the job
  uses minimal `contents: read` with no checkout.
- The wingetcreate v1.12.8.0 SHA256 was verified against Microsoft's published
  `wingetcreate.exe.txt` checksum.
- The bootstrap manifests pass `winget validate` locally (schema 1.10.0,
  `zip` + `portable`, x64 + arm64, with a `Microsoft.VCRedist.2015+` dependency
  since `ryl.exe` links `VCRUNTIME140.dll`).
- The Windows fixes were verified by running the affected scripts on Windows
  (the `codex-review-watch` watcher now runs end-to-end).
