### PR TITLE
Add conda-forge install instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ uv tool install ryl                 # uv
 npm install -g @owenlamont/ryl      # npm
 pip install ryl                     # pip
 cargo install ryl                   # cargo
+pixi global install ryl             # conda-forge
 winget install owenlamont.ryl       # winget (Windows)
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,6 +21,13 @@ toolchain.
     npm install --global @owenlamont/ryl
     ```
 
+=== "conda"
+
+    ```bash
+    pixi global install ryl
+    # or: conda install -c conda-forge ryl
+    ```
+
 === "winget (Windows)"
 
     ```powershell

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,9 @@ pip install ryl
 # Or with npm
 npm install --global @owenlamont/ryl
 
+# Or with conda (conda-forge)
+pixi global install ryl
+
 # Or with winget (Windows)
 winget install owenlamont.ryl
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -29,6 +29,13 @@ toolchain.
     npm install --global @owenlamont/ryl
     ```
 
+=== "conda"
+
+    ```bash
+    pixi global install ryl
+    # or: conda install -c conda-forge ryl
+    ```
+
 === "winget (Windows)"
 
     ```powershell

--- a/prek.toml
+++ b/prek.toml
@@ -155,7 +155,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/owenlamont/ryl-pre-commit"
-rev = "v0.16.0"
+rev = "v0.17.0"
 hooks = [
   { id = "ryl", args = ["--fix"] },
   { id = "ryl-markdown", args = ["--fix"] }


### PR DESCRIPTION
Documents installing ryl from conda-forge across the README, the docs index, the installation-page tabs, and the regenerated `llms-full.txt`:

- `pixi global install ryl` (primary, since ryl is a standalone CLI)
- `conda install -c conda-forge ryl` (alternative, shown in the installation-page tab)

Mirrors how the winget instructions were added in #312, ahead of the package actually being live, so the docs are ready the moment it lands.

Refs #298. The conda-forge recipe is in review at conda-forge/staged-recipes#33725 (all CI green, awaiting a reviewer). Once that merges and ryl is published to the `conda-forge` channel, these commands work; until then they document the in-flight method (same as winget, which is awaiting microsoft/winget-pkgs#387703).

`docs/llms.txt` / `docs/llms-full.txt` were regenerated via `scripts/gen_llms_txt.py` (the `docs/llms.txt is current` prek guard passes).

Also folds in a minor dogfooding bump: the `ryl-pre-commit` hook in `prek.toml` from v0.16.0 to v0.17.0 so the repo lints with the latest release (`prek run --all-files` stays green; 0.17.0 added no rules over 0.16.0).
