### PR TITLE
Add LSP nice-to-have features (#317)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,13 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
   `cargo clippy --fix`, `cargo clippy`, `rumdl` for Markdown/docs, etc.), so skip
   invoking those individually. Re-run `prek run --all-files` until the auto-fixes
   stabilise and a full pass succeeds without modifying files before running coverage.
+- When editing **feature-gated** code (e.g. anything `#[cfg(feature = "lsp")]`), reproduce
+  CI's two clippy gates locally with `-D warnings` (prek's clippy does not, so it misses
+  these): `cargo clippy --all-targets -- -D warnings` and `cargo clippy --all-targets
+  --no-default-features -- -D warnings`. The `-D warnings` is what promotes a `dead_code`
+  warning to an error — e.g. an `lsp`-only helper with no caller once the feature is off
+  fails the minimal build, which a plain `cargo clippy` run shows only as a warning and
+  silently passes.
 - Whenever source files are edited ensure the full test suite passes (run
   `uv run .agents/skills/coverage/coverage-missing.py` to regenerate coverage; it
   reports uncovered ranges and confirms when coverage is complete). See the `coverage`
@@ -445,19 +452,39 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
 - Language server (`ryl server`, `src/lsp/`, behind the default-on `lsp` feature): a
   synchronous `lsp-server`+`lsp-types` adapter over the engine. `serve(&Connection)`
   runs the handshake + message loop; `run()` wires stdio and drops the connection
-  before `io_threads.join()` so the writer thread finishes. It reuses
-  `lint_str`/`lint_markdown_str` for diagnostics and `apply_safe_fixes`/`fix_markdown_str`
-  for `source.fixAll.ryl` + `textDocument/formatting` (whole-file/per-rule fixes only —
-  the engine has no per-occurrence fix; the fix-all action honours `context.only`). Config
-  is resolved per document via `discover_config` (full CLI precedence incl.
-  `YAMLLINT_CONFIG_FILE`); a rule-less/absent config lints nothing silently, a malformed
-  one lints nothing but is surfaced once via `window/showMessage` (no hard exit-2).
-  **Position encoding is the one
-  load-bearing new piece:** LSP columns are UTF-16 code units by default (NOT ryl's
-  1-based code-point columns); `encoding::problem_range` walks the line CR-aware via
-  `line_syntax` and the negotiated encoding (UTF-8/16/32), so multibyte/astral-plane
-  columns need real surrogate-pair fixtures (BMP `café`/`å` pass vacuously). `lsp-types`
-  0.97 forces a benign `bitflags` 1-vs-2 duplicate, allowlisted in `clippy.toml`. The
-  `lsp` feature must stay compilable out: CI runs `cargo clippy --no-default-features`
-  (the LSP tests are `#![cfg(feature = "lsp")]`). See `docs/editor-integration.md`.
+  before `io_threads.join()` so the writer thread finishes. `mod.rs` is the protocol
+  loop/dispatch; the connection-free logic lives in submodules so it is unit/property
+  testable: `encoding` (position math + `uri_to_path`/`path_to_uri`), `analysis`
+  (lint/fix → LSP), `actions` (code-action builders), `hover`, `rename`. Capabilities:
+  push diagnostics (`publishDiagnostics`); pull diagnostics (`textDocument/diagnostic` +
+  `workspace/diagnostic`, the latter over a per-entry-cancellable
+  `discover::gather_yaml_from_dir_cancellable` walk of every root, deduped, full report
+  each call, no result-id caching; it runs on a background worker thread — so the message
+  loop stays responsive — lints files in parallel via `rayon`, and is cancellable via
+  `$/cancelRequest`/shutdown through an `AtomicBool` the worker checks (the walk per
+  entry; only an in-progress single-file read is uninterrupted). A new pull
+  supersedes/cancels any in-flight one (bounding workers); `serve` joins outstanding
+  workers before returning); `source.fixAll.ryl` + per-rule
+  `source.fixAll.ryl.<rule>` (via `fix::SAFE_FIX_RULE_IDS`, YAML only) + `quickfix`
+  disable-rule inserts (`# ryl disable-line` / first-line `# ryl disable-file`; the
+  disable-line is suppressed for a diagnostic inside a block scalar, where a `#` would be
+  content not a directive, via `protected_scalar_lines`); `textDocument/formatting`; hover
+  (rule + message + docs link for a covered diagnostic); anchor/alias `rename` +
+  `prepareRename` (granit scanner tokens, document-scoped, YAML only); and INCREMENTAL
+  sync (ranged edits applied via `encoding::offset_at`). The engine has no per-occurrence
+  fix; code actions honour `context.only`. Config is resolved per document via
+  `discover_config` (full CLI precedence incl. `YAMLLINT_CONFIG_FILE`), layering the
+  client's `Settings` (`initializationOptions` / `workspace/didChangeConfiguration`:
+  `configPath`/`configData`/`enable`, CLI-equivalent precedence). Config-file changes
+  re-lint open docs via a dynamic `didChangeWatchedFiles` registration (push model;
+  `workspace/configuration` pull is deferred). A rule-less/absent config or `enable:false`
+  lints nothing silently; a malformed one lints nothing but is surfaced once via
+  `window/showMessage` (no hard exit-2). **Position encoding is the one load-bearing
+  piece:** LSP columns are UTF-16 code units by default (NOT ryl's 1-based code-point
+  columns); `encoding::problem_range`/`offset_at` walk the line CR-aware via `line_syntax`
+  and the negotiated encoding (UTF-8/16/32), so multibyte/astral-plane columns need real
+  surrogate-pair fixtures (BMP `café`/`å` pass vacuously). `lsp-types` 0.97 forces a benign
+  `bitflags` 1-vs-2 duplicate, allowlisted in `clippy.toml`. The `lsp` feature must stay
+  compilable out: CI runs `cargo clippy --no-default-features` (the LSP tests are
+  `#![cfg(feature = "lsp")]`). See `docs/editor-integration.md`.
 - Exit codes: `0` (ok/none), `1` (invalid YAML), `2` (usage error).

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -6,19 +6,27 @@ as you type. It is the same lint and fix engine as the CLI, exposed over the pro
 
 A ryl language server is a **linter** provider. It is meant to run *alongside* Red Hat's
 [`yaml-language-server`](https://github.com/redhat-developer/yaml-language-server) (schema
-validation, completion, hover), the way Ruff runs alongside Pylance: editors attach both
-and merge their diagnostics. ryl does not do schema validation, completion, or hover.
+validation, completion, schema hover), the way Ruff runs alongside Pylance: editors attach
+both and merge their diagnostics. ryl does not do schema validation or completion; its
+hover only explains ryl's own diagnostics.
 
 ## What it provides
 
 | Capability | LSP feature | Behaviour |
 | --- | --- | --- |
-| Diagnostics | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change |
+| Diagnostics (push) | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change |
+| Diagnostics (pull) | `textDocument/diagnostic`, `workspace/diagnostic` | On-demand diagnostics for one document or every `*.yaml`/`*.yml` under the workspace root |
 | Fix all | `source.fixAll.ryl` code action | Applies every safe fix to the document (the `--fix` set) |
+| Fix all of one rule | `source.fixAll.ryl.<rule>` code action | Applies just one safe-fixable rule's fixes (offered per rule with a diagnostic) |
+| Disable a rule | `quickfix` code action | Inserts `# ryl disable-line rule:<rule>` (per line) or a first-line `# ryl disable-file` (whole file) |
 | Formatting | `textDocument/formatting` | Same as "fix all": formatting *is* applying safe fixes |
+| Hover | `textDocument/hover` | The rule and message for a diagnostic under the cursor, with a link to the rules reference |
+| Rename | `textDocument/rename`, `textDocument/prepareRename` | Rename a YAML anchor/alias and every same-name use in its document |
+| Config watching | `workspace/didChangeWatchedFiles` | Re-lints open documents when a ryl/yamllint config file changes on disk |
 
 The fix-all action and formatting both apply ryl's whole-file safe fixes; ryl has no
-per-occurrence "fix just this one" action, because its fix engine operates per file. A
+per-occurrence "fix just this one" action, because its fix engine operates per file (the
+per-rule fix-all is the finest grain available, and applies only to YAML, not Markdown). A
 document that does not parse is never modified (the same guarantee as `ryl --fix`).
 
 ## Running it
@@ -37,6 +45,22 @@ file with no discovered config that enables at least one rule produces no diagno
 YAML and Markdown (embedded YAML) documents are both supported; the source kind is resolved
 from your `[files]` globs just like the CLI. An untitled (unsaved) buffer is linted as YAML,
 with config discovery anchored at the workspace root.
+
+## Configuring it from the editor
+
+The server reads optional settings from the client, either in `initializationOptions` at
+startup or via a `workspace/didChangeConfiguration` notification (a `ryl` section is
+accepted, so `{"ryl": {...}}` and a bare `{...}` both work). Changing them re-lints open
+documents:
+
+| Setting | Effect |
+| --- | --- |
+| `enable` (bool, default `true`) | `false` turns ryl off: no diagnostics, no actions |
+| `configPath` (string) | Use this config file instead of discovering one (like `ryl -c`) |
+| `configData` (string) | Inline YAML config text, highest precedence (like `ryl -d`) |
+
+These are the same precedence as the CLI: `configData` > `configPath` > the discovered
+project/user config.
 
 ## Neovim
 
@@ -71,9 +95,34 @@ format-on-save via `editor.defaultFormatter`.
 - **Position encoding** is negotiated at startup (UTF-8, UTF-16, or UTF-32); ryl supports
   all three and defaults to UTF-16 when the client states no preference, so columns line up
   correctly even for multi-byte and astral-plane characters.
-- Diagnostics for an open document are recomputed when it is opened or edited. Editing a
-  **config file** on disk (`.ryl.toml`, `pyproject.toml`, a yamllint config) does not yet
-  re-lint already-open documents; re-open or edit a document to pick up the new config.
+- **Config watching** re-lints open documents when a ryl/yamllint config file changes on
+  disk, for clients that support dynamic `didChangeWatchedFiles` registration. It watches
+  the standard config filenames anywhere in the workspace plus an explicit `configPath`;
+  files pulled in via a config's `extends:` are not individually watched, so re-open a
+  document to refresh after editing those. A client without the capability simply picks up
+  a config change on the next edit or re-open.
+- **Document sync is incremental** — the editor sends only the edited range — but ryl
+  re-lints the whole reconstructed document each time (it is fast enough that this is
+  invisible).
+- **Disable-rule actions** insert a `# ryl disable-line` comment on its own line. A
+  diagnostic *inside* a block scalar gets no disable-line action (a `#` there would be
+  scalar content, not a directive) — use the whole-file disable or a config-level ignore
+  for those.
+- **Rename** targets YAML anchors/aliases only (not Markdown-embedded YAML), and is scoped
+  to the document the anchor lives in: a name reused across a `---`/`...` boundary is a
+  distinct anchor and is left untouched.
+- **Workspace pull diagnostics** cover `*.yaml`/`*.yml` files under each workspace root
+  (git-ignored files excluded); Markdown and files matched only by custom `[files]` globs
+  are diagnosed when opened or pulled individually. The scan runs on a background thread
+  (so editing, hover, and other requests stay responsive while it works) and lints files
+  in parallel across CPU cores. A new pull supersedes any in-flight one, and a
+  `$/cancelRequest` (and shutdown) stops it promptly: the directory walk is cancelled
+  per entry and the lint pass is fast, so only an in-progress single-file read is not
+  interrupted.
+- **Disable-rule actions are offered for YAML documents only** — in Markdown the
+  diagnostic's line is a host-file line whose embedded YAML carries a prefix, so a raw
+  comment insert would be unreliable; Markdown documents get the fix-all action (which is
+  region-aware) instead.
 - A missing config or one that enables no rules produces **no diagnostics** — the editor
   stays quiet, matching ryl's "no rule is on unless you enable it" philosophy. A
   **malformed** config (which would make `ryl` exit non-zero on the CLI) is reported once

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1643,19 +1643,27 @@ as you type. It is the same lint and fix engine as the CLI, exposed over the pro
 
 A ryl language server is a **linter** provider. It is meant to run *alongside* Red Hat's
 [`yaml-language-server`](https://github.com/redhat-developer/yaml-language-server) (schema
-validation, completion, hover), the way Ruff runs alongside Pylance: editors attach both
-and merge their diagnostics. ryl does not do schema validation, completion, or hover.
+validation, completion, schema hover), the way Ruff runs alongside Pylance: editors attach
+both and merge their diagnostics. ryl does not do schema validation or completion; its
+hover only explains ryl's own diagnostics.
 
 ## What it provides
 
 | Capability | LSP feature | Behaviour |
 | --- | --- | --- |
-| Diagnostics | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change |
+| Diagnostics (push) | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change |
+| Diagnostics (pull) | `textDocument/diagnostic`, `workspace/diagnostic` | On-demand diagnostics for one document or every `*.yaml`/`*.yml` under the workspace root |
 | Fix all | `source.fixAll.ryl` code action | Applies every safe fix to the document (the `--fix` set) |
+| Fix all of one rule | `source.fixAll.ryl.<rule>` code action | Applies just one safe-fixable rule's fixes (offered per rule with a diagnostic) |
+| Disable a rule | `quickfix` code action | Inserts `# ryl disable-line rule:<rule>` (per line) or a first-line `# ryl disable-file` (whole file) |
 | Formatting | `textDocument/formatting` | Same as "fix all": formatting *is* applying safe fixes |
+| Hover | `textDocument/hover` | The rule and message for a diagnostic under the cursor, with a link to the rules reference |
+| Rename | `textDocument/rename`, `textDocument/prepareRename` | Rename a YAML anchor/alias and every same-name use in its document |
+| Config watching | `workspace/didChangeWatchedFiles` | Re-lints open documents when a ryl/yamllint config file changes on disk |
 
 The fix-all action and formatting both apply ryl's whole-file safe fixes; ryl has no
-per-occurrence "fix just this one" action, because its fix engine operates per file. A
+per-occurrence "fix just this one" action, because its fix engine operates per file (the
+per-rule fix-all is the finest grain available, and applies only to YAML, not Markdown). A
 document that does not parse is never modified (the same guarantee as `ryl --fix`).
 
 ## Running it
@@ -1674,6 +1682,22 @@ file with no discovered config that enables at least one rule produces no diagno
 YAML and Markdown (embedded YAML) documents are both supported; the source kind is resolved
 from your `[files]` globs just like the CLI. An untitled (unsaved) buffer is linted as YAML,
 with config discovery anchored at the workspace root.
+
+## Configuring it from the editor
+
+The server reads optional settings from the client, either in `initializationOptions` at
+startup or via a `workspace/didChangeConfiguration` notification (a `ryl` section is
+accepted, so `{"ryl": {...}}` and a bare `{...}` both work). Changing them re-lints open
+documents:
+
+| Setting | Effect |
+| --- | --- |
+| `enable` (bool, default `true`) | `false` turns ryl off: no diagnostics, no actions |
+| `configPath` (string) | Use this config file instead of discovering one (like `ryl -c`) |
+| `configData` (string) | Inline YAML config text, highest precedence (like `ryl -d`) |
+
+These are the same precedence as the CLI: `configData` > `configPath` > the discovered
+project/user config.
 
 ## Neovim
 
@@ -1708,9 +1732,34 @@ format-on-save via `editor.defaultFormatter`.
 - **Position encoding** is negotiated at startup (UTF-8, UTF-16, or UTF-32); ryl supports
   all three and defaults to UTF-16 when the client states no preference, so columns line up
   correctly even for multi-byte and astral-plane characters.
-- Diagnostics for an open document are recomputed when it is opened or edited. Editing a
-  **config file** on disk (`.ryl.toml`, `pyproject.toml`, a yamllint config) does not yet
-  re-lint already-open documents; re-open or edit a document to pick up the new config.
+- **Config watching** re-lints open documents when a ryl/yamllint config file changes on
+  disk, for clients that support dynamic `didChangeWatchedFiles` registration. It watches
+  the standard config filenames anywhere in the workspace plus an explicit `configPath`;
+  files pulled in via a config's `extends:` are not individually watched, so re-open a
+  document to refresh after editing those. A client without the capability simply picks up
+  a config change on the next edit or re-open.
+- **Document sync is incremental** — the editor sends only the edited range — but ryl
+  re-lints the whole reconstructed document each time (it is fast enough that this is
+  invisible).
+- **Disable-rule actions** insert a `# ryl disable-line` comment on its own line. A
+  diagnostic *inside* a block scalar gets no disable-line action (a `#` there would be
+  scalar content, not a directive) — use the whole-file disable or a config-level ignore
+  for those.
+- **Rename** targets YAML anchors/aliases only (not Markdown-embedded YAML), and is scoped
+  to the document the anchor lives in: a name reused across a `---`/`...` boundary is a
+  distinct anchor and is left untouched.
+- **Workspace pull diagnostics** cover `*.yaml`/`*.yml` files under each workspace root
+  (git-ignored files excluded); Markdown and files matched only by custom `[files]` globs
+  are diagnosed when opened or pulled individually. The scan runs on a background thread
+  (so editing, hover, and other requests stay responsive while it works) and lints files
+  in parallel across CPU cores. A new pull supersedes any in-flight one, and a
+  `$/cancelRequest` (and shutdown) stops it promptly: the directory walk is cancelled
+  per entry and the lint pass is fast, so only an in-progress single-file read is not
+  interrupted.
+- **Disable-rule actions are offered for YAML documents only** — in Markdown the
+  diagnostic's line is a host-file line whose embedded YAML carries a prefix, so a raw
+  comment insert would be unreliable; Markdown documents get the fix-all action (which is
+  region-aware) instead.
 - A missing config or one that enables no rules produces **no diagnostics** — the editor
   stays quiet, matching ryl's "no rule is on unless you enable it" philosophy. A
   **malformed** config (which would make `ryl` exit non-zero on the CLI) is reported once

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1,7 +1,11 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+// Only the LSP's workspace pull needs the cancellable walk; keep it (and its atomics
+// import) out of a `--no-default-features` build so it is not flagged as dead code.
+#[cfg(feature = "lsp")]
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use ignore::WalkBuilder;
+use ignore::{Walk, WalkBuilder};
 
 pub fn is_yaml_path(path: &Path) -> bool {
     path.extension().and_then(OsStr::to_str).is_some_and(|ext| {
@@ -9,23 +13,49 @@ pub fn is_yaml_path(path: &Path) -> bool {
     })
 }
 
-#[must_use]
-pub fn gather_yaml_from_dir(dir: &Path) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    let walker = WalkBuilder::new(dir)
+/// The shared directory walker: honours git ignore/exclude, includes hidden files, and
+/// does not follow symlinks. Used by both the plain and cancellable YAML gatherers so the
+/// traversal rules cannot drift between them.
+fn yaml_walker(dir: &Path) -> Walk {
+    WalkBuilder::new(dir)
         .hidden(false)
         .ignore(true)
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
         .follow_links(false)
-        .build();
+        .build()
+}
 
-    for entry in walker.flatten() {
+#[must_use]
+pub fn gather_yaml_from_dir(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for entry in yaml_walker(dir).flatten() {
         let p = entry.path();
         if p.is_file() && is_yaml_path(p) {
             files.push(p.to_path_buf());
         }
     }
     files
+}
+
+/// Like [`gather_yaml_from_dir`] but abandons the walk and returns `None` as soon as
+/// `cancel` is set (checked once per entry), so a cancelled `workspace/diagnostic` stops
+/// enumerating a (possibly huge or slow) tree instead of finishing the whole walk.
+#[cfg(feature = "lsp")]
+pub(crate) fn gather_yaml_from_dir_cancellable(
+    dir: &Path,
+    cancel: &AtomicBool,
+) -> Option<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for entry in yaml_walker(dir).flatten() {
+        if cancel.load(Ordering::Relaxed) {
+            return None;
+        }
+        let p = entry.path();
+        if p.is_file() && is_yaml_path(p) {
+            files.push(p.to_path_buf());
+        }
+    }
+    Some(files)
 }

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -93,6 +93,25 @@ const EMPTY_LINES_FIX: RuleFix = RuleFix {
     safety: FixSafety::Safe,
 };
 
+/// Every rule with a safe `--fix`, in application order. Referencing each rule's `ID`
+/// keeps the spellings in sync with the `ctx.apply` sequence in
+/// [`apply_safe_fixes_filtered`]; extend both together when adding a safe fixer. The LSP
+/// drives per-rule "Fix all `<rule>`" actions off this list (skipping every other id).
+pub const SAFE_FIX_RULE_IDS: [&str; 12] = [
+    new_lines::ID,
+    comments::ID,
+    comments_indentation::ID,
+    commas::ID,
+    braces::ID,
+    brackets::ID,
+    new_line_at_end_of_file::ID,
+    quoted_strings::ID,
+    trailing_spaces::ID,
+    document_start::ID,
+    document_end::ID,
+    empty_lines::ID,
+];
+
 #[derive(Debug, Clone, Default)]
 pub struct FixStats {
     pub changed_files: usize,

--- a/src/lsp/actions.rs
+++ b/src/lsp/actions.rs
@@ -1,0 +1,298 @@
+//! Builds the code actions `ryl server` offers for a document: the whole-file
+//! `source.fixAll.ryl`, a per-rule `source.fixAll.ryl.<rule>` for each safe-fixable
+//! rule with a diagnostic, and `quickfix` actions that insert a `# ryl disable-line`
+//! (per rule/line) or a first-line `# ryl disable-file`. All edits are pure functions of
+//! the document text and the request context; the actual fixing reuses
+//! [`analysis::fix_all_edit`] / [`analysis::fix_rule_edit`], and the disable inserts
+//! mirror the directive grammar in [`crate::directives`].
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::Path;
+
+use lsp_types::{
+    CodeAction, CodeActionContext, CodeActionKind, CodeActionOrCommand,
+    CodeActionResponse, Diagnostic, DocumentChanges, NumberOrString, OneOf,
+    OptionalVersionedTextDocumentIdentifier, Position, Range, TextDocumentEdit,
+    TextEdit, Uri, WorkspaceEdit,
+};
+
+use crate::config::{SourceKind, YamlLintConfig};
+use crate::fix::SAFE_FIX_RULE_IDS;
+use crate::lsp::analysis::{fix_all_edit, fix_rule_edit};
+use crate::lsp::encoding::PositionEncoding;
+use crate::rules::ALL_RULE_IDS;
+use crate::rules::support::line_syntax::{
+    buffer_newline, line_contents, protected_scalar_lines,
+};
+
+/// The whole-file safe-fix code-action kind, also usable for `editor.codeActionsOnSave`.
+const FIX_ALL_KIND: &str = "source.fixAll.ryl";
+
+/// Everything `build` needs about the document under action, so each call site stays
+/// short. Borrowed from the server's open-document state and resolved config.
+pub struct Input<'a> {
+    pub uri: &'a Uri,
+    pub text: &'a str,
+    pub version: i32,
+    pub path: &'a Path,
+    pub cfg: &'a YamlLintConfig,
+    pub base_dir: &'a Path,
+    pub kind: SourceKind,
+    pub enc: PositionEncoding,
+    pub supports_document_changes: bool,
+}
+
+/// Build every code action that applies to `input`, filtered by the request's
+/// `context.only`. Returns `None` when nothing applies (no fix and no disableable
+/// diagnostic), so the server replies with a null result rather than an empty list.
+#[must_use]
+pub fn build(input: &Input, context: &CodeActionContext) -> Option<CodeActionResponse> {
+    let mut actions = Vec::new();
+
+    if admits(context.only.as_deref(), FIX_ALL_KIND)
+        && let Some(edit) = fix_all_edit(
+            input.text,
+            input.path,
+            input.cfg,
+            input.base_dir,
+            input.kind,
+            input.enc,
+        )
+    {
+        actions.push(entry(
+            "Fix all ryl problems".to_string(),
+            FIX_ALL_KIND,
+            input,
+            edit,
+        ));
+    }
+
+    for rule in fixable_rules_present(&context.diagnostics) {
+        let kind = format!("{FIX_ALL_KIND}.{rule}");
+        if admits(context.only.as_deref(), &kind)
+            && let Some(edit) = fix_rule_edit(
+                input.text,
+                input.path,
+                input.cfg,
+                input.base_dir,
+                input.kind,
+                input.enc,
+                rule,
+            )
+        {
+            actions.push(entry(
+                format!("Fix all {rule} problems"),
+                &kind,
+                input,
+                edit,
+            ));
+        }
+    }
+
+    // Disable actions insert `#` directives by document line. That is only sound for a
+    // plain YAML document: in Markdown the diagnostic's line is a host-file line whose
+    // embedded YAML carries a prefix (fence indent, `> `, …), so a raw insert would land
+    // in the wrong place or as fenced content. Markdown documents get fix-all only.
+    if matches!(input.kind, SourceKind::Yaml)
+        && admits(context.only.as_deref(), CodeActionKind::QUICKFIX.as_str())
+    {
+        // A line spanned by a *multi-line* scalar (block `|`/`>` or a quoted/plain scalar
+        // continued across lines) is scalar content, not comment context: a disable-line
+        // insert there would land inside the still-open scalar and corrupt the value
+        // instead of acting as a directive. Skip those lines (the set is 1-based granit
+        // line numbers). When the document does NOT parse (e.g. an undefined alias) we
+        // cannot tell which lines are scalar content, so no disable-line is offered at all;
+        // disable-file (a line-0 prepend) is always safe.
+        let scalar_lines = protected_scalar_lines(input.text, |_, span| {
+            span.start.line() != span.end.line()
+        });
+        if let Some(scalar_lines) = scalar_lines {
+            for (rule, line) in disable_targets(&context.diagnostics) {
+                if let Some(action) =
+                    disable_line_action(input, &rule, line, &scalar_lines)
+                {
+                    actions.push(action);
+                }
+            }
+        }
+        // A whole-file disable is only useful when ryl itself flagged the file.
+        if has_ryl_diagnostic(&context.diagnostics) {
+            actions.push(disable_file_action(input));
+        }
+    }
+
+    (!actions.is_empty()).then_some(actions)
+}
+
+/// Whether the client's `context.only` filter admits an action of `kind`: no filter
+/// means yes, otherwise a requested kind must equal `kind` or be an ancestor of it (so a
+/// `source` / `source.fixAll` request matches `source.fixAll.ryl`, the way
+/// `editor.codeActionsOnSave` issues them).
+fn admits(only: Option<&[CodeActionKind]>, kind: &str) -> bool {
+    match only {
+        None => true,
+        Some(only) => only.iter().any(|requested| {
+            let requested = requested.as_str();
+            kind == requested || kind.starts_with(&format!("{requested}."))
+        }),
+    }
+}
+
+/// The ryl rule id a diagnostic carries in its `code`, if any. Only ryl's own
+/// diagnostics are considered (a document may also carry diagnostics from a coexisting
+/// server such as yaml-language-server), and only a known rule id is accepted — so a
+/// foreign or crafted code (e.g. one containing a newline) can never form a directive.
+fn diagnostic_rule(diagnostic: &Diagnostic) -> Option<&'static str> {
+    if diagnostic.source.as_deref() != Some("ryl") {
+        return None;
+    }
+    let code = match &diagnostic.code {
+        Some(NumberOrString::String(code)) => code.as_str(),
+        _ => return None,
+    };
+    ALL_RULE_IDS.into_iter().find(|id| *id == code)
+}
+
+/// Whether the document has at least one ryl-sourced diagnostic (so the whole-file
+/// disable is offered for ryl's findings, not a coexisting server's).
+fn has_ryl_diagnostic(diagnostics: &[Diagnostic]) -> bool {
+    diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.source.as_deref() == Some("ryl"))
+}
+
+/// Safe-fixable rules with at least one diagnostic, in fix-application order (stable and
+/// independent of diagnostic order) so the offered actions are deterministic.
+fn fixable_rules_present(diagnostics: &[Diagnostic]) -> Vec<&'static str> {
+    let present: HashSet<&str> =
+        diagnostics.iter().filter_map(diagnostic_rule).collect();
+    SAFE_FIX_RULE_IDS
+        .iter()
+        .copied()
+        .filter(|rule| present.contains(rule))
+        .collect()
+}
+
+/// Distinct `(rule, 0-based line)` pairs to offer a `disable-line` for, in diagnostic
+/// order.
+fn disable_targets(diagnostics: &[Diagnostic]) -> Vec<(String, u32)> {
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+    for diagnostic in diagnostics {
+        if let Some(rule) = diagnostic_rule(diagnostic) {
+            let line = diagnostic.range.start.line;
+            if seen.insert((rule.to_string(), line)) {
+                targets.push((rule.to_string(), line));
+            }
+        }
+    }
+    targets
+}
+
+/// A `disable-line` quickfix: insert `# ryl disable-line rule:<rule>` on its own line
+/// above `line`, indented like `line` so the comment does not itself trip
+/// `comments-indentation`. A standalone `disable-line` applies to the *next* line (see
+/// [`crate::directives`]), which is the diagnostic's line after the insertion shifts it
+/// down. `None` when `line` is past the document or inside a multi-line scalar (where a
+/// `#` insert would be scalar content, not a directive).
+fn disable_line_action(
+    input: &Input,
+    rule: &str,
+    line: u32,
+    scalar_lines: &HashSet<usize>,
+) -> Option<CodeActionOrCommand> {
+    let index = usize::try_from(line).unwrap_or(usize::MAX);
+    // `protected_scalar_lines` is 1-based; the 0-based LSP `line` maps to `index + 1`.
+    if scalar_lines.contains(&index.saturating_add(1)) {
+        return None;
+    }
+    let lines = line_contents(input.text);
+    let target = lines.get(index)?;
+    let indent: String = target
+        .chars()
+        .take_while(|ch| *ch == ' ' || *ch == '\t')
+        .collect();
+    let newline = buffer_newline(input.text);
+    let insert = format!("{indent}# ryl disable-line rule:{rule}{newline}");
+    let edit = TextEdit::new(at_line_start(line), insert);
+    Some(entry(
+        format!("Disable {rule} for this line"),
+        CodeActionKind::QUICKFIX.as_str(),
+        input,
+        edit,
+    ))
+}
+
+/// A `disable-file` quickfix: prepend a first-line `# ryl disable-file`, which skips the
+/// whole file (all rules) for linting and `--fix` (see [`crate::directives`]).
+fn disable_file_action(input: &Input) -> CodeActionOrCommand {
+    let insert = format!("# ryl disable-file{}", buffer_newline(input.text));
+    let edit = TextEdit::new(at_line_start(0), insert);
+    entry(
+        "Disable ryl for this file".to_string(),
+        CodeActionKind::QUICKFIX.as_str(),
+        input,
+        edit,
+    )
+}
+
+/// A zero-width range at the start of `line`, for an insert-a-line edit.
+fn at_line_start(line: u32) -> Range {
+    Range {
+        start: Position::new(line, 0),
+        end: Position::new(line, 0),
+    }
+}
+
+/// Wrap a single whole-or-partial `TextEdit` as a titled code action of `kind`.
+fn entry(
+    title: String,
+    kind: &str,
+    input: &Input,
+    edit: TextEdit,
+) -> CodeActionOrCommand {
+    CodeActionOrCommand::CodeAction(CodeAction {
+        title,
+        kind: Some(CodeActionKind::from(kind.to_string())),
+        edit: Some(workspace_edit(
+            input.uri.clone(),
+            input.version,
+            vec![edit],
+            input.supports_document_changes,
+        )),
+        ..Default::default()
+    })
+}
+
+/// Build a single-file workspace edit from one or more `edits`. A client advertising
+/// `documentChanges` support gets a versioned `TextDocumentEdit` (so it can discard the
+/// edit if the buffer moved past `version` before the edit is applied); otherwise it gets
+/// the unversioned `changes` map. Shared by the code actions here and by rename. `Uri`
+/// has benign interior mutability (a fluent-uri parse cache) that never affects its
+/// hash/equality, hence the lint allow.
+#[allow(clippy::mutable_key_type)]
+pub(crate) fn workspace_edit(
+    uri: Uri,
+    version: i32,
+    edits: Vec<TextEdit>,
+    supports_document_changes: bool,
+) -> WorkspaceEdit {
+    if supports_document_changes {
+        WorkspaceEdit {
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri,
+                    version: Some(version),
+                },
+                edits: edits.into_iter().map(OneOf::Left).collect(),
+            }])),
+            ..Default::default()
+        }
+    } else {
+        WorkspaceEdit {
+            changes: Some(HashMap::from([(uri, edits)])),
+            ..Default::default()
+        }
+    }
+}

--- a/src/lsp/analysis.rs
+++ b/src/lsp/analysis.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, TextEdit};
 
 use crate::config::{SourceKind, YamlLintConfig};
-use crate::fix::{apply_safe_fixes, fix_markdown_str};
+use crate::fix::{
+    SAFE_FIX_RULE_IDS, apply_safe_fixes, apply_safe_fixes_filtered, fix_markdown_str,
+};
 use crate::lint::{LintProblem, Severity, lint_str};
 use crate::lsp::encoding::{PositionEncoding, full_range, problem_range};
 use crate::markdown_embed::lint_markdown_str;
@@ -77,5 +79,31 @@ pub fn fix_all_edit(
         SourceKind::Markdown => fix_markdown_str(text, path, cfg, base_dir)?,
         SourceKind::Yaml => apply_safe_fixes(text, cfg, path, base_dir),
     };
+    (fixed != text).then(|| TextEdit::new(full_range(text, enc), fixed))
+}
+
+/// The whole-document edit applying only `rule`'s safe fix — every other safe fixer is
+/// skipped — or `None` when nothing changes, `rule` has no safe fix, or `kind` is not
+/// plain YAML (the markdown fix path has no per-rule variant). Backs the per-rule
+/// `source.fixAll.ryl.<rule>` code action.
+#[must_use]
+pub fn fix_rule_edit(
+    text: &str,
+    path: &Path,
+    cfg: &YamlLintConfig,
+    base_dir: &Path,
+    kind: SourceKind,
+    enc: PositionEncoding,
+    rule: &str,
+) -> Option<TextEdit> {
+    if matches!(kind, SourceKind::Markdown) || !SAFE_FIX_RULE_IDS.contains(&rule) {
+        return None;
+    }
+    let skip: Vec<&str> = SAFE_FIX_RULE_IDS
+        .iter()
+        .copied()
+        .filter(|id| *id != rule)
+        .collect();
+    let fixed = apply_safe_fixes_filtered(text, cfg, path, base_dir, &skip);
     (fixed != text).then(|| TextEdit::new(full_range(text, enc), fixed))
 }

--- a/src/lsp/encoding.rs
+++ b/src/lsp/encoding.rs
@@ -8,11 +8,12 @@
 //! is CR-aware via [`line_contents`] (the same primitive the rules use), never a
 //! fresh `\n`-only scanner.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
-use lsp_types::{Position, PositionEncodingKind, Range};
+use lsp_types::{Position, PositionEncodingKind, Range, Uri};
 
-use crate::rules::support::line_syntax::line_contents;
+use crate::rules::support::line_syntax::{line_contents, split_lines_preserve_endings};
 
 /// The position encoding negotiated at `initialize`. ryl supports all three; the
 /// LSP-mandated default when a client advertises none is UTF-16.
@@ -68,6 +69,23 @@ fn prefix_units(line: &str, char_count: usize, enc: PositionEncoding) -> u32 {
     u32::try_from(units).unwrap_or(u32::MAX)
 }
 
+/// The LSP [`Position`] of a 1-based ryl `(line, column)` (column in code points): the
+/// position *before* `column` (its 0-based code-unit offset under `enc`). Shared by
+/// [`problem_range`] and by rename, which needs arbitrary start/end positions rather
+/// than a one-char span.
+#[must_use]
+pub fn position_at(
+    lines: &[&str],
+    line_1based: usize,
+    column_1based: usize,
+    enc: PositionEncoding,
+) -> Position {
+    let line_idx = line_1based.saturating_sub(1);
+    let line = lines.get(line_idx).copied().unwrap_or("");
+    let character = prefix_units(line, column_1based.saturating_sub(1), enc);
+    Position::new(u32::try_from(line_idx).unwrap_or(u32::MAX), character)
+}
+
 /// Convert a 1-based ryl `(line, column)` (column in code points) to an LSP range
 /// spanning the single character at that point. ryl reports points, not spans, so
 /// the range is one character wide (clamped to the line; zero-width at or past
@@ -79,15 +97,26 @@ pub fn problem_range(
     column_1based: usize,
     enc: PositionEncoding,
 ) -> Range {
-    let line_idx = line_1based.saturating_sub(1);
-    let line = lines.get(line_idx).copied().unwrap_or("");
-    let start = prefix_units(line, column_1based.saturating_sub(1), enc);
-    let end = prefix_units(line, column_1based, enc);
-    let line_u32 = u32::try_from(line_idx).unwrap_or(u32::MAX);
     Range {
-        start: Position::new(line_u32, start),
-        end: Position::new(line_u32, end),
+        start: position_at(lines, line_1based, column_1based, enc),
+        end: position_at(lines, line_1based, column_1based.saturating_add(1), enc),
     }
+}
+
+/// Whether `position` lies within `range` (start-inclusive, end-exclusive — the standard
+/// `[start, end)`), with one carve-out: a zero-width range (`start == end`, ryl's
+/// end-of-line diagnostics) matches at that point. End-exclusivity keeps a cursor one
+/// column *past* a token from being treated as on it. Used for hover and rename
+/// hit-testing.
+#[must_use]
+pub fn range_contains(range: Range, position: Position) -> bool {
+    let after_start = position.line > range.start.line
+        || (position.line == range.start.line
+            && position.character >= range.start.character);
+    let before_end = position.line < range.end.line
+        || (position.line == range.end.line
+            && position.character < range.end.character);
+    after_start && (before_end || range.start == range.end && position == range.start)
 }
 
 /// The range covering the whole `text`, used for a full-document replacement edit.
@@ -111,6 +140,47 @@ pub fn full_range(text: &str, enc: PositionEncoding) -> Range {
         start: Position::new(0, 0),
         end,
     }
+}
+
+/// Byte offset in `text` of an LSP [`Position`] under `enc` — the inverse of the
+/// forward `(line, column)` conversion, used to apply incremental edits. CR-aware via
+/// [`split_lines_preserve_endings`] (the same primitive the forward direction uses), so
+/// the two cannot disagree on where a line begins. Clamps a line past the end to
+/// `text.len()` and a `character` past the line's content to the line's content end (the
+/// LSP "past line length defaults to line length" rule); a `character` landing inside a
+/// multi-unit char snaps to that char's start, so a malformed mid-surrogate position is
+/// handled rather than panicking.
+#[must_use]
+pub fn offset_at(text: &str, position: Position, enc: PositionEncoding) -> usize {
+    let mut offset = 0usize;
+    for (line_idx, content, ending) in split_lines_preserve_endings(text) {
+        if u32::try_from(line_idx).unwrap_or(u32::MAX) == position.line {
+            return offset + column_byte(content, position.character, enc);
+        }
+        offset += content.len() + ending.len();
+    }
+    // `position.line` is at or past the phantom final line (a trailing break leaves no
+    // entry for it): clamp to the end of the text.
+    text.len()
+}
+
+/// Byte offset within `content` (a single break-free line) of the LSP `character`
+/// (code units under `enc`). Stops before a char whose units would overshoot, so a
+/// `character` past the content clamps to its end and a mid-char position snaps to the
+/// char start.
+fn column_byte(content: &str, character: u32, enc: PositionEncoding) -> usize {
+    let mut units = 0u32;
+    let mut bytes = 0usize;
+    for ch in content.chars() {
+        let next =
+            units.saturating_add(u32::try_from(enc.units(ch)).unwrap_or(u32::MAX));
+        if next > character {
+            break;
+        }
+        units = next;
+        bytes += ch.len_utf8();
+    }
+    bytes
 }
 
 /// Best-effort conversion of a `file:` URI to a filesystem path, or `None` for a
@@ -146,6 +216,45 @@ pub fn uri_to_path(uri: &str) -> Option<PathBuf> {
         .filter(|tail| is_drive_prefixed(tail))
         .map_or(decoded.as_str(), |tail| tail);
     Some(PathBuf::from(trimmed))
+}
+
+/// Build a `file:` URI for `path` (the inverse of [`uri_to_path`]), percent-encoding any
+/// byte outside the URI-safe set so it round-trips back through `uri_to_path`. Used to
+/// label workspace pull-diagnostic reports; a backslash is normalised to `/` and a drive
+/// path (`C:/…`) gets the `file:///C:/…` leading slash. A non-UTF-8 path is rendered
+/// lossily (such paths cannot round-trip, but ryl targets UTF-8 paths).
+///
+/// # Panics
+/// Never in practice: the result is `file://` followed by URI-safe ASCII and `%XX`
+/// escapes, which always parses as a valid `file:` URI.
+#[must_use]
+pub fn path_to_uri(path: &Path) -> Uri {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let slashed = path.to_string_lossy().replace('\\', "/");
+    let mut encoded = String::from("file://");
+    if !slashed.starts_with('/') {
+        encoded.push('/');
+    }
+    for byte in slashed.bytes() {
+        match byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'.'
+            | b'_'
+            | b'~'
+            | b'/'
+            | b':' => encoded.push(byte as char),
+            _ => {
+                encoded.push('%');
+                encoded.push(HEX[(byte >> 4) as usize] as char);
+                encoded.push(HEX[(byte & 0x0f) as usize] as char);
+            }
+        }
+    }
+    // The encoded form is `file://` + URI-safe ASCII + `%XX` escapes, always a valid URI.
+    Uri::from_str(&encoded).expect("a percent-encoded file path is a valid file URI")
 }
 
 /// Whether `s` starts with a `X:` Windows drive prefix.

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -1,0 +1,53 @@
+//! Hover support for `ryl server`. Hovering a position covered by a ryl diagnostic
+//! shows that rule's id, the diagnostic message, and a link to the rules reference.
+//! ryl reports points, not rich descriptions, and `docs/rules.md` has no per-rule
+//! anchors, so the value-add over the inline diagnostic is the click-through link; schema
+//! hover stays Red Hat's `yaml-language-server`'s job. This is a pure function of the
+//! already-computed diagnostics, so it carries no protocol state.
+
+use lsp_types::{
+    Diagnostic, Hover, HoverContents, MarkupContent, MarkupKind, NumberOrString,
+    Position,
+};
+
+use crate::lsp::encoding::range_contains;
+
+/// The rules reference page; there are no per-rule anchors to deep-link to.
+const RULES_URL: &str = "https://ryl-docs.pages.dev/rules/";
+
+/// Build a hover for `position` from the document's `diagnostics`, or `None` when no
+/// diagnostic covers it. Multiple overlapping diagnostics are all listed; the hover
+/// range is the first match so the editor can highlight the offending token.
+#[must_use]
+pub fn hover(diagnostics: &[Diagnostic], position: Position) -> Option<Hover> {
+    let mut matching = diagnostics
+        .iter()
+        .filter(|d| range_contains(d.range, position));
+    let first = matching.next()?;
+    let mut body = section(first);
+    for diagnostic in matching {
+        body.push_str("\n\n");
+        body.push_str(&section(diagnostic));
+    }
+    body.push_str("\n\n[Rule reference](");
+    body.push_str(RULES_URL);
+    body.push(')');
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: body,
+        }),
+        range: Some(first.range),
+    })
+}
+
+/// One diagnostic rendered as a Markdown heading (`ryl: <rule>`, or just `ryl` for a
+/// rule-less syntax diagnostic) followed by its message.
+fn section(diagnostic: &Diagnostic) -> String {
+    match &diagnostic.code {
+        Some(NumberOrString::String(rule)) => {
+            format!("**ryl: {rule}**\n\n{}", diagnostic.message)
+        }
+        _ => format!("**ryl**\n\n{}", diagnostic.message),
+    }
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,9 +1,10 @@
 //! The `ryl server` language server: a thin synchronous protocol adapter over
 //! ryl's existing lint and fix engine, built on `lsp-server` + `lsp-types` (the
-//! rust-analyzer / Ruff stack). It provides diagnostics, a `source.fixAll.ryl`
-//! code action, and `textDocument/formatting` (= apply safe fixes). Schema
-//! validation, completion, and hover are intentionally left to Red Hat's
-//! `yaml-language-server`, which ryl coexists with.
+//! rust-analyzer / Ruff stack). It provides diagnostics (push + pull), code actions
+//! (`source.fixAll.ryl`, per-rule fix-all, and disable-rule inserts),
+//! `textDocument/formatting` (= apply safe fixes), hover, anchor/alias rename, and
+//! config-file watching. Schema validation, completion, and schema hover are
+//! intentionally left to Red Hat's `yaml-language-server`, which ryl coexists with.
 //!
 //! Handling is graceful throughout: a malformed `initialize` (client-controlled)
 //! ends the session cleanly, unknown requests get a `MethodNotFound` response, and
@@ -11,33 +12,47 @@
 //! shutdown/exit handshake. The only `expect` is on serialising ryl's own
 //! capabilities, which cannot fail.
 
+pub mod actions;
 pub mod analysis;
 pub mod encoding;
+pub mod hover;
+pub mod rename;
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+
+use rayon::prelude::*;
 
 use lsp_server::{
     Connection, ErrorCode, Message, Notification, Request, RequestId, Response,
 };
 use lsp_types::{
-    CodeAction, CodeActionContext, CodeActionKind, CodeActionOrCommand,
-    CodeActionParams, CodeActionProviderCapability, CodeActionResponse,
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DocumentChanges, DocumentFormattingParams, InitializeParams, InitializeResult,
-    MessageType, OneOf, OptionalVersionedTextDocumentIdentifier,
-    PublishDiagnosticsParams, ServerCapabilities, ServerInfo, ShowMessageParams,
-    TextDocumentEdit, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Uri,
-    WorkspaceEdit,
+    CancelParams, CodeActionParams, CodeActionProviderCapability, CodeActionResponse,
+    Diagnostic, DiagnosticOptions, DiagnosticServerCapabilities, DiagnosticSeverity,
+    DidChangeConfigurationParams, DidChangeTextDocumentParams,
+    DidChangeWatchedFilesRegistrationOptions, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentFormattingParams, FileSystemWatcher, FullDocumentDiagnosticReport,
+    GlobPattern, Hover, HoverParams, HoverProviderCapability, InitializeParams,
+    InitializeResult, MessageType, NumberOrString, OneOf, Position,
+    PrepareRenameResponse, PublishDiagnosticsParams, Range, Registration,
+    RegistrationParams, RelatedFullDocumentDiagnosticReport, RenameOptions,
+    RenameParams, ServerCapabilities, ServerInfo, ShowMessageParams,
+    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextEdit, Uri, WorkDoneProgressOptions, WorkspaceDiagnosticReport,
+    WorkspaceDocumentDiagnosticReport, WorkspaceEdit,
+    WorkspaceFullDocumentDiagnosticReport,
 };
 
 use crate::config::{ConfigContext, Overrides, SourceKind, discover_config};
-use crate::lsp::encoding::{PositionEncoding, negotiate, uri_to_path};
-
-/// The code-action kind ryl offers: a whole-file safe-fix, usable for
-/// `editor.codeActionsOnSave` (a `source.fixAll` request subsumes it).
-const FIX_ALL_KIND: &str = "source.fixAll.ryl";
+use crate::discover::gather_yaml_from_dir_cancellable;
+use crate::lsp::encoding::{
+    PositionEncoding, negotiate, offset_at, path_to_uri, uri_to_path,
+};
 
 /// How a session ended, mapped to a process exit code by [`run`]. Per the LSP
 /// spec an `exit` notification *without* a prior `shutdown` is abnormal (exit 1);
@@ -127,23 +142,20 @@ pub fn serve(connection: &Connection) -> SessionOutcome {
         serde_json::to_value(result).expect("server capabilities always serialize");
     let _ = connection.initialize_finish(id, result);
 
+    let settings = Settings::from_options(params.initialization_options.as_ref());
+
+    // `initialize_finish` above blocks until the client's `initialized` notification
+    // arrives, so the session is fully initialized here — registering a capability now
+    // respects the LSP ordering (it is not sent before `initialized`). Register a
+    // config-file watcher only when the client supports dynamic registration for it;
+    // older clients simply get no auto-reload (they can still re-open files).
+    if client_supports_watch_registration(&params) {
+        register_config_watchers(connection, settings.config_file.as_deref());
+    }
+
     let server = Server {
         encoding,
-        // Anchors config discovery for untitled (non-file) buffers. Prefer the
-        // first workspace folder; fall back to the LSP-3.17-deprecated `root_uri`
-        // for older clients that send only it (hence the scoped allow).
-        root: params
-            .workspace_folders
-            .as_ref()
-            .and_then(|folders| folders.first())
-            .and_then(|folder| uri_to_path(folder.uri.as_str()))
-            .or_else(|| {
-                #[allow(deprecated)]
-                params
-                    .root_uri
-                    .as_ref()
-                    .and_then(|uri| uri_to_path(uri.as_str()))
-            }),
+        roots: workspace_roots(&params),
         supports_document_changes: params
             .capabilities
             .workspace
@@ -151,8 +163,10 @@ pub fn serve(connection: &Connection) -> SessionOutcome {
             .and_then(|workspace| workspace.workspace_edit.as_ref())
             .and_then(|workspace_edit| workspace_edit.document_changes)
             .unwrap_or(false),
+        settings,
         documents: HashMap::new(),
         reported_errors: HashSet::new(),
+        workers: Vec::new(),
     };
     server.message_loop(connection)
 }
@@ -160,39 +174,217 @@ pub fn serve(connection: &Connection) -> SessionOutcome {
 fn server_capabilities(encoding: PositionEncoding) -> ServerCapabilities {
     ServerCapabilities {
         position_encoding: Some(encoding.kind()),
+        // INCREMENTAL: a change carries only the edited range (saves transfer); ryl
+        // re-lints the whole reconstructed document regardless.
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
-            TextDocumentSyncKind::FULL,
+            TextDocumentSyncKind::INCREMENTAL,
         )),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         document_formatting_provider: Some(OneOf::Left(true)),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        })),
+        diagnostic_provider: Some(DiagnosticServerCapabilities::Options(
+            DiagnosticOptions {
+                identifier: Some("ryl".to_string()),
+                // Each YAML file is linted independently — no cross-file diagnostics.
+                inter_file_dependencies: false,
+                workspace_diagnostics: true,
+                ..Default::default()
+            },
+        )),
         ..Default::default()
     }
 }
 
-/// An open document: its latest full text (FULL sync sends the whole text on
-/// every change) and version, the latter stamped into fix-all edits so a client
-/// can drop a stale edit if the buffer moved on before it was applied.
+/// Whether the client can accept a dynamic `didChangeWatchedFiles` registration.
+fn client_supports_watch_registration(params: &InitializeParams) -> bool {
+    params
+        .capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.did_change_watched_files.as_ref())
+        .and_then(|watched| watched.dynamic_registration)
+        .unwrap_or(false)
+}
+
+/// The client's workspace roots: every `workspace_folders` path, or the
+/// LSP-3.17-deprecated `root_uri` for an older client that sends only it (hence the
+/// scoped allow). Anchors untitled-buffer config discovery and bounds the
+/// `workspace/diagnostic` walk.
+fn workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
+    if let Some(folders) = params.workspace_folders.as_ref()
+        && !folders.is_empty()
+    {
+        return folders
+            .iter()
+            .filter_map(|folder| uri_to_path(folder.uri.as_str()))
+            .collect();
+    }
+    #[allow(deprecated)]
+    params
+        .root_uri
+        .as_ref()
+        .and_then(|uri| uri_to_path(uri.as_str()))
+        .into_iter()
+        .collect()
+}
+
+/// Ask the client to watch ryl's config files so an out-of-editor edit re-lints open
+/// documents. Watches the standard config filenames anywhere in the workspace, plus an
+/// explicitly-configured `config_file` (whose name need not match the standard set).
+/// Fire-and-forget: the response is irrelevant and is ignored in the loop.
+///
+/// Known limitation: files pulled in via a config's `extends:`, and a `configPath` changed
+/// after startup, are not (re-)watched — re-open a document to refresh after editing those.
+fn register_config_watchers(connection: &Connection, config_file: Option<&Path>) {
+    let mut watchers = vec![FileSystemWatcher {
+        glob_pattern: GlobPattern::String(
+            "**/{ryl.toml,.ryl.toml,pyproject.toml,.yamllint,.yamllint.yaml,\
+             .yamllint.yml}"
+                .to_string(),
+        ),
+        kind: None,
+    }];
+    // An explicit config path may live outside the roots or use a non-standard name, so
+    // watch it directly (the `**/` glob above would miss it).
+    if let Some(path) = config_file.and_then(Path::to_str) {
+        watchers.push(FileSystemWatcher {
+            glob_pattern: GlobPattern::String(path.replace('\\', "/")),
+            kind: None,
+        });
+    }
+    let options = DidChangeWatchedFilesRegistrationOptions { watchers };
+    let registration = Registration {
+        id: "ryl-watch-config".to_string(),
+        method: "workspace/didChangeWatchedFiles".to_string(),
+        register_options: serde_json::to_value(options).ok(),
+    };
+    let params = RegistrationParams {
+        registrations: vec![registration],
+    };
+    send(
+        connection,
+        Message::Request(Request::new(
+            RequestId::from("ryl-register-watchers".to_string()),
+            "client/registerCapability".to_string(),
+            params,
+        )),
+    );
+}
+
+/// An open document: its URI, latest full text (reconstructed from incremental changes),
+/// and version. The version is stamped into edits so a client can drop a stale edit if
+/// the buffer moved on before it was applied; the URI is kept so re-linting open
+/// documents needs no re-parse of the key.
 struct Document {
+    uri: Uri,
     version: i32,
     text: String,
 }
 
+/// Client-provided settings (from `initializationOptions` or
+/// `workspace/didChangeConfiguration`): a config-file path / inline data override
+/// (mirroring the CLI's `-c`/`-d`) and an on/off toggle (`ryl.enable`). `pub` only so the
+/// free `workspace_scan` (which a worker thread runs) is unit-testable.
+#[derive(Debug, Clone)]
+pub struct Settings {
+    config_file: Option<PathBuf>,
+    config_data: Option<String>,
+    enable: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            config_file: None,
+            config_data: None,
+            enable: true,
+        }
+    }
+}
+
+impl Settings {
+    /// Parse settings from a client payload, falling back to defaults for absent keys.
+    fn from_options(value: Option<&serde_json::Value>) -> Self {
+        let mut settings = Self::default();
+        // Accept either a bare settings object (our `initializationOptions`) or one
+        // nested under a `ryl` section (the `didChangeConfiguration` convention).
+        if let Some(section) = value.map(|value| value.get("ryl").unwrap_or(value)) {
+            if let Some(path) = section.get("configPath").and_then(as_nonempty_str) {
+                settings.config_file = Some(PathBuf::from(path));
+            }
+            if let Some(data) = section.get("configData").and_then(as_nonempty_str) {
+                settings.config_data = Some(data.to_string());
+            }
+            if let Some(enable) =
+                section.get("enable").and_then(serde_json::Value::as_bool)
+            {
+                settings.enable = enable;
+            }
+        }
+        settings
+    }
+
+    fn overrides(&self) -> Overrides {
+        Overrides {
+            config_file: self.config_file.clone(),
+            config_data: self.config_data.clone(),
+        }
+    }
+}
+
+fn as_nonempty_str(value: &serde_json::Value) -> Option<&str> {
+    value.as_str().filter(|text| !text.is_empty())
+}
+
 struct Server {
     encoding: PositionEncoding,
-    /// Workspace root for anchoring config discovery of non-file (untitled) URIs.
-    root: Option<PathBuf>,
-    /// Whether the client supports `WorkspaceEdit.documentChanges` (versioned
-    /// edits). When it does not, fix-all falls back to the unversioned `changes` map.
+    /// Workspace roots (all client folders) for anchoring config discovery of non-file
+    /// (untitled) URIs and for enumerating files in a `workspace/diagnostic` pull. Empty
+    /// when the client sent no folders.
+    roots: Vec<PathBuf>,
+    /// Whether the client supports `WorkspaceEdit.documentChanges` (versioned edits).
     supports_document_changes: bool,
+    /// Client-provided overrides and on/off toggle.
+    settings: Settings,
     /// Open documents, keyed by their URI string.
     documents: HashMap<String, Document>,
     /// Config-discovery error messages already surfaced via `window/showMessage`,
     /// so a broken config is reported once rather than on every file/keystroke.
     reported_errors: HashSet<String>,
+    /// In-flight `workspace/diagnostic` scans, each on its own thread so the (potentially
+    /// large) repo walk never blocks the message loop. Each carries a cancellation flag
+    /// the loop flips on `$/cancelRequest` or at shutdown.
+    workers: Vec<Worker>,
 }
+
+/// A `workspace/diagnostic` scan running on a background thread.
+struct Worker {
+    id: RequestId,
+    cancel: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
+}
+
+/// Open-document text/version snapshot, keyed by path, handed to a worker so it can prefer
+/// unsaved buffer content over on-disk content without sharing the live document store.
+pub type OpenText = HashMap<PathBuf, (String, i32)>;
 
 impl Server {
     fn message_loop(mut self, connection: &Connection) -> SessionOutcome {
+        let outcome = self.run_loop(connection);
+        // Signal and join any in-flight workspace scans so no detached thread outlives the
+        // session (each checks its cancel flag between files, so this returns promptly).
+        for worker in self.workers.drain(..) {
+            worker.cancel.store(true, Ordering::Relaxed);
+            let _ = worker.handle.join();
+        }
+        outcome
+    }
+
+    fn run_loop(&mut self, connection: &Connection) -> SessionOutcome {
         for message in &connection.receiver {
             match message {
                 Message::Request(request) => {
@@ -215,6 +407,7 @@ impl Server {
                     }
                     self.handle_notification(connection, notification);
                 }
+                // Responses (e.g. to our fire-and-forget registerCapability) are ignored.
                 Message::Response(_) => {}
             }
         }
@@ -222,7 +415,7 @@ impl Server {
         SessionOutcome::Clean
     }
 
-    fn handle_request(&self, connection: &Connection, request: Request) {
+    fn handle_request(&mut self, connection: &Connection, request: Request) {
         let Request { id, method, params } = request;
         match method.as_str() {
             "textDocument/codeAction" => {
@@ -235,6 +428,23 @@ impl Server {
                     .and_then(|params| self.formatting(&params));
                 respond(connection, id, result);
             }
+            "textDocument/hover" => {
+                let result = parse::<HoverParams>(&params)
+                    .and_then(|params| self.hover(&params));
+                respond(connection, id, result);
+            }
+            "textDocument/prepareRename" => {
+                let result = parse::<TextDocumentPositionParams>(&params)
+                    .and_then(|params| self.prepare_rename(&params));
+                respond(connection, id, result);
+            }
+            "textDocument/rename" => self.rename(connection, id, &params),
+            "textDocument/diagnostic" => {
+                let result = parse::<DocumentDiagnosticParams>(&params)
+                    .map(|params| self.document_diagnostic(&params));
+                respond(connection, id, result);
+            }
+            "workspace/diagnostic" => self.spawn_workspace_diagnostic(connection, id),
             other => {
                 send(
                     connection,
@@ -267,16 +477,8 @@ impl Server {
                 }
             }
             "textDocument/didChange" => {
-                if let Some(params) = parse::<DidChangeTextDocumentParams>(&params)
-                    && let Some(change) = params.content_changes.into_iter().next_back()
-                {
-                    let document = params.text_document;
-                    self.update(
-                        connection,
-                        document.uri,
-                        document.version,
-                        change.text,
-                    );
+                if let Some(params) = parse::<DidChangeTextDocumentParams>(&params) {
+                    self.apply_changes(connection, params);
                 }
             }
             "textDocument/didClose" => {
@@ -286,11 +488,69 @@ impl Server {
                     publish(connection, uri, None, Vec::new());
                 }
             }
+            // A watched config file changed: config is resolved per request (no cache),
+            // so just re-lint open docs. Clear the surfaced-errors set so a still-broken
+            // config re-reports once.
+            "workspace/didChangeWatchedFiles" => {
+                self.reported_errors.clear();
+                self.relint_open_documents(connection);
+            }
+            "workspace/didChangeConfiguration" => {
+                if let Some(params) = parse::<DidChangeConfigurationParams>(&params) {
+                    self.settings = Settings::from_options(Some(&params.settings));
+                    self.reported_errors.clear();
+                    self.relint_open_documents(connection);
+                }
+            }
+            // Cancel an in-flight workspace scan: flip its cancel flag so the worker stops
+            // between files and answers with a RequestCancelled error.
+            "$/cancelRequest" => {
+                if let Some(params) = parse::<CancelParams>(&params) {
+                    let target = request_id(params.id);
+                    for worker in &self.workers {
+                        if worker.id == target {
+                            worker.cancel.store(true, Ordering::Relaxed);
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
 
-    /// Store the latest text/version for `uri` and publish fresh diagnostics.
+    /// Reconstruct the document from incremental (or full-replace) changes, store it, and
+    /// publish fresh diagnostics. A change with a range patches the current text at that
+    /// range; a range-less change replaces the whole document.
+    fn apply_changes(
+        &mut self,
+        connection: &Connection,
+        params: DidChangeTextDocumentParams,
+    ) {
+        let uri = params.text_document.uri;
+        let version = params.text_document.version;
+        let mut text = self
+            .documents
+            .get(uri.as_str())
+            .map_or_else(String::new, |document| document.text.clone());
+        for change in params.content_changes {
+            match change.range {
+                Some(range) => {
+                    let start = offset_at(&text, range.start, self.encoding);
+                    let end = offset_at(&text, range.end, self.encoding);
+                    // Ignore a reversed range (offsets are clamped to the text and land
+                    // on char boundaries, so the splice itself is always valid).
+                    if start <= end {
+                        text.replace_range(start..end, &change.text);
+                    }
+                }
+                None => text = change.text,
+            }
+        }
+        self.update(connection, uri, version, text);
+    }
+
+    /// Store the latest text/version for `uri` and publish fresh diagnostics, surfacing a
+    /// config error once if discovery fails.
     fn update(
         &mut self,
         connection: &Connection,
@@ -298,27 +558,43 @@ impl Server {
         version: i32,
         text: String,
     ) {
-        let diagnostics = match self.resolve(uri.as_str()) {
-            Ok(Some(target)) => analysis::diagnostics(
-                &text,
-                &target.path,
-                &target.context.config,
-                &target.context.base_dir,
-                target.kind,
-                self.encoding,
-            ),
-            // No config / no rules / ignored / not a linted kind: nothing to report.
-            Ok(None) => Vec::new(),
-            // A broken config disables linting silently, which is confusing — tell
-            // the user once, then publish empty diagnostics like the other cases.
+        let diagnostics = match self.diagnostics_for(uri.as_str(), &text) {
+            Ok(diagnostics) => diagnostics,
+            // A broken config disables linting silently, which is confusing — tell the
+            // user once, then publish empty diagnostics.
             Err(error) => {
                 self.report_config_error(connection, &error);
                 Vec::new()
             }
         };
-        self.documents
-            .insert(uri.as_str().to_string(), Document { version, text });
+        self.documents.insert(
+            uri.as_str().to_string(),
+            Document {
+                uri: uri.clone(),
+                version,
+                text,
+            },
+        );
         publish(connection, uri, Some(version), diagnostics);
+    }
+
+    /// Re-lint and republish every open document (after a config or watched-file change).
+    fn relint_open_documents(&mut self, connection: &Connection) {
+        // Snapshot to avoid borrowing `documents` while `update` mutates it.
+        let snapshot: Vec<(Uri, i32, String)> = self
+            .documents
+            .values()
+            .map(|document| {
+                (
+                    document.uri.clone(),
+                    document.version,
+                    document.text.clone(),
+                )
+            })
+            .collect();
+        for (uri, version, text) in snapshot {
+            self.update(connection, uri, version, text);
+        }
     }
 
     /// Surface a config-discovery error to the user once (deduped by message).
@@ -326,7 +602,7 @@ impl Server {
         if self.reported_errors.insert(error.to_string()) {
             let params = ShowMessageParams {
                 typ: MessageType::ERROR,
-                message: format!("ryl: configuration error, linting is off: {error}"),
+                message: config_error_text(error),
             };
             send(
                 connection,
@@ -339,93 +615,246 @@ impl Server {
     }
 
     fn code_action(&self, params: &CodeActionParams) -> Option<CodeActionResponse> {
-        if !fix_all_requested(&params.context) {
-            return None;
-        }
         let uri = &params.text_document.uri;
-        let version = self.documents.get(uri.as_str())?.version;
-        let edit = self.fix_edit(uri.as_str())?;
-        let action = CodeAction {
-            title: "Fix all ryl problems".to_string(),
-            kind: Some(CodeActionKind::new(FIX_ALL_KIND)),
-            edit: Some(workspace_edit(
-                uri.clone(),
-                version,
-                edit,
-                self.supports_document_changes,
-            )),
-            ..Default::default()
+        let document = self.documents.get(uri.as_str())?;
+        let target = self.resolve(uri.as_str()).ok().flatten()?;
+        let input = actions::Input {
+            uri,
+            text: &document.text,
+            version: document.version,
+            path: &target.path,
+            cfg: &target.context.config,
+            base_dir: &target.context.base_dir,
+            kind: target.kind,
+            enc: self.encoding,
+            supports_document_changes: self.supports_document_changes,
         };
-        Some(vec![CodeActionOrCommand::CodeAction(action)])
+        actions::build(&input, &params.context)
     }
 
     fn formatting(&self, params: &DocumentFormattingParams) -> Option<Vec<TextEdit>> {
-        Some(vec![self.fix_edit(params.text_document.uri.as_str())?])
-    }
-
-    /// The whole-document safe-fix edit for an open document, shared by the
-    /// fix-all code action and formatting.
-    fn fix_edit(&self, uri: &str) -> Option<TextEdit> {
+        let uri = params.text_document.uri.as_str();
         let document = self.documents.get(uri)?;
-        // A config error or non-linted file means there is nothing to fix; the
-        // error itself was already surfaced when the document was opened/changed.
         let target = self.resolve(uri).ok().flatten()?;
-        analysis::fix_all_edit(
+        Some(vec![analysis::fix_all_edit(
             &document.text,
             &target.path,
             &target.context.config,
             &target.context.base_dir,
             target.kind,
             self.encoding,
-        )
+        )?])
     }
 
-    /// Resolve the path, config, and source kind for a URI. `Ok(None)` means
-    /// nothing to lint (no config, no rules, ignored, or not a linted kind); `Err`
-    /// is a config-discovery/parse failure the caller surfaces to the user.
+    fn hover(&self, params: &HoverParams) -> Option<Hover> {
+        let position = &params.text_document_position_params;
+        let document = self.documents.get(position.text_document.uri.as_str())?;
+        // Recompute diagnostics for hit-testing; the engine is sub-ms/file and this
+        // avoids caching published diagnostics. A config error here is silent (it was
+        // already surfaced on open/change).
+        let diagnostics = self
+            .diagnostics_for(position.text_document.uri.as_str(), &document.text)
+            .unwrap_or_default();
+        hover::hover(&diagnostics, position.position)
+    }
+
+    fn prepare_rename(
+        &self,
+        params: &TextDocumentPositionParams,
+    ) -> Option<PrepareRenameResponse> {
+        let uri = params.text_document.uri.as_str();
+        if !matches!(self.document_kind(uri), Some(SourceKind::Yaml)) {
+            return None;
+        }
+        let document = self.documents.get(uri)?;
+        rename::prepare_rename(&document.text, params.position, self.encoding)
+    }
+
+    fn rename(
+        &self,
+        connection: &Connection,
+        id: RequestId,
+        params: &serde_json::Value,
+    ) {
+        let null = || respond(connection, id.clone(), Option::<WorkspaceEdit>::None);
+        let Some(params) = parse::<RenameParams>(params) else {
+            null();
+            return;
+        };
+        let uri = &params.text_document_position.text_document.uri;
+        let Some(document) = self.documents.get(uri.as_str()) else {
+            null();
+            return;
+        };
+        if !matches!(self.document_kind(uri.as_str()), Some(SourceKind::Yaml)) {
+            null();
+            return;
+        }
+        match rename::rename_edits(
+            &document.text,
+            params.text_document_position.position,
+            &params.new_name,
+            self.encoding,
+        ) {
+            Ok(Some(edits)) => {
+                let edit = actions::workspace_edit(
+                    uri.clone(),
+                    document.version,
+                    edits,
+                    self.supports_document_changes,
+                );
+                respond(connection, id, Some(edit));
+            }
+            Ok(None) => null(),
+            // An illegal new name is a request error, per the LSP rename spec.
+            Err(message) => send(
+                connection,
+                Message::Response(Response::new_err(
+                    id,
+                    ErrorCode::InvalidParams as i32,
+                    message,
+                )),
+            ),
+        }
+    }
+
+    /// The pull-diagnostic report for one document (stored text if open, else read from
+    /// disk).
+    fn document_diagnostic(
+        &self,
+        params: &DocumentDiagnosticParams,
+    ) -> DocumentDiagnosticReport {
+        let uri = params.text_document.uri.as_str();
+        let items = self.document_text(uri).map_or_else(Vec::new, |text| {
+            // Surface a config failure as an error diagnostic rather than an empty (clean)
+            // report, so a pull-only client is not misled into thinking the file is fine.
+            self.diagnostics_for(uri, &text)
+                .unwrap_or_else(|error| vec![config_error_diagnostic(&error)])
+        });
+        DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
+            related_documents: None,
+            full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                result_id: None,
+                items,
+            },
+        })
+    }
+
+    /// Snapshot open documents (text + version) by path, so a worker can prefer unsaved
+    /// buffer content over on-disk content without sharing the live document store.
+    fn open_snapshot(&self) -> OpenText {
+        self.documents
+            .iter()
+            .filter_map(|(uri, document)| {
+                uri_to_path(uri)
+                    .map(|path| (path, (document.text.clone(), document.version)))
+            })
+            .collect()
+    }
+
+    /// Start a `workspace/diagnostic` scan on a background thread so the (potentially
+    /// large) repo walk + parallel lint never blocks the message loop. The worker answers
+    /// the request itself over the connection; the loop stays responsive and can cancel it.
+    fn spawn_workspace_diagnostic(&mut self, connection: &Connection, id: RequestId) {
+        // Supersede any in-flight scan: cancel it (it answers RequestCancelled) so a client
+        // issuing rapid pulls (e.g. on every save) does not accumulate concurrent
+        // walks/snapshots — only the latest pull does real work, keeping the worker count
+        // bounded. Then drop the handles of any that have already finished.
+        for worker in &self.workers {
+            worker.cancel.store(true, Ordering::Relaxed);
+        }
+        self.workers.retain(|worker| !worker.handle.is_finished());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let token = Arc::clone(&cancel);
+        let sender = connection.sender.clone();
+        let roots = self.roots.clone();
+        let settings = self.settings.clone();
+        let encoding = self.encoding;
+        let open = self.open_snapshot();
+        let response_id = id.clone();
+        let handle = thread::spawn(move || {
+            let scan = workspace_scan(&roots, &open, &settings, encoding, &token);
+            let _ =
+                sender.send(Message::Response(workspace_response(response_id, scan)));
+        });
+        self.workers.push(Worker { id, cancel, handle });
+    }
+
+    /// Text of `uri`: the open buffer if tracked, else the file decoded from disk.
+    fn document_text(&self, uri: &str) -> Option<String> {
+        if let Some(document) = self.documents.get(uri) {
+            return Some(document.text.clone());
+        }
+        let path = uri_to_path(uri)?;
+        crate::decoder::read_file(&path).ok()
+    }
+
+    /// Diagnostics for `text` resolved against `uri`'s config, or `Err` on a config
+    /// failure (callers decide whether to surface it).
+    fn diagnostics_for(
+        &self,
+        uri: &str,
+        text: &str,
+    ) -> Result<Vec<Diagnostic>, String> {
+        Ok(match self.resolve(uri)? {
+            Some(target) => analysis::diagnostics(
+                text,
+                &target.path,
+                &target.context.config,
+                &target.context.base_dir,
+                target.kind,
+                self.encoding,
+            ),
+            None => Vec::new(),
+        })
+    }
+
+    /// Resolve the path, config, and source kind for a URI. `Ok(None)` means nothing to
+    /// lint (disabled, no config, no rules, ignored, or not a linted kind); `Err` is a
+    /// config-discovery/parse failure the caller surfaces to the user.
     fn resolve(&self, uri: &str) -> Result<Option<Target>, String> {
-        // A non-file URI is an untitled/unsaved buffer with no real path: anchor
-        // discovery at the workspace fallback and (below) lint it as YAML regardless
-        // of `[files]`, since it is unsaved YAML the user is editing.
-        let (path, is_file) = match uri_to_path(uri) {
+        let (path, is_file) = self.uri_path(uri);
+        self.resolve_path(path, is_file, true)
+    }
+
+    /// As [`Self::resolve`] but from an already-decoded path. `require_rules` gates on the
+    /// config enabling at least one rule (true for linting/fixing; false for rename, which
+    /// works regardless of lint config). Used by `document_kind`; the free
+    /// [`resolve_for_path`] backs both this and the worker (which has no `&self`).
+    fn resolve_path(
+        &self,
+        path: PathBuf,
+        is_file: bool,
+        require_rules: bool,
+    ) -> Result<Option<Target>, String> {
+        resolve_for_path(path, is_file, require_rules, &self.settings)
+    }
+
+    /// The source kind of `uri` ignoring whether any rule is enabled — rename works
+    /// regardless of lint config, but only on YAML documents. `None` when disabled,
+    /// ignored, config fails, or the kind is not YAML/markdown.
+    fn document_kind(&self, uri: &str) -> Option<SourceKind> {
+        let (path, is_file) = self.uri_path(uri);
+        self.resolve_path(path, is_file, false)
+            .ok()
+            .flatten()
+            .map(|target| target.kind)
+    }
+
+    /// Decode a URI to `(path, is_file)`: a non-file URI is an untitled/unsaved buffer
+    /// with no real path, anchored at the workspace fallback and linted as YAML.
+    fn uri_path(&self, uri: &str) -> (PathBuf, bool) {
+        match uri_to_path(uri) {
             Some(path) => (path, true),
             None => (self.fallback_base().join("untitled.yaml"), false),
-        };
-        // Full CLI precedence for this one input: project config (walking up from
-        // the path), then `YAMLLINT_CONFIG_FILE`, then user-global, then empty.
-        let mut context =
-            discover_config(std::slice::from_ref(&path), &Overrides::default())?;
-        if !context.config.enables_any_rule() {
-            return Ok(None);
         }
-        let kind = if is_file {
-            // A real file: honour path-based ignores, and take its kind from
-            // `[files]`. An overlapping glob makes `source_kind` error (surfaced
-            // like any config mistake); no match skips the file.
-            if context.config.is_file_ignored(&path, &context.base_dir) {
-                return Ok(None);
-            }
-            match context.config.source_kind(&path, &context.base_dir)? {
-                Some(kind) => kind,
-                None => return Ok(None),
-            }
-        } else {
-            // A non-file (untitled/unsaved) buffer has no real path: like stdin
-            // without `--stdin-filename`, disable every path-based filter (whole-file
-            // ignore, per-file and per-rule ignores) and lint it as YAML.
-            context.config.disable_path_based_rule_ignores();
-            SourceKind::Yaml
-        };
-        Ok(Some(Target {
-            path,
-            context,
-            kind,
-        }))
     }
 
     fn fallback_base(&self) -> PathBuf {
-        self.root
-            .clone()
+        // Anchor untitled buffers at the first workspace root, else the process cwd.
+        self.roots
+            .first()
+            .cloned()
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
     }
 }
@@ -436,48 +865,140 @@ struct Target {
     kind: SourceKind,
 }
 
-/// Build the fix-all workspace edit. A client advertising `documentChanges`
-/// support gets a versioned `TextDocumentEdit` (so it can discard the edit if the
-/// buffer moved past `version` before the edit is applied); otherwise it gets the
-/// unversioned `changes` map. `Uri` has benign interior mutability (a fluent-uri
-/// parse cache) that never affects its hash/equality, hence the lint allow.
-#[allow(clippy::mutable_key_type)]
-fn workspace_edit(
-    uri: Uri,
-    version: i32,
-    edit: TextEdit,
-    supports_document_changes: bool,
-) -> WorkspaceEdit {
-    if supports_document_changes {
-        WorkspaceEdit {
-            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
-                text_document: OptionalVersionedTextDocumentIdentifier {
-                    uri,
-                    version: Some(version),
-                },
-                edits: vec![OneOf::Left(edit)],
-            }])),
-            ..Default::default()
+/// Resolve config + source kind for an already-decoded path, layering `settings` (the
+/// client overrides + enable toggle) onto CLI-precedence discovery. `require_rules` gates
+/// on the config enabling at least one rule (true for linting/fixing; false for rename).
+/// Free (no `&self`) so a `workspace/diagnostic` worker thread can call it too.
+fn resolve_for_path(
+    path: PathBuf,
+    is_file: bool,
+    require_rules: bool,
+    settings: &Settings,
+) -> Result<Option<Target>, String> {
+    if !settings.enable {
+        return Ok(None);
+    }
+    let mut context =
+        discover_config(std::slice::from_ref(&path), &settings.overrides())?;
+    if require_rules && !context.config.enables_any_rule() {
+        return Ok(None);
+    }
+    let kind = if is_file {
+        // A real file: honour path-based ignores, and take its kind from `[files]`.
+        if context.config.is_file_ignored(&path, &context.base_dir) {
+            return Ok(None);
+        }
+        match context.config.source_kind(&path, &context.base_dir)? {
+            Some(kind) => kind,
+            None => return Ok(None),
         }
     } else {
-        WorkspaceEdit {
-            changes: Some(HashMap::from([(uri, vec![edit])])),
-            ..Default::default()
+        // A non-file (untitled/unsaved) buffer has no real path: like stdin without
+        // `--stdin-filename`, disable every path-based filter and lint it as YAML.
+        context.config.disable_path_based_rule_ignores();
+        SourceKind::Yaml
+    };
+    Ok(Some(Target {
+        path,
+        context,
+        kind,
+    }))
+}
+
+/// Lint one workspace file for a pull report, preferring the open buffer's text. Returns
+/// `None` to skip a non-linted/ignored file or one that can't be read; a config failure
+/// becomes an error report rather than a silent omit (a pull client would read absence as
+/// clean).
+fn file_report(
+    path: &Path,
+    settings: &Settings,
+    encoding: PositionEncoding,
+    open: &OpenText,
+) -> Option<WorkspaceDocumentDiagnosticReport> {
+    let target = match resolve_for_path(path.to_path_buf(), true, true, settings) {
+        Ok(Some(target)) => target,
+        Ok(None) => return None,
+        Err(error) => {
+            return Some(workspace_report(
+                path_to_uri(path),
+                None,
+                vec![config_error_diagnostic(&error)],
+            ));
         }
+    };
+    let (text, version) = match open.get(path) {
+        Some((text, version)) => (text.clone(), Some(i64::from(*version))),
+        None => (crate::decoder::read_file(path).ok()?, None),
+    };
+    let items = analysis::diagnostics(
+        &text,
+        &target.path,
+        &target.context.config,
+        &target.context.base_dir,
+        target.kind,
+        encoding,
+    );
+    Some(workspace_report(path_to_uri(path), version, items))
+}
+
+/// The `workspace/diagnostic` scan: enumerate `*.yaml`/`*.yml` under each root (git-ignore
+/// honoured), de-duplicate across roots, then lint them in parallel ([`rayon`], like the
+/// CLI). Returns `None` if `cancel` is set (the request was cancelled), so the worker
+/// answers with `RequestCancelled`. The walk + lint run off the message loop, so the server
+/// stays responsive however large the tree. `pub` for unit testing (a worker runs it).
+pub fn workspace_scan(
+    roots: &[PathBuf],
+    open: &OpenText,
+    settings: &Settings,
+    encoding: PositionEncoding,
+    cancel: &AtomicBool,
+) -> Option<Vec<WorkspaceDocumentDiagnosticReport>> {
+    let mut files = Vec::new();
+    let mut seen = HashSet::new();
+    for root in roots {
+        // The walk is per-entry cancellable, so a cancelled pull stops enumerating a (huge
+        // or slow) tree instead of finishing it; `?` propagates the cancellation. The lint
+        // pass below is fast and rayon-parallel and is not separately interrupted — the
+        // residual mid-`read_file` window is per ryl's threat model (realistic payloads,
+        // not a degraded-fs racer), and that in-progress failure mode cannot be tested
+        // deterministically.
+        for path in gather_yaml_from_dir_cancellable(root, cancel)? {
+            // De-duplicate so a file reachable from two (e.g. nested) roots is linted once.
+            if seen.insert(path.clone()) {
+                files.push(path);
+            }
+        }
+    }
+    Some(
+        files
+            .par_iter()
+            .filter_map(|path| file_report(path, settings, encoding, open))
+            .collect(),
+    )
+}
+
+/// Build the `workspace/diagnostic` response: the report, or a `RequestCancelled` error
+/// when the scan was cancelled. `pub` for unit testing.
+#[must_use]
+pub fn workspace_response(
+    id: RequestId,
+    scan: Option<Vec<WorkspaceDocumentDiagnosticReport>>,
+) -> Response {
+    match scan {
+        Some(items) => Response::new_ok(id, WorkspaceDiagnosticReport { items }),
+        None => Response::new_err(
+            id,
+            ErrorCode::RequestCanceled as i32,
+            "workspace diagnostic cancelled".to_string(),
+        ),
     }
 }
 
-/// Whether the client's `context.only` filter admits the fix-all action: no
-/// filter means yes, otherwise a requested kind must equal or be an ancestor of
-/// `source.fixAll.ryl` (so a `source` or `source.fixAll` request still matches,
-/// the way `editor.codeActionsOnSave` issues them).
-fn fix_all_requested(context: &CodeActionContext) -> bool {
-    match &context.only {
-        None => true,
-        Some(only) => only.iter().any(|kind| {
-            let kind = kind.as_str();
-            FIX_ALL_KIND == kind || FIX_ALL_KIND.starts_with(&format!("{kind}."))
-        }),
+/// Convert an LSP `$/cancelRequest` id to an `lsp-server` request id for matching.
+fn request_id(id: NumberOrString) -> RequestId {
+    match id {
+        NumberOrString::Number(number) => RequestId::from(number),
+        NumberOrString::String(text) => RequestId::from(text),
     }
 }
 
@@ -499,11 +1020,49 @@ fn parse<P: serde::de::DeserializeOwned>(params: &serde_json::Value) -> Option<P
     serde_json::from_value(params.clone()).ok()
 }
 
+/// The user-facing message for a config-discovery failure, shared by the push path's
+/// `window/showMessage` and the pull path's synthetic diagnostic.
+fn config_error_text(error: &str) -> String {
+    format!("ryl: configuration error, linting is off: {error}")
+}
+
+/// A single error diagnostic standing in for a config-discovery failure, so a pull
+/// request surfaces the failure (in the report the client consumes) rather than reporting
+/// the file as clean.
+fn config_error_diagnostic(error: &str) -> Diagnostic {
+    Diagnostic {
+        range: Range {
+            start: Position::new(0, 0),
+            end: Position::new(0, 0),
+        },
+        severity: Some(DiagnosticSeverity::ERROR),
+        source: Some("ryl".to_string()),
+        message: config_error_text(error),
+        ..Default::default()
+    }
+}
+
+/// One file's full report for a `workspace/diagnostic` result.
+fn workspace_report(
+    uri: Uri,
+    version: Option<i64>,
+    items: Vec<Diagnostic>,
+) -> WorkspaceDocumentDiagnosticReport {
+    WorkspaceDocumentDiagnosticReport::Full(WorkspaceFullDocumentDiagnosticReport {
+        uri,
+        version,
+        full_document_diagnostic_report: FullDocumentDiagnosticReport {
+            result_id: None,
+            items,
+        },
+    })
+}
+
 fn publish(
     connection: &Connection,
     uri: Uri,
     version: Option<i32>,
-    diagnostics: Vec<lsp_types::Diagnostic>,
+    diagnostics: Vec<Diagnostic>,
 ) {
     let params = PublishDiagnosticsParams {
         uri,

--- a/src/lsp/rename.rs
+++ b/src/lsp/rename.rs
@@ -1,0 +1,171 @@
+//! Anchor/alias rename for `ryl server`. Renaming an anchor (`&name`) or alias
+//! (`*name`) rewrites every occurrence of that name *within the same YAML document*
+//! (anchors are document-scoped: a name reused across a `---`/`...` boundary is a
+//! distinct anchor, matching how `rules::anchors` defines anchor identity). Detection
+//! reuses granit's scanner tokens, so a literal `&`/`*` inside a scalar is never mistaken
+//! for an anchor. Pure functions of the document text; the server wraps the returned
+//! edits into a workspace edit.
+
+use granit_parser::{Scanner, StrInput, TokenType};
+use lsp_types::{Position, PrepareRenameResponse, Range, TextEdit};
+
+use crate::lsp::encoding::{PositionEncoding, position_at, range_contains};
+use crate::rules::support::line_syntax::line_contents;
+use crate::rules::support::punctuation::{build_line_starts, line_and_column};
+use crate::rules::support::span_utils::CharPos;
+
+/// One anchor/alias occurrence: its scanned name, the 0-based char index where the name
+/// begins, and the document it belongs to (incremented on each `---`/`...` boundary so
+/// cross-document names stay distinct).
+struct Occurrence {
+    name: String,
+    name_start: usize,
+    name_len: usize,
+    document: usize,
+}
+
+/// Scan `text` for every anchor/alias occurrence.
+fn occurrences(text: &str) -> Vec<Occurrence> {
+    let mut occurrences = Vec::new();
+    let mut document = 0usize;
+    for token in Scanner::new(StrInput::new(text)) {
+        let name = match token.1 {
+            TokenType::DocumentStart | TokenType::DocumentEnd => {
+                document += 1;
+                continue;
+            }
+            TokenType::Anchor(name) | TokenType::Alias(name) => name.to_string(),
+            _ => continue,
+        };
+        // granit's Anchor/Alias span starts at the `&`/`*` sigil, so the name begins one
+        // char in (verified: the span never starts on the name itself).
+        occurrences.push(Occurrence {
+            name_len: name.chars().count(),
+            name_start: token.0.start.index() + 1,
+            name,
+            document,
+        });
+    }
+    occurrences
+}
+
+/// The LSP range covering an occurrence's name. Anchor/alias names never span a line
+/// break, so start and end share a line.
+fn name_range(
+    occurrence: &Occurrence,
+    line_starts: &[CharPos],
+    lines: &[&str],
+    enc: PositionEncoding,
+) -> Range {
+    let (line, column) =
+        line_and_column(line_starts, CharPos::new(occurrence.name_start));
+    Range {
+        start: position_at(lines, line, column, enc),
+        end: position_at(lines, line, column + occurrence.name_len, enc),
+    }
+}
+
+/// Resolve the anchor/alias occurrence whose name covers `position`, if any.
+fn occurrence_at<'a>(
+    occurrences: &'a [Occurrence],
+    line_starts: &[CharPos],
+    lines: &[&str],
+    position: Position,
+    enc: PositionEncoding,
+) -> Option<&'a Occurrence> {
+    occurrences
+        .iter()
+        .find(|occ| range_contains(name_range(occ, line_starts, lines, enc), position))
+}
+
+/// For `textDocument/prepareRename`: the name range + placeholder when `position` is on
+/// an anchor/alias, else `None` (the editor then reports the location is not renameable).
+#[must_use]
+pub fn prepare_rename(
+    text: &str,
+    position: Position,
+    enc: PositionEncoding,
+) -> Option<PrepareRenameResponse> {
+    let char_indices: Vec<(usize, char)> = text.char_indices().collect();
+    let line_starts = build_line_starts(&char_indices);
+    let lines = line_contents(text);
+    let occurrences = occurrences(text);
+    let target = occurrence_at(&occurrences, &line_starts, &lines, position, enc)?;
+    Some(PrepareRenameResponse::RangeWithPlaceholder {
+        range: name_range(target, &line_starts, &lines, enc),
+        placeholder: target.name.clone(),
+    })
+}
+
+/// For `textDocument/rename`: the edits renaming the anchor/alias at `position` to
+/// `new_name` across its document. `Ok(None)` when `position` is not on an anchor/alias;
+/// `Err` when `new_name` is not a legal anchor name (the server returns it as a request
+/// error, per the LSP spec).
+///
+/// # Errors
+/// Returns an error message when `new_name` is empty or contains a control character,
+/// whitespace, or a YAML flow indicator (`,[]{}`), which `ns-anchor-char` forbids (a `:`
+/// is spec-legal and allowed), or when it collides with another anchor in the document.
+pub fn rename_edits(
+    text: &str,
+    position: Position,
+    new_name: &str,
+    enc: PositionEncoding,
+) -> Result<Option<Vec<TextEdit>>, String> {
+    let char_indices: Vec<(usize, char)> = text.char_indices().collect();
+    let line_starts = build_line_starts(&char_indices);
+    let lines = line_contents(text);
+    let occurrences = occurrences(text);
+    let Some(target) = occurrence_at(&occurrences, &line_starts, &lines, position, enc)
+    else {
+        return Ok(None);
+    };
+    validate_name(new_name)?;
+    // Renaming onto a name already used by a *different* anchor/alias in this document
+    // would silently rebind aliases (an alias resolves to the nearest preceding anchor of
+    // its name), so reject the collision rather than change the document's meaning.
+    if new_name != target.name
+        && occurrences
+            .iter()
+            .any(|occ| occ.document == target.document && occ.name == new_name)
+    {
+        return Err(format!(
+            "cannot rename to {new_name:?}: an anchor or alias with that name already \
+             exists in this document"
+        ));
+    }
+    let edits = occurrences
+        .iter()
+        .filter(|occ| occ.name == target.name && occ.document == target.document)
+        .map(|occ| {
+            TextEdit::new(
+                name_range(occ, &line_starts, &lines, enc),
+                new_name.to_string(),
+            )
+        })
+        .collect();
+    Ok(Some(edits))
+}
+
+/// Reject an anchor name that is not a valid `ns-anchor-char*` (YAML 1.2.2 §6.9.2):
+/// `ns-anchor-char` is a non-space printable character excluding the flow indicators
+/// `,[]{}`. So reject control characters (LSP/JSON can carry escaped ones like NUL that
+/// would make the document non-printable), whitespace, and the flow indicators. A `:` is
+/// left allowed — it is spec-legal (granit/the reference parser read `&foo:bar` as the
+/// name `foo:bar`), though the `anchors` rule may then flag it as ambiguous.
+fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("anchor name must not be empty".to_string());
+    }
+    if let Some(bad) = name.chars().find(|ch| {
+        ch.is_control()
+            || ch.is_whitespace()
+            || matches!(ch, ',' | '[' | ']' | '{' | '}')
+    }) {
+        return Err(format!(
+            "invalid anchor name: {bad:?} is not allowed (no control characters, \
+             whitespace, or flow indicators , [ ] {{ }})"
+        ));
+    }
+    Ok(())
+}

--- a/tests/lsp_server.rs
+++ b/tests/lsp_server.rs
@@ -14,18 +14,26 @@ use lsp_server::{Connection, Message, Notification, Request, RequestId, Response
 use lsp_types::{
     ClientCapabilities, CodeActionContext, CodeActionKind, CodeActionOrCommand,
     CodeActionParams, CodeActionResponse, Diagnostic, DidChangeTextDocumentParams,
-    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DocumentChanges,
-    DocumentFormattingParams, FormattingOptions, GeneralClientCapabilities,
-    InitializeParams, InitializeResult, OneOf, PartialResultParams,
-    PositionEncodingKind, PublishDiagnosticsParams, Range,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, TextEdit,
-    Uri, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
-    WorkspaceClientCapabilities, WorkspaceEditClientCapabilities, WorkspaceFolder,
+    DidChangeWatchedFilesClientCapabilities, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DocumentChanges, DocumentDiagnosticReport,
+    DocumentFormattingParams, FormattingOptions, GeneralClientCapabilities, Hover,
+    HoverContents, InitializeParams, InitializeResult, NumberOrString, OneOf,
+    PartialResultParams, Position, PositionEncodingKind, PrepareRenameResponse,
+    PublishDiagnosticsParams, Range, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri,
+    VersionedTextDocumentIdentifier, WorkDoneProgressParams,
+    WorkspaceClientCapabilities, WorkspaceDiagnosticReport,
+    WorkspaceDocumentDiagnosticReport, WorkspaceEdit, WorkspaceEditClientCapabilities,
+    WorkspaceFolder,
 };
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
 const TRAILING: &str = "[rules]\ntrailing-spaces = \"enable\"\n";
+
+/// A method ryl does not (and will not) handle, so requesting it always yields a
+/// `MethodNotFound` error — used to probe that the server is still responsive.
+const UNHANDLED_METHOD: &str = "ryl/internalUnhandledProbe";
 
 fn uri(text: &str) -> Uri {
     Uri::from_str(text).expect("valid URI")
@@ -49,6 +57,21 @@ fn project(config: &str) -> TempDir {
     dir
 }
 
+/// A one-character ryl diagnostic for `rule` at a 0-based position, as a client echoes
+/// back in a code-action request's context (carrying ryl's `source` as the real server
+/// does, so the source filter accepts it).
+fn diag(rule: &str, line: u32, character: u32) -> Diagnostic {
+    Diagnostic {
+        range: Range::new(
+            Position::new(line, character),
+            Position::new(line, character + 1),
+        ),
+        code: Some(NumberOrString::String(rule.to_string())),
+        source: Some("ryl".to_string()),
+        ..Default::default()
+    }
+}
+
 /// In-process client driving a server thread over a memory connection.
 struct Client {
     conn: Option<Connection>,
@@ -65,11 +88,53 @@ impl Client {
         Self::launch_full(encodings, root, true, None)
     }
 
+    /// Launch advertising several workspace folders (a multi-root workspace).
+    fn launch_roots(roots: &[&Path]) -> (Self, InitializeResult) {
+        let (server, client) = Connection::memory();
+        let thread = thread::spawn(move || {
+            let _ = ryl::lsp::serve(&server);
+        });
+        let mut this = Client {
+            conn: Some(client),
+            thread: Some(thread),
+            next_id: 0,
+        };
+        let params = InitializeParams {
+            workspace_folders: Some(
+                roots
+                    .iter()
+                    .map(|path| WorkspaceFolder {
+                        uri: file_uri(path, ""),
+                        name: "root".to_string(),
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        let id = this.request("initialize", params);
+        let response = this.response(&id);
+        this.notify("initialized", serde_json::json!({}));
+        let init = serde_json::from_value(response.result.expect("initialize result"))
+            .expect("InitializeResult");
+        (this, init)
+    }
+
     fn launch_full(
         encodings: Option<Vec<PositionEncodingKind>>,
         root: Option<&Path>,
         document_changes: bool,
         root_uri: Option<&Path>,
+    ) -> (Self, InitializeResult) {
+        Self::launch_with(encodings, root, document_changes, root_uri, false, None)
+    }
+
+    fn launch_with(
+        encodings: Option<Vec<PositionEncodingKind>>,
+        root: Option<&Path>,
+        document_changes: bool,
+        root_uri: Option<&Path>,
+        watch: bool,
+        options: Option<Value>,
     ) -> (Self, InitializeResult) {
         let (server, client) = Connection::memory();
         let thread = thread::spawn(move || {
@@ -80,7 +145,14 @@ impl Client {
             thread: Some(thread),
             next_id: 0,
         };
-        let init = this.initialize(encodings, root, document_changes, root_uri);
+        let init = this.initialize(
+            encodings,
+            root,
+            document_changes,
+            root_uri,
+            watch,
+            options,
+        );
         (this, init)
     }
 
@@ -169,6 +241,8 @@ impl Client {
         root: Option<&Path>,
         document_changes: bool,
         root_uri: Option<&Path>,
+        watch: bool,
+        options: Option<Value>,
     ) -> InitializeResult {
         let params = InitializeParams {
             capabilities: ClientCapabilities {
@@ -178,15 +252,26 @@ impl Client {
                         ..Default::default()
                     }
                 }),
-                workspace: document_changes.then(|| WorkspaceClientCapabilities {
-                    workspace_edit: Some(WorkspaceEditClientCapabilities {
-                        document_changes: Some(true),
+                workspace: (document_changes || watch).then(|| {
+                    WorkspaceClientCapabilities {
+                        workspace_edit: document_changes.then(|| {
+                            WorkspaceEditClientCapabilities {
+                                document_changes: Some(true),
+                                ..Default::default()
+                            }
+                        }),
+                        did_change_watched_files: watch.then(|| {
+                            DidChangeWatchedFilesClientCapabilities {
+                                dynamic_registration: Some(true),
+                                ..Default::default()
+                            }
+                        }),
                         ..Default::default()
-                    }),
-                    ..Default::default()
+                    }
                 }),
                 ..Default::default()
             },
+            initialization_options: options,
             workspace_folders: root.map(|path| {
                 vec![WorkspaceFolder {
                     uri: file_uri(path, ""),
@@ -279,10 +364,118 @@ impl Client {
             .expect("response")
     }
 
+    fn code_action_with_diagnostics(
+        &mut self,
+        uri: Uri,
+        diagnostics: Vec<Diagnostic>,
+    ) -> Option<CodeActionResponse> {
+        let params = CodeActionParams {
+            text_document: TextDocumentIdentifier { uri },
+            range: Range::default(),
+            context: CodeActionContext {
+                diagnostics,
+                only: None,
+                trigger_kind: None,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let id = self.request("textDocument/codeAction", params);
+        let response = self.response(&id);
+        serde_json::from_value(response.result.expect("code action result"))
+            .expect("response")
+    }
+
+    fn hover(&mut self, uri: &Uri, line: u32, character: u32) -> Option<Hover> {
+        let params = json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+        });
+        let id = self.request("textDocument/hover", params);
+        let response = self.response(&id);
+        serde_json::from_value(response.result.expect("hover result"))
+            .expect("Option<Hover>")
+    }
+
+    fn prepare_rename(
+        &mut self,
+        uri: &Uri,
+        line: u32,
+        character: u32,
+    ) -> Option<PrepareRenameResponse> {
+        let params = json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+        });
+        let id = self.request("textDocument/prepareRename", params);
+        let response = self.response(&id);
+        serde_json::from_value(response.result.expect("prepareRename result"))
+            .expect("Option<PrepareRenameResponse>")
+    }
+
+    /// Send a rename and return the raw response (so a test can check error vs result).
+    fn rename(
+        &mut self,
+        uri: &Uri,
+        line: u32,
+        character: u32,
+        new_name: &str,
+    ) -> Response {
+        let params = json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "newName": new_name,
+        });
+        let id = self.request("textDocument/rename", params);
+        self.response(&id)
+    }
+
+    fn document_diagnostic(&mut self, uri: &Uri) -> DocumentDiagnosticReport {
+        let params = json!({ "textDocument": { "uri": uri } });
+        let id = self.request("textDocument/diagnostic", params);
+        let response = self.response(&id);
+        serde_json::from_value(response.result.expect("diagnostic result"))
+            .expect("DocumentDiagnosticReport")
+    }
+
+    fn workspace_diagnostic(&mut self) -> WorkspaceDiagnosticReport {
+        let params = json!({ "previousResultIds": [] });
+        let id = self.request("workspace/diagnostic", params);
+        let response = self.response(&id);
+        serde_json::from_value(response.result.expect("workspace diagnostic result"))
+            .expect("WorkspaceDiagnosticReport")
+    }
+
+    /// Send an incremental (ranged) change replacing `range` with `text`.
+    fn did_change_range(&self, uri: Uri, version: i32, range: Range, text: &str) {
+        self.notify(
+            "textDocument/didChange",
+            DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier { uri, version },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: Some(range),
+                    range_length: None,
+                    text: text.to_string(),
+                }],
+            },
+        );
+    }
+
+    /// Receive the next server-to-client request, skipping notifications/responses.
+    fn recv_request(&self) -> Request {
+        loop {
+            if let Message::Request(request) =
+                self.conn().receiver.recv().expect("recv")
+            {
+                return request;
+            }
+        }
+    }
+
     /// Confirm the server still processes messages (an unknown request gets an
     /// error response). Used after sending something the server should ignore.
     fn assert_alive(&mut self) {
-        let id = self.request("textDocument/hover", Value::Null);
+        let id = self.request(UNHANDLED_METHOD, Value::Null);
         let response = self.response(&id);
         assert!(
             response.error.is_some(),
@@ -641,7 +834,7 @@ fn formatting_a_clean_document_is_null() {
 #[test]
 fn unknown_request_is_method_not_found() {
     let (mut client, _init) = Client::launch(None, None);
-    let id = client.request("textDocument/hover", Value::Null);
+    let id = client.request(UNHANDLED_METHOD, Value::Null);
     let response = client.response(&id);
     let error = response.error.expect("unknown method errors");
     assert_eq!(error.code, lsp_server::ErrorCode::MethodNotFound as i32);
@@ -900,6 +1093,940 @@ fn file_matching_two_source_kinds_is_reported() {
     assert!(
         messages.iter().any(is_show_message),
         "ambiguous source kind is surfaced via window/showMessage"
+    );
+}
+
+// --- #317 nice-to-haves: capabilities, watching, config, actions, hover, sync, rename,
+//     and pull diagnostics. ---
+
+#[test]
+fn initialize_advertises_extended_capabilities() {
+    let (_client, init) = Client::launch(None, None);
+    let caps = init.capabilities;
+    assert!(caps.hover_provider.is_some(), "advertises hover");
+    assert!(caps.rename_provider.is_some(), "advertises rename");
+    assert!(
+        caps.diagnostic_provider.is_some(),
+        "advertises pull diagnostics"
+    );
+    assert!(
+        matches!(
+            caps.text_document_sync,
+            Some(lsp_types::TextDocumentSyncCapability::Kind(
+                lsp_types::TextDocumentSyncKind::INCREMENTAL
+            ))
+        ),
+        "negotiates incremental sync"
+    );
+}
+
+#[test]
+fn registers_config_watcher_when_the_client_supports_it() {
+    let dir = project(TRAILING);
+    let (client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, true, None);
+    let request = client.recv_request();
+    assert_eq!(request.method, "client/registerCapability");
+    let params = request.params.to_string();
+    assert!(
+        params.contains("didChangeWatchedFiles"),
+        "registers the watched-files capability: {params}"
+    );
+    assert!(
+        params.contains("ryl.toml"),
+        "watches ryl config files: {params}"
+    );
+}
+
+#[test]
+fn config_watcher_includes_an_explicit_config_path() {
+    let root = tempdir().expect("tempdir");
+    let config = root.path().join("custom.toml");
+    std::fs::write(&config, TRAILING).expect("config");
+    let config_path = config.display().to_string().replace('\\', "/");
+    let options = json!({ "configPath": config_path });
+    let (client, _init) =
+        Client::launch_with(None, Some(root.path()), true, None, true, Some(options));
+    let request = client.recv_request();
+    assert_eq!(request.method, "client/registerCapability");
+    let params = request.params.to_string();
+    assert!(
+        params.contains("custom.toml"),
+        "an explicit configPath (non-standard name) is also watched: {params}"
+    );
+}
+
+#[test]
+fn watched_file_change_relints_open_documents() {
+    // Start under a config that does not flag the trailing space.
+    let dir = project("[rules]\nkey-duplicates = \"enable\"\n");
+    let (client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, true, None);
+    assert_eq!(
+        client.recv_request().method,
+        "client/registerCapability",
+        "the watcher is registered first"
+    );
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc, "a: 1 \n");
+    assert!(
+        client.diagnostics().is_empty(),
+        "clean under the initial config"
+    );
+    // Swap in a config that enables trailing-spaces, then signal the watcher.
+    std::fs::write(dir.path().join(".ryl.toml"), TRAILING).expect("rewrite config");
+    client.notify("workspace/didChangeWatchedFiles", json!({ "changes": [] }));
+    assert_eq!(
+        client.diagnostics().len(),
+        1,
+        "the new on-disk config re-lints the open document"
+    );
+}
+
+#[test]
+fn config_data_init_option_enables_linting() {
+    // An empty workspace root with no project config: only the inline configData makes
+    // trailing-spaces apply to the untitled buffer.
+    let root = tempdir().expect("tempdir");
+    let options = json!({ "configData": "rules:\n  trailing-spaces: enable\n" });
+    let (client, _init) =
+        Client::launch_with(None, Some(root.path()), true, None, false, Some(options));
+    client.did_open(uri("untitled:Untitled-cfg"), "a: 1 \n");
+    assert_eq!(
+        client.diagnostics().len(),
+        1,
+        "inline configData enables the rule for an otherwise config-less buffer"
+    );
+}
+
+#[test]
+fn enable_false_turns_linting_off() {
+    let dir = project(TRAILING);
+    let options = json!({ "enable": false });
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, Some(options));
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    assert!(
+        client.diagnostics().is_empty(),
+        "ryl is turned off via enable=false"
+    );
+    assert!(client.code_action(doc).is_none(), "and offers no actions");
+}
+
+#[test]
+fn did_change_configuration_updates_settings_and_relints() {
+    let dir = project(TRAILING);
+    let options = json!({ "enable": false });
+    let (client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, Some(options));
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc, "a: 1 \n");
+    assert!(client.diagnostics().is_empty(), "disabled at start");
+    client.notify(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "ryl": { "enable": true } } }),
+    );
+    assert_eq!(
+        client.diagnostics().len(),
+        1,
+        "re-enabling via didChangeConfiguration re-lints open docs"
+    );
+}
+
+#[test]
+fn hover_reports_the_rule_and_docs_link() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    let _ = client.diagnostics();
+    // The trailing space is column 5 (1-based) -> 0-based character 4.
+    let hover = client
+        .hover(&doc, 0, 4)
+        .expect("hovering the flagged position");
+    let HoverContents::Markup(markup) = hover.contents else {
+        panic!("expected markup contents");
+    };
+    assert!(markup.value.contains("trailing-spaces"), "names the rule");
+    assert!(
+        markup.value.contains("ryl-docs.pages.dev/rules"),
+        "links to the rules reference"
+    );
+}
+
+#[test]
+fn hover_off_a_diagnostic_is_null() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    let _ = client.diagnostics();
+    assert!(
+        client.hover(&doc, 0, 0).is_none(),
+        "no diagnostic covers the start of the line"
+    );
+}
+
+#[test]
+fn code_action_offers_disable_and_per_rule_fixes() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    let _ = client.diagnostics();
+    let actions = client
+        .code_action_with_diagnostics(doc, vec![diag("trailing-spaces", 0, 4)])
+        .expect("a flagged document offers actions");
+    let titles: Vec<&str> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionOrCommand::Command(_) => None,
+        })
+        .collect();
+    assert!(
+        titles.contains(&"Fix all ryl problems"),
+        "fix-all: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Fix all trailing-spaces problems"),
+        "per-rule fix-all: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Disable trailing-spaces for this line"),
+        "disable-line: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Disable ryl for this file"),
+        "disable-file: {titles:?}"
+    );
+}
+
+#[test]
+fn disable_line_action_inserts_a_directive_above_the_line() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    let _ = client.diagnostics();
+    let actions = client
+        .code_action_with_diagnostics(doc, vec![diag("trailing-spaces", 0, 4)])
+        .expect("actions offered");
+    let action = actions
+        .iter()
+        .find_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action)
+                if action.title == "Disable trailing-spaces for this line" =>
+            {
+                Some(action)
+            }
+            _ => None,
+        })
+        .expect("the disable-line action is present");
+    let Some(DocumentChanges::Edits(edits)) = action
+        .edit
+        .as_ref()
+        .and_then(|edit| edit.document_changes.as_ref())
+    else {
+        panic!("expected a versioned edit");
+    };
+    let OneOf::Left(text_edit) = &edits[0].edits[0] else {
+        panic!("expected a plain TextEdit");
+    };
+    assert_eq!(
+        text_edit.new_text, "# ryl disable-line rule:trailing-spaces\n",
+        "inserts the directive on its own line"
+    );
+    assert_eq!(
+        (text_edit.range.start.line, text_edit.range.start.character),
+        (0, 0),
+        "above the diagnostic's line"
+    );
+}
+
+#[test]
+fn incremental_change_patches_the_document() {
+    let dir = project(TRAILING);
+    let (client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1\n");
+    assert!(client.diagnostics().is_empty(), "clean on open");
+    // Insert a trailing space at the end of the first line's content.
+    let at_eol = Range::new(Position::new(0, 4), Position::new(0, 4));
+    client.did_change_range(doc, 2, at_eol, " ");
+    assert_eq!(
+        client.diagnostics().len(),
+        1,
+        "the incrementally inserted space is flagged"
+    );
+}
+
+#[test]
+fn rename_rewrites_an_anchor_and_its_aliases() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: &anchor 1\nb: *anchor\n");
+    let _ = client.diagnostics();
+    let prepared = client
+        .prepare_rename(&doc, 0, 6)
+        .expect("the anchor name is renameable");
+    let PrepareRenameResponse::RangeWithPlaceholder { placeholder, .. } = prepared
+    else {
+        panic!("expected a range + placeholder");
+    };
+    assert_eq!(placeholder, "anchor");
+    let response = client.rename(&doc, 0, 6, "renamed");
+    let edit: WorkspaceEdit =
+        serde_json::from_value(response.result.expect("rename produces an edit"))
+            .expect("workspace edit");
+    let Some(DocumentChanges::Edits(edits)) = edit.document_changes else {
+        panic!("expected versioned document changes");
+    };
+    assert_eq!(
+        edits[0].edits.len(),
+        2,
+        "the anchor and its alias are renamed"
+    );
+}
+
+#[test]
+fn rename_rejects_an_illegal_name() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: &anchor 1\n");
+    let _ = client.diagnostics();
+    let response = client.rename(&doc, 0, 6, "bad name");
+    assert!(response.error.is_some(), "a name with a space is rejected");
+}
+
+#[test]
+fn rename_off_an_anchor_is_null() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1\n");
+    let _ = client.diagnostics();
+    let response = client.rename(&doc, 0, 0, "x");
+    assert_eq!(response.result, Some(Value::Null), "nothing to rename here");
+    assert!(response.error.is_none());
+}
+
+#[test]
+fn code_action_offers_no_disable_actions_for_markdown() {
+    let dir = project(
+        "[files]\nmarkdown = [\"*.md\"]\n[rules]\ntrailing-spaces = \"enable\"\n",
+    );
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.md");
+    client.did_open(doc.clone(), "```yaml\na: 1 \n```\n");
+    let _ = client.diagnostics();
+    // The trailing space is on the embedded-YAML line; a disable comment can't be inserted
+    // reliably into a Markdown host, so only the (region-aware) fix-all is offered.
+    let actions = client
+        .code_action_with_diagnostics(doc, vec![diag("trailing-spaces", 1, 4)])
+        .expect("fix-all is offered for markdown");
+    let titles: Vec<&str> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionOrCommand::Command(_) => None,
+        })
+        .collect();
+    assert!(titles.contains(&"Fix all ryl problems"), "{titles:?}");
+    assert!(
+        !titles.iter().any(|title| title.starts_with("Disable")),
+        "no disable actions are offered for a markdown document: {titles:?}"
+    );
+}
+
+#[test]
+fn rename_is_disabled_for_markdown_documents() {
+    let dir = project(
+        "[files]\nmarkdown = [\"*.md\"]\n[rules]\ntrailing-spaces = \"enable\"\n",
+    );
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.md");
+    client.did_open(doc.clone(), "```yaml\na: &anchor 1\n```\n");
+    let _ = client.diagnostics();
+    assert!(
+        client.prepare_rename(&doc, 1, 6).is_none(),
+        "rename targets YAML documents, not markdown hosts"
+    );
+}
+
+#[test]
+fn document_diagnostic_pull_reports_open_and_disk_files() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let open = file_uri(dir.path(), "open.yaml");
+    client.did_open(open.clone(), "a: 1 \n");
+    let _ = client.diagnostics();
+    let DocumentDiagnosticReport::Full(report) = client.document_diagnostic(&open)
+    else {
+        panic!("expected a full report");
+    };
+    assert_eq!(
+        report.full_document_diagnostic_report.items.len(),
+        1,
+        "the open buffer is linted on pull"
+    );
+    // A file only on disk is read and linted too.
+    std::fs::write(dir.path().join("disk.yaml"), "b: 2 \n").expect("write disk file");
+    let on_disk = file_uri(dir.path(), "disk.yaml");
+    let DocumentDiagnosticReport::Full(report) = client.document_diagnostic(&on_disk)
+    else {
+        panic!("expected a full report");
+    };
+    assert_eq!(
+        report.full_document_diagnostic_report.items.len(),
+        1,
+        "a closed file is read from disk and linted"
+    );
+}
+
+#[test]
+fn document_diagnostic_pull_is_empty_for_unreadable_targets() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let missing = file_uri(dir.path(), "nope.yaml");
+    let DocumentDiagnosticReport::Full(report) = client.document_diagnostic(&missing)
+    else {
+        panic!("expected a full report");
+    };
+    assert!(
+        report.full_document_diagnostic_report.items.is_empty(),
+        "a missing file yields no diagnostics"
+    );
+    let DocumentDiagnosticReport::Full(report) =
+        client.document_diagnostic(&uri("untitled:none"))
+    else {
+        panic!("expected a full report");
+    };
+    assert!(
+        report.full_document_diagnostic_report.items.is_empty(),
+        "an unopened untitled buffer has no path to read"
+    );
+}
+
+#[test]
+fn workspace_diagnostic_pull_reports_repo_files() {
+    let dir = project(TRAILING);
+    std::fs::write(dir.path().join("bad.yaml"), "a: 1 \n").expect("write bad");
+    std::fs::write(dir.path().join("good.yaml"), "a: 1\n").expect("write good");
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, None);
+    let report = client.workspace_diagnostic();
+    let bad = report
+        .items
+        .iter()
+        .find_map(|item| match item {
+            WorkspaceDocumentDiagnosticReport::Full(full)
+                if full.uri.as_str().ends_with("bad.yaml") =>
+            {
+                Some(full)
+            }
+            _ => None,
+        })
+        .expect("bad.yaml is reported");
+    assert_eq!(
+        bad.full_document_diagnostic_report.items.len(),
+        1,
+        "the trailing space in bad.yaml is reported"
+    );
+}
+
+#[test]
+fn code_action_ignores_a_foreign_servers_diagnostics() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n"); // a real trailing space -> fix-all available
+    let _ = client.diagnostics();
+    // A diagnostic from a coexisting server (e.g. yaml-language-server) must not produce
+    // ryl disable/per-rule actions or a "disable ryl" action.
+    let foreign = Diagnostic {
+        range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+        code: Some(NumberOrString::String("schema-error".to_string())),
+        source: Some("yaml-language-server".to_string()),
+        ..Default::default()
+    };
+    let actions = client
+        .code_action_with_diagnostics(doc, vec![foreign])
+        .expect("the whole-file fix-all is still offered from the text");
+    let titles: Vec<&str> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionOrCommand::Command(_) => None,
+        })
+        .collect();
+    assert!(titles.contains(&"Fix all ryl problems"), "{titles:?}");
+    assert!(
+        !titles.iter().any(|title| title.starts_with("Disable")),
+        "no disable actions for a foreign diagnostic: {titles:?}"
+    );
+}
+
+#[test]
+fn document_diagnostic_pull_surfaces_a_config_error() {
+    let dir = project("this is not valid toml = =\n");
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1\n");
+    let _ = client.diagnostics();
+    let DocumentDiagnosticReport::Full(report) = client.document_diagnostic(&doc)
+    else {
+        panic!("expected a full report");
+    };
+    let items = report.full_document_diagnostic_report.items;
+    assert_eq!(items.len(), 1, "the config error surfaces as a diagnostic");
+    assert!(
+        items[0].message.contains("configuration error"),
+        "{:?}",
+        items[0].message
+    );
+}
+
+#[test]
+fn workspace_diagnostic_pull_surfaces_a_config_error() {
+    let dir = project("this is not valid toml = =\n");
+    std::fs::write(dir.path().join("a.yaml"), "x: 1\n").expect("write");
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, None);
+    let report = client.workspace_diagnostic();
+    let surfaced = report.items.iter().any(|item| match item {
+        WorkspaceDocumentDiagnosticReport::Full(full) => full
+            .full_document_diagnostic_report
+            .items
+            .iter()
+            .any(|d| d.message.contains("configuration error")),
+        WorkspaceDocumentDiagnosticReport::Unchanged(_) => false,
+    });
+    assert!(
+        surfaced,
+        "a malformed config surfaces as an error diagnostic, not a silent clean report"
+    );
+}
+
+#[test]
+fn workspace_diagnostic_pull_spans_multiple_roots_and_dedups() {
+    let dir = project(TRAILING);
+    std::fs::write(dir.path().join("bad.yaml"), "a: 1 \n").expect("write");
+    // The same directory advertised as two roots: every file is walked twice, so the
+    // report must de-duplicate it to one entry.
+    let (mut client, _init) = Client::launch_roots(&[dir.path(), dir.path()]);
+    let report = client.workspace_diagnostic();
+    let bad_reports = report
+        .items
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                WorkspaceDocumentDiagnosticReport::Full(full)
+                    if full.uri.as_str().ends_with("bad.yaml")
+            )
+        })
+        .count();
+    assert_eq!(
+        bad_reports, 1,
+        "a file reachable from two roots is reported once"
+    );
+}
+
+#[test]
+fn workspace_diagnostic_can_be_cancelled() {
+    let dir = project(TRAILING);
+    std::fs::write(dir.path().join("a.yaml"), "a: 1 \n").expect("write");
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, None);
+    let id = client.request("workspace/diagnostic", json!({ "previousResultIds": [] }));
+    // Cancel by id. Depending on the race the worker answers with the report or a
+    // RequestCancelled error, but the request is always answered (the loop never hangs).
+    client.notify("$/cancelRequest", json!({ "id": client.next_id }));
+    let response = client.response(&id);
+    assert!(
+        response.result.is_some() || response.error.is_some(),
+        "a cancelled workspace pull is always answered"
+    );
+}
+
+#[test]
+fn cancel_request_for_unknown_or_malformed_id_is_ignored() {
+    let dir = project(TRAILING);
+    std::fs::write(dir.path().join("a.yaml"), "a: 1 \n").expect("write");
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, None);
+    let id = client.request("workspace/diagnostic", json!({ "previousResultIds": [] }));
+    // A string id matches no in-flight scan; a malformed params is ignored entirely.
+    client.notify("$/cancelRequest", json!({ "id": "no-such-request" }));
+    client.notify("$/cancelRequest", json!("not the params shape"));
+    let _ = client.response(&id); // the pull still completes
+    client.assert_alive();
+}
+
+#[test]
+fn workspace_diagnostic_reaps_finished_workers() {
+    let dir = project(TRAILING);
+    std::fs::write(dir.path().join("a.yaml"), "a: 1\n").expect("write");
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, None);
+    // Two sequential pulls: the second's spawn reaps the first's finished worker.
+    let _ = client.workspace_diagnostic();
+    let _ = client.workspace_diagnostic();
+    client.assert_alive();
+}
+
+#[test]
+fn workspace_diagnostic_without_a_root_is_empty() {
+    let (mut client, _init) = Client::launch(None, None);
+    assert!(
+        client.workspace_diagnostic().items.is_empty(),
+        "without a workspace root there is nothing to scan"
+    );
+}
+
+#[test]
+fn workspace_diagnostic_pull_handles_open_ignored_and_unreadable_files() {
+    let dir =
+        project("ignore = [\"skip.yaml\"]\n[rules]\ntrailing-spaces = \"enable\"\n");
+    std::fs::write(dir.path().join("bad.yaml"), "a: 1 \n").expect("bad");
+    std::fs::write(dir.path().join("skip.yaml"), "a: 1 \n").expect("ignored");
+    // A UTF-16 LE BOM followed by an odd byte count cannot be decoded.
+    std::fs::write(dir.path().join("binary.yaml"), [0xFF, 0xFE, 0x41])
+        .expect("undecodable");
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, None);
+    // Open one walked file (so the open-buffer text is used) and an untitled buffer (a
+    // non-file URI the open map skips).
+    client.did_open(file_uri(dir.path(), "bad.yaml"), "a: 1 \n");
+    let _ = client.diagnostics();
+    client.did_open(uri("untitled:ws"), "a: 1\n");
+    let _ = client.diagnostics();
+    let report = client.workspace_diagnostic();
+    let paths: Vec<&str> = report
+        .items
+        .iter()
+        .map(|item| match item {
+            WorkspaceDocumentDiagnosticReport::Full(full) => full.uri.as_str(),
+            WorkspaceDocumentDiagnosticReport::Unchanged(unchanged) => {
+                unchanged.uri.as_str()
+            }
+        })
+        .collect();
+    assert!(
+        paths.iter().any(|path| path.ends_with("bad.yaml")),
+        "the open walked file is reported: {paths:?}"
+    );
+    assert!(
+        !paths.iter().any(|path| path.ends_with("skip.yaml")),
+        "the config-ignored file is skipped: {paths:?}"
+    );
+    assert!(
+        !paths.iter().any(|path| path.ends_with("binary.yaml")),
+        "the undecodable file is skipped: {paths:?}"
+    );
+}
+
+#[test]
+fn config_path_init_option_points_at_a_config_file() {
+    let root = tempdir().expect("tempdir");
+    let config = root.path().join("custom.toml");
+    std::fs::write(&config, TRAILING).expect("write config");
+    let config_path = config.display().to_string().replace('\\', "/");
+    let options = json!({ "configPath": config_path });
+    let (client, _init) =
+        Client::launch_with(None, Some(root.path()), true, None, false, Some(options));
+    client.did_open(uri("untitled:cfg-path"), "a: 1 \n");
+    assert_eq!(
+        client.diagnostics().len(),
+        1,
+        "configPath supplies the rules for an otherwise config-less buffer"
+    );
+}
+
+#[test]
+fn malformed_did_change_configuration_is_ignored() {
+    let (mut client, _init) = Client::launch(None, None);
+    client.notify(
+        "workspace/didChangeConfiguration",
+        Value::String("bad".to_string()),
+    );
+    client.assert_alive();
+}
+
+#[test]
+fn incremental_change_ignores_a_reversed_range() {
+    let dir = project(TRAILING);
+    let (client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1\n");
+    assert!(client.diagnostics().is_empty(), "clean on open");
+    // A reversed range (start after end) is skipped, leaving the document unchanged.
+    let reversed = Range::new(Position::new(0, 4), Position::new(0, 0));
+    client.did_change_range(doc, 2, reversed, " ");
+    assert!(
+        client.diagnostics().is_empty(),
+        "a reversed-range edit is ignored, so no problem appears"
+    );
+}
+
+#[test]
+fn formatting_with_unresolvable_config_is_null() {
+    let dir = project("this is not valid toml = =\n");
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    let _ = client.diagnostics();
+    assert!(
+        client.formatting(doc).is_none(),
+        "no resolvable config -> nothing to format"
+    );
+}
+
+#[test]
+fn prepare_rename_on_an_unopened_document_is_null() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    assert!(
+        client
+            .prepare_rename(&file_uri(dir.path(), "never.yaml"), 0, 0)
+            .is_none(),
+        "an unopened document has no buffer to rename in"
+    );
+}
+
+#[test]
+fn malformed_rename_params_yield_a_null_result() {
+    let (mut client, _init) = Client::launch(None, None);
+    let id = client.request("textDocument/rename", Value::String("bad".to_string()));
+    let response = client.response(&id);
+    assert_eq!(
+        response.result,
+        Some(Value::Null),
+        "bad rename params -> null"
+    );
+}
+
+#[test]
+fn rename_on_an_unopened_document_is_null() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let response = client.rename(&file_uri(dir.path(), "never.yaml"), 0, 0, "x");
+    assert_eq!(
+        response.result,
+        Some(Value::Null),
+        "an unopened document yields no rename edit"
+    );
+}
+
+#[test]
+fn rename_on_a_markdown_document_is_null() {
+    let dir = project(
+        "[files]\nmarkdown = [\"*.md\"]\n[rules]\ntrailing-spaces = \"enable\"\n",
+    );
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.md");
+    client.did_open(doc.clone(), "```yaml\na: &anchor 1\n```\n");
+    let _ = client.diagnostics();
+    let response = client.rename(&doc, 1, 6, "renamed");
+    assert_eq!(
+        response.result,
+        Some(Value::Null),
+        "rename targets YAML documents, not markdown hosts"
+    );
+}
+
+#[test]
+fn code_action_handles_edge_case_diagnostics() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    let _ = client.diagnostics();
+    let mut rule_less = diag("trailing-spaces", 0, 4);
+    rule_less.code = None; // a syntax-style diagnostic the client may echo back
+    let diagnostics = vec![
+        diag("trailing-spaces", 0, 4),
+        diag("trailing-spaces", 0, 4), // duplicate (rule, line) -> deduped
+        diag("commas", 0, 0),          // fixable, but no comma fix applies here
+        diag("trailing-spaces", 99, 0), // line past the document -> no disable action
+        diag("not-a-real-rule", 0, 0), // ryl-sourced but unknown rule id -> skipped
+        rule_less,                     // no rule code -> skipped
+    ];
+    let actions = client
+        .code_action_with_diagnostics(doc, diagnostics)
+        .expect("at least the fix-all action is offered");
+    let titles: Vec<&str> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionOrCommand::Command(_) => None,
+        })
+        .collect();
+    assert!(
+        !titles.contains(&"Fix all commas problems"),
+        "no per-rule action when that rule changes nothing: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Fix all trailing-spaces problems"),
+        "the rule that does have a fix is offered: {titles:?}"
+    );
+    let trailing_disables = titles
+        .iter()
+        .filter(|title| title.starts_with("Disable trailing-spaces"))
+        .count();
+    assert_eq!(
+        trailing_disables, 1,
+        "the duplicate is deduped and the out-of-range line is dropped: {titles:?}"
+    );
+}
+
+#[test]
+fn disable_line_is_not_offered_inside_a_block_scalar() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    // The trailing space on line 2 (0-based) is inside a literal block scalar, where a
+    // `# ryl disable-line` insert would be scalar content rather than a directive.
+    client.did_open(doc.clone(), "key: |\n  aaa\n  bbb \nmore: 1\n");
+    let _ = client.diagnostics();
+    let actions = client
+        .code_action_with_diagnostics(doc, vec![diag("trailing-spaces", 2, 7)])
+        .expect("disable-file is still offered");
+    let titles: Vec<&str> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionOrCommand::Command(_) => None,
+        })
+        .collect();
+    assert!(
+        !titles
+            .iter()
+            .any(|title| title.starts_with("Disable trailing-spaces for this line")),
+        "no disable-line action inside a block scalar: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Disable ryl for this file"),
+        "the whole-file disable is still offered: {titles:?}"
+    );
+}
+
+#[test]
+fn disable_line_is_not_offered_inside_a_multiline_quoted_scalar() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    // A double-quoted scalar continued onto line 2 (0-based 1): a disable-line insert there
+    // would land inside the still-open quote and corrupt the value, so it is not offered.
+    client.did_open(doc.clone(), "key: \"first\n  second\"\n");
+    let _ = client.diagnostics();
+    let actions = client
+        .code_action_with_diagnostics(doc, vec![diag("trailing-spaces", 1, 2)])
+        .expect("disable-file is still offered");
+    let titles: Vec<&str> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionOrCommand::Command(_) => None,
+        })
+        .collect();
+    assert!(
+        !titles
+            .iter()
+            .any(|title| title.starts_with("Disable trailing-spaces for this line")),
+        "no disable-line inside a multiline quoted scalar: {titles:?}"
+    );
+}
+
+#[test]
+fn disable_line_is_suppressed_when_the_document_cannot_parse() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    // The undefined alias makes the document unparsable, so block-scalar detection fails
+    // and a disable-line could land in the literal block's content. Suppress it (but the
+    // line-0 disable-file prepend is always safe).
+    client.did_open(doc.clone(), "a: |\n  text \nb: *undefined\n");
+    let _ = client.diagnostics();
+    let actions = client
+        .code_action_with_diagnostics(doc, vec![diag("trailing-spaces", 1, 6)])
+        .expect("disable-file is still offered");
+    let titles: Vec<&str> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionOrCommand::Command(_) => None,
+        })
+        .collect();
+    assert!(
+        !titles
+            .iter()
+            .any(|title| title.starts_with("Disable trailing-spaces for this line")),
+        "no disable-line when block-scalar detection cannot run: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Disable ryl for this file"),
+        "the line-0 disable-file is still offered: {titles:?}"
+    );
+}
+
+#[test]
+fn rename_respects_enable_false() {
+    let dir = project(TRAILING);
+    let options = json!({ "enable": false });
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, Some(options));
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: &anchor 1\n");
+    let _ = client.diagnostics();
+    assert!(
+        client.prepare_rename(&doc, 0, 6).is_none(),
+        "rename is off when ryl is disabled"
+    );
+}
+
+#[test]
+fn prepare_rename_with_unresolvable_config_is_null() {
+    let dir = project("this is not valid toml = =\n");
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: &anchor 1\n");
+    let _ = client.diagnostics();
+    assert!(
+        client.prepare_rename(&doc, 0, 6).is_none(),
+        "a broken config disables rename too"
+    );
+}
+
+#[test]
+fn rename_works_on_an_untitled_yaml_buffer() {
+    let dir = project(TRAILING);
+    let (mut client, _init) =
+        Client::launch_with(None, Some(dir.path()), true, None, false, None);
+    let doc = uri("untitled:anchors");
+    client.did_open(doc.clone(), "a: &anchor 1\nb: *anchor\n");
+    let _ = client.diagnostics();
+    assert!(
+        client.prepare_rename(&doc, 0, 6).is_some(),
+        "an untitled YAML buffer's anchors are renameable"
+    );
+}
+
+#[test]
+fn prepare_rename_on_an_ignored_file_is_null() {
+    let dir =
+        project("ignore = [\"skip.yaml\"]\n[rules]\ntrailing-spaces = \"enable\"\n");
+    let (mut client, _init) = Client::launch(None, None);
+    let doc = file_uri(dir.path(), "skip.yaml");
+    client.did_open(doc.clone(), "a: &anchor 1\n");
+    let _ = client.diagnostics();
+    assert!(
+        client.prepare_rename(&doc, 0, 6).is_none(),
+        "a config-ignored file is not renameable"
     );
 }
 

--- a/tests/lsp_unit.rs
+++ b/tests/lsp_unit.rs
@@ -5,14 +5,24 @@
 //! `file:` URI decoding, whole-document edit ranges) cheaply and exhaustively.
 
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 
-use lsp_types::PositionEncodingKind;
+use lsp_server::{ErrorCode, RequestId};
+use lsp_types::{
+    Diagnostic, NumberOrString, Position, PositionEncodingKind, PrepareRenameResponse,
+    Range,
+};
+use tempfile::tempdir;
 
 use ryl::config::{SourceKind, YamlLintConfig};
-use ryl::lsp::analysis::{diagnostics, fix_all_edit};
+use ryl::lsp::analysis::{diagnostics, fix_all_edit, fix_rule_edit};
 use ryl::lsp::encoding::{
-    PositionEncoding, full_range, negotiate, problem_range, uri_to_path,
+    PositionEncoding, full_range, negotiate, offset_at, path_to_uri, problem_range,
+    range_contains, uri_to_path,
 };
+use ryl::lsp::hover::hover;
+use ryl::lsp::rename::{prepare_rename, rename_edits};
+use ryl::lsp::{OpenText, Settings, workspace_response, workspace_scan};
 
 #[test]
 fn negotiate_prefers_clients_first_supported_kind() {
@@ -148,6 +158,24 @@ fn full_range_of_empty_text_is_zero_width() {
         "empty start"
     );
     assert_eq!((range.end.line, range.end.character), (0, 0), "empty end");
+}
+
+#[test]
+fn range_contains_is_end_exclusive_except_for_zero_width() {
+    let one_char = Range::new(Position::new(0, 3), Position::new(0, 4));
+    assert!(
+        range_contains(one_char, Position::new(0, 3)),
+        "the start is inclusive"
+    );
+    assert!(
+        !range_contains(one_char, Position::new(0, 4)),
+        "the end is exclusive, so a cursor just past the token does not match"
+    );
+    let zero_width = Range::new(Position::new(0, 3), Position::new(0, 3));
+    assert!(
+        range_contains(zero_width, Position::new(0, 3)),
+        "a zero-width range (an end-of-line diagnostic) matches at its point"
+    );
 }
 
 #[test]
@@ -376,5 +404,421 @@ fn fix_all_edit_skips_markdown_with_an_unsupported_bare_cr() {
         )
         .is_none(),
         "a bare CR markdown host is left untouched"
+    );
+}
+
+// --- offset_at: the inverse of the forward column conversion (incremental sync) ---
+
+#[test]
+fn offset_at_counts_code_units_across_an_astral_char() {
+    // "a: 😀 b": the emoji is 1 code point / 2 UTF-16 units / 4 UTF-8 bytes, so the byte
+    // offset of `b` (8) is reached at a different `character` per encoding.
+    let text = "a: \u{1F600} b";
+    assert_eq!(
+        offset_at(text, Position::new(0, 6), PositionEncoding::Utf16),
+        8,
+        "UTF-16: a,:,space=3 + emoji=2 + space=1 -> char 6 is byte 8"
+    );
+    assert_eq!(
+        offset_at(text, Position::new(0, 8), PositionEncoding::Utf8),
+        8,
+        "UTF-8: the emoji is 4 bytes"
+    );
+    assert_eq!(
+        offset_at(text, Position::new(0, 5), PositionEncoding::Utf32),
+        8,
+        "UTF-32: the emoji is one unit"
+    );
+}
+
+#[test]
+fn offset_at_snaps_a_mid_surrogate_character_to_the_char_start() {
+    // UTF-16 character 4 lands inside the surrogate pair of the emoji at byte 3.
+    let text = "a: \u{1F600} b";
+    assert_eq!(
+        offset_at(text, Position::new(0, 4), PositionEncoding::Utf16),
+        3,
+        "a mid-char position snaps back to the char start"
+    );
+}
+
+#[test]
+fn offset_at_clamps_columns_and_lines_past_the_end() {
+    let text = "ab\ncd";
+    assert_eq!(
+        offset_at(text, Position::new(0, 99), PositionEncoding::Utf16),
+        2,
+        "a character past the line clamps to its content end"
+    );
+    assert_eq!(
+        offset_at(text, Position::new(1, 1), PositionEncoding::Utf16),
+        4,
+        "second line, second char"
+    );
+    assert_eq!(
+        offset_at(text, Position::new(9, 0), PositionEncoding::Utf16),
+        text.len(),
+        "a line past the document clamps to the text end"
+    );
+}
+
+#[test]
+fn offset_at_handles_a_phantom_line_after_a_trailing_break() {
+    assert_eq!(
+        offset_at("ab\n", Position::new(1, 0), PositionEncoding::Utf16),
+        3,
+        "the position after a trailing break is the text end"
+    );
+    assert_eq!(
+        offset_at("", Position::new(0, 0), PositionEncoding::Utf16),
+        0,
+        "empty text"
+    );
+}
+
+// --- path_to_uri: inverse of uri_to_path, round-tripping local paths ---
+
+#[test]
+fn path_to_uri_round_trips_a_path_with_spaces() {
+    let uri = path_to_uri(Path::new("/home/u/a b.yaml"));
+    assert_eq!(
+        uri.as_str(),
+        "file:///home/u/a%20b.yaml",
+        "space is encoded"
+    );
+    assert_eq!(
+        uri_to_path(uri.as_str()).expect("uri -> path"),
+        Path::new("/home/u/a b.yaml"),
+        "round-trips back to the original path"
+    );
+}
+
+#[test]
+fn path_to_uri_adds_the_leading_slash_for_a_drive_path() {
+    let uri = path_to_uri(Path::new("C:/proj/x.yaml"));
+    assert_eq!(
+        uri.as_str(),
+        "file:///C:/proj/x.yaml",
+        "drive gets a leading slash"
+    );
+}
+
+// --- fix_rule_edit: a single rule's safe fix in isolation ---
+
+#[test]
+fn fix_rule_edit_fixes_only_the_named_rule() {
+    // Two fixable problems: a comma-spacing issue and a trailing space.
+    let cfg = yaml_cfg("[rules]\ntrailing-spaces = \"enable\"\ncommas = \"enable\"\n");
+    let source = "a: [1 ,2] \n";
+    let trailing = fix_rule_edit(
+        source,
+        Path::new("/proj/x.yaml"),
+        &cfg,
+        Path::new("/proj"),
+        SourceKind::Yaml,
+        PositionEncoding::Utf16,
+        "trailing-spaces",
+    )
+    .expect("trailing-spaces is fixable here");
+    assert_eq!(
+        trailing.new_text, "a: [1 ,2]\n",
+        "only the trailing space is removed; the comma spacing is left for its own rule"
+    );
+    let commas = fix_rule_edit(
+        source,
+        Path::new("/proj/x.yaml"),
+        &cfg,
+        Path::new("/proj"),
+        SourceKind::Yaml,
+        PositionEncoding::Utf16,
+        "commas",
+    )
+    .expect("commas is fixable here");
+    assert!(
+        commas.new_text.contains("[1, 2]") && commas.new_text.ends_with("] \n"),
+        "only comma spacing is fixed; the trailing space remains: {:?}",
+        commas.new_text
+    );
+}
+
+#[test]
+fn fix_rule_edit_is_none_for_an_unfixable_rule_or_markdown() {
+    let cfg = yaml_cfg("[rules]\ntrailing-spaces = \"enable\"\nanchors = \"enable\"\n");
+    assert!(
+        fix_rule_edit(
+            "a: 1 \n",
+            Path::new("/proj/x.yaml"),
+            &cfg,
+            Path::new("/proj"),
+            SourceKind::Yaml,
+            PositionEncoding::Utf16,
+            "anchors",
+        )
+        .is_none(),
+        "anchors has no safe fix"
+    );
+    assert!(
+        fix_rule_edit(
+            "```yaml\na: 1 \n```\n",
+            Path::new("/proj/x.md"),
+            &cfg,
+            Path::new("/proj"),
+            SourceKind::Markdown,
+            PositionEncoding::Utf16,
+            "trailing-spaces",
+        )
+        .is_none(),
+        "per-rule fix is not offered for markdown"
+    );
+}
+
+// --- hover: rule id + message + docs link for a covered position ---
+
+fn diagnostic(rule: Option<&str>, range: Range, message: &str) -> Diagnostic {
+    Diagnostic {
+        range,
+        code: rule.map(|rule| NumberOrString::String(rule.to_string())),
+        message: message.to_string(),
+        ..Default::default()
+    }
+}
+
+fn one_char(line: u32, character: u32) -> Range {
+    Range::new(
+        Position::new(line, character),
+        Position::new(line, character + 1),
+    )
+}
+
+#[test]
+fn hover_shows_the_rule_message_and_link_for_a_covered_position() {
+    let diags = vec![diagnostic(
+        Some("trailing-spaces"),
+        one_char(0, 4),
+        "trailing spaces",
+    )];
+    let hover = hover(&diags, Position::new(0, 4)).expect("position is covered");
+    let lsp_types::HoverContents::Markup(markup) = hover.contents else {
+        panic!("expected markup contents");
+    };
+    assert!(markup.value.contains("trailing-spaces"), "names the rule");
+    assert!(
+        markup.value.contains("trailing spaces"),
+        "shows the message"
+    );
+    assert!(
+        markup.value.contains("https://ryl-docs.pages.dev/rules/"),
+        "links to the rules reference"
+    );
+}
+
+#[test]
+fn hover_is_none_away_from_any_diagnostic() {
+    let diags = vec![diagnostic(Some("colons"), one_char(0, 4), "x")];
+    assert!(
+        hover(&diags, Position::new(2, 0)).is_none(),
+        "no diagnostic covers the position"
+    );
+}
+
+#[test]
+fn hover_lists_every_overlapping_diagnostic() {
+    let diags = vec![
+        diagnostic(Some("colons"), one_char(0, 3), "colon issue"),
+        diagnostic(None, one_char(0, 3), "syntax issue"),
+    ];
+    let hover = hover(&diags, Position::new(0, 3)).expect("covered");
+    let lsp_types::HoverContents::Markup(markup) = hover.contents else {
+        panic!("expected markup");
+    };
+    assert!(markup.value.contains("colon issue"), "first diagnostic");
+    assert!(
+        markup.value.contains("syntax issue"),
+        "rule-less diagnostic also listed"
+    );
+    assert!(
+        markup.value.contains("**ryl**"),
+        "rule-less heading is bare ryl"
+    );
+}
+
+// --- rename: anchor/alias spans, name validation, document scoping ---
+
+#[test]
+fn prepare_rename_reports_the_name_range_on_an_anchor() {
+    // "a: &anchor 1": the name `anchor` occupies 0-based chars 4..10.
+    let response = prepare_rename(
+        "a: &anchor 1\nb: *anchor\n",
+        Position::new(0, 6),
+        PositionEncoding::Utf16,
+    )
+    .expect("position is on an anchor name");
+    let PrepareRenameResponse::RangeWithPlaceholder { range, placeholder } = response
+    else {
+        panic!("expected a range + placeholder");
+    };
+    assert_eq!(placeholder, "anchor", "the current name is the placeholder");
+    assert_eq!(
+        (range.start.character, range.end.character),
+        (4, 10),
+        "the range covers the name, excluding the & sigil"
+    );
+}
+
+#[test]
+fn prepare_rename_is_none_off_an_anchor() {
+    assert!(
+        prepare_rename(
+            "plain: text\n",
+            Position::new(0, 0),
+            PositionEncoding::Utf16
+        )
+        .is_none(),
+        "an ordinary scalar is not renameable"
+    );
+}
+
+#[test]
+fn rename_edits_rewrite_the_anchor_and_its_aliases() {
+    let edits = rename_edits(
+        "a: &anchor 1\nb: *anchor\n",
+        Position::new(0, 6),
+        "renamed",
+        PositionEncoding::Utf16,
+    )
+    .expect("valid rename")
+    .expect("position is on an anchor");
+    assert_eq!(edits.len(), 2, "the anchor and its one alias are renamed");
+    assert!(
+        edits.iter().all(|edit| edit.new_text == "renamed"),
+        "every edit inserts the new name"
+    );
+}
+
+#[test]
+fn rename_edits_are_scoped_to_one_document() {
+    // The same name in two documents (separated by `---`) is two distinct anchors.
+    let edits = rename_edits(
+        "a: &x 1\n---\nb: &x 2\n",
+        Position::new(0, 4),
+        "y",
+        PositionEncoding::Utf16,
+    )
+    .expect("valid rename")
+    .expect("on the first anchor");
+    assert_eq!(
+        edits.len(),
+        1,
+        "only the first document's anchor is renamed"
+    );
+    assert_eq!(edits[0].range.start.line, 0, "the edit is on line 0");
+}
+
+#[test]
+fn rename_edits_reject_an_illegal_new_name() {
+    let source = "a: &anchor 1\n";
+    // Whitespace, flow indicators, the empty string, and control characters (which
+    // LSP/JSON can carry escaped, e.g. NUL) are all rejected.
+    for bad in ["with space", "a,b", "[x]", "", "ax\u{0}y"] {
+        assert!(
+            rename_edits(source, Position::new(0, 6), bad, PositionEncoding::Utf16)
+                .is_err(),
+            "{bad:?} is not a legal anchor name"
+        );
+    }
+}
+
+#[test]
+fn rename_edits_are_none_off_an_anchor() {
+    assert!(
+        rename_edits(
+            "plain: text\n",
+            Position::new(0, 0),
+            "x",
+            PositionEncoding::Utf16
+        )
+        .expect("no error")
+        .is_none(),
+        "nothing to rename away from an anchor"
+    );
+}
+
+#[test]
+fn rename_edits_reject_a_name_that_collides_with_another_anchor() {
+    // `*x` resolves to `&x`; renaming `x` -> `y` would silently rebind it to `&y`'s value.
+    let text = "a: &x 1\nb: &y 2\nc: *x\n";
+    assert!(
+        rename_edits(text, Position::new(0, 4), "y", PositionEncoding::Utf16).is_err(),
+        "renaming onto an existing anchor name is rejected"
+    );
+    assert!(
+        rename_edits(text, Position::new(0, 4), "z", PositionEncoding::Utf16)
+            .expect("a fresh name is valid")
+            .is_some(),
+        "renaming to an unused name is allowed"
+    );
+    assert!(
+        rename_edits(text, Position::new(0, 4), "x", PositionEncoding::Utf16)
+            .expect("the same name is valid")
+            .is_some(),
+        "renaming to the same name is a no-op, not a collision"
+    );
+}
+
+// --- workspace_scan / workspace_response: the background pull's pure core ---
+
+fn workspace_project() -> tempfile::TempDir {
+    // An adjacent .ryl.toml shields config discovery from the walk (no HOME needed).
+    let dir = tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".ryl.toml"),
+        "[rules]\ntrailing-spaces = \"enable\"\n",
+    )
+    .expect("config");
+    dir
+}
+
+#[test]
+fn workspace_scan_lints_each_root_file() {
+    let dir = workspace_project();
+    std::fs::write(dir.path().join("bad.yaml"), "a: 1 \n").expect("yaml");
+    let reports = workspace_scan(
+        &[dir.path().to_path_buf()],
+        &OpenText::new(),
+        &Settings::default(),
+        PositionEncoding::Utf16,
+        &AtomicBool::new(false),
+    )
+    .expect("an uncancelled scan returns reports");
+    assert!(!reports.is_empty(), "the flagged file is reported");
+}
+
+#[test]
+fn workspace_scan_returns_none_when_cancelled() {
+    let dir = workspace_project();
+    // A file must exist so the per-item cancel check in the parallel map runs.
+    std::fs::write(dir.path().join("a.yaml"), "a: 1\n").expect("yaml");
+    assert!(
+        workspace_scan(
+            &[dir.path().to_path_buf()],
+            &OpenText::new(),
+            &Settings::default(),
+            PositionEncoding::Utf16,
+            &AtomicBool::new(true),
+        )
+        .is_none(),
+        "a cancelled scan yields no report"
+    );
+}
+
+#[test]
+fn workspace_response_is_ok_or_cancelled() {
+    let ok = workspace_response(RequestId::from(1), Some(Vec::new()));
+    assert!(ok.error.is_none(), "a completed scan is an ok response");
+    let cancelled = workspace_response(RequestId::from(2), None);
+    assert_eq!(
+        cancelled.error.expect("a cancelled scan is an error").code,
+        ErrorCode::RequestCanceled as i32,
+        "cancellation maps to the RequestCancelled code"
     );
 }

--- a/tests/property_lsp.rs
+++ b/tests/property_lsp.rs
@@ -12,6 +12,9 @@
 //! - `uri_to_path` is total (never panics, whatever the input).
 //! - the fix-all edit, applied via an *independent* position->byte converter,
 //!   reproduces `apply_safe_fixes` exactly (so `full_range` covers the document).
+//! - `offset_at` (the inverse converter for incremental sync) is bounded, lands on a
+//!   char boundary, and is monotone in the column.
+//! - renaming an anchor rewrites every same-name occurrence in its document.
 
 #[path = "property_check/harness.rs"]
 #[allow(dead_code)] // shared harness; this suite uses only a few of its helpers
@@ -21,13 +24,15 @@ mod strategy;
 
 use std::path::Path;
 
+use lsp_types::Position;
 use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
 
 use ryl::config::SourceKind;
 use ryl::fix::apply_safe_fixes;
 use ryl::lsp::analysis::{diagnostics, fix_all_edit};
-use ryl::lsp::encoding::{PositionEncoding, problem_range, uri_to_path};
+use ryl::lsp::encoding::{PositionEncoding, offset_at, problem_range, uri_to_path};
+use ryl::lsp::rename::rename_edits;
 
 use harness::trigger_all_config;
 use strategy::arb_document;
@@ -55,6 +60,17 @@ fn arb_line() -> impl Strategy<Value = String> {
             .filter(|ch| *ch != '\n' && *ch != '\r')
             .collect()
     })
+}
+
+/// A few lines joined with assorted YAML 1.2 breaks, for exercising the CR-aware
+/// inverse converter over multibyte, multi-line input.
+fn arb_text() -> impl Strategy<Value = String> {
+    let part = (
+        arb_line(),
+        prop_oneof![Just("\n"), Just("\r\n"), Just("\r")],
+    );
+    prop::collection::vec(part, 0..5)
+        .prop_map(|parts| parts.into_iter().map(|(l, b)| format!("{l}{b}")).collect())
 }
 
 /// URIs biased toward `file:` forms (plus arbitrary strings) to exercise the
@@ -172,6 +188,37 @@ proptest! {
     #[test]
     fn uri_to_path_is_total(uri in arb_uri()) {
         let _ = uri_to_path(&uri);
+    }
+
+    #[test]
+    fn offset_at_is_bounded_on_a_boundary_and_monotone(
+        text in arb_text(),
+        line in 0u32..6,
+        character in 0u32..40,
+    ) {
+        for enc in ENCODINGS {
+            let offset = offset_at(&text, Position::new(line, character), enc);
+            prop_assert!(offset <= text.len(), "never past the end");
+            prop_assert!(
+                text.is_char_boundary(offset),
+                "offset lands on a char boundary so a splice is valid"
+            );
+            let next = offset_at(&text, Position::new(line, character + 1), enc);
+            prop_assert!(next >= offset, "monotone in the column");
+        }
+    }
+
+    #[test]
+    fn rename_rewrites_every_same_name_occurrence(name in "[a-z][a-z0-9]{0,5}") {
+        // The anchor name starts at 0-based char 4 of `k: &<name> ...`.
+        let text = format!("k: &{name} 1\nv: *{name}\nw: *{name}\n");
+        let edits = rename_edits(&text, Position::new(0, 4), "renamed", PositionEncoding::Utf16)
+            .expect("a legal new name")
+            .expect("the position is on the anchor");
+        prop_assert_eq!(edits.len(), 3, "the anchor and both aliases are rewritten");
+        for edit in &edits {
+            prop_assert_eq!(&edit.new_text, "renamed");
+        }
     }
 
     #[test]

--- a/tests/property_lsp_protocol.rs
+++ b/tests/property_lsp_protocol.rs
@@ -28,13 +28,14 @@ use lsp_server::{Connection, Message, Notification, Request, RequestId};
 use lsp_types::{
     CodeActionContext, CodeActionParams, DidChangeTextDocumentParams,
     DidCloseTextDocumentParams, DidOpenTextDocumentParams, DocumentFormattingParams,
-    FormattingOptions, InitializeParams, PartialResultParams, PublishDiagnosticsParams,
-    Range, TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
-    Uri, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
+    FormattingOptions, InitializeParams, PartialResultParams, Position,
+    PublishDiagnosticsParams, Range, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, Uri, VersionedTextDocumentIdentifier,
+    WorkDoneProgressParams,
 };
 use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
-use serde_json::{Value, to_value};
+use serde_json::{Value, json, to_value};
 use tempfile::tempdir;
 
 use ryl::config::{Overrides, SourceKind, discover_config};
@@ -149,6 +150,32 @@ fn doc_path(dir: &Path, index: u8) -> std::path::PathBuf {
     dir.join(format!("doc{index}.yaml"))
 }
 
+/// Byte offset of the start of `line` (0-based) in `text`, CR-aware. Independent of the
+/// server's converter so an incremental edit at column 0 cross-checks `offset_at`'s
+/// line counting; clamps a line past the end to the text end.
+fn line_start_byte(text: &str, line: u32) -> usize {
+    let bytes = text.as_bytes();
+    let mut byte = 0;
+    let mut current = 0;
+    while current < line && byte < bytes.len() {
+        match bytes[byte] {
+            b'\r' => {
+                byte += 1;
+                if bytes.get(byte) == Some(&b'\n') {
+                    byte += 1;
+                }
+                current += 1;
+            }
+            b'\n' => {
+                byte += 1;
+                current += 1;
+            }
+            _ => byte += 1,
+        }
+    }
+    byte
+}
+
 fn doc_uri(dir: &Path, index: u8) -> Uri {
     // Valid file URI cross-platform (forward slashes; leading slash before a
     // Windows drive) so the suite runs on every OS.
@@ -169,6 +196,8 @@ enum Op {
     Close(u8),
     CodeAction(u8),
     Formatting(u8),
+    Hover(u8),
+    Diagnostic(u8),
 }
 
 fn arb_op() -> impl Strategy<Value = Op> {
@@ -187,6 +216,8 @@ fn arb_op() -> impl Strategy<Value = Op> {
             }),
         index.clone().prop_map(Op::Close),
         index.clone().prop_map(Op::CodeAction),
+        index.clone().prop_map(Op::Hover),
+        index.clone().prop_map(Op::Diagnostic),
         index.prop_map(Op::Formatting),
     ]
 }
@@ -334,11 +365,91 @@ proptest! {
                     };
                     prop_assert!(response.error.is_none(), "formatting never errors");
                 }
+                Op::Hover(index) => {
+                    let params = json!({
+                        "textDocument": { "uri": doc_uri(dir.path(), index) },
+                        "position": { "line": 0, "character": 0 },
+                    });
+                    let id = driver.request("textDocument/hover", params);
+                    let Message::Response(response) = driver.await_response(&id) else {
+                        unreachable!("await_response returns a response");
+                    };
+                    prop_assert!(response.error.is_none(), "hover never errors");
+                }
+                Op::Diagnostic(index) => {
+                    let params =
+                        json!({ "textDocument": { "uri": doc_uri(dir.path(), index) } });
+                    let id = driver.request("textDocument/diagnostic", params);
+                    let Message::Response(response) = driver.await_response(&id) else {
+                        unreachable!("await_response returns a response");
+                    };
+                    prop_assert!(response.error.is_none(), "pull diagnostic never errors");
+                }
             }
         }
 
         // A clean shutdown/exit must terminate the server; Drop then joins the
         // thread, so a panic or hang in the loop surfaces here.
+        driver.shutdown();
+    }
+
+    #[test]
+    fn incremental_edits_keep_diagnostics_faithful(
+        initial in arb_document().prop_map(|document| document.render()),
+        inserts in prop::collection::vec(
+            (0u32..6, prop_oneof![Just(" "), Just("x"), Just("k: 1\n")]),
+            0..6,
+        ),
+    ) {
+        let dir = tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".ryl.toml"), CONFIG).expect("write config");
+        let mut driver = Driver::start();
+        let uri = doc_uri(dir.path(), 0);
+        let mut version = 1;
+        driver.notify(
+            "textDocument/didOpen",
+            to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "yaml".to_string(),
+                    version,
+                    text: initial.clone(),
+                },
+            })
+            .expect("serialize"),
+        );
+        let published = driver.await_publish();
+        let mut model = initial;
+        check_update(dir.path(), 0, version, &model, &published)?;
+
+        for (line, insert) in inserts {
+            // The server applies the ranged edit via its own converter; the model
+            // applies it at the independently-computed line-start byte (column 0
+            // is unit-unambiguous), so the two texts must stay byte-identical.
+            let at = line_start_byte(&model, line);
+            model.insert_str(at, insert);
+            version += 1;
+            driver.notify(
+                "textDocument/didChange",
+                to_value(DidChangeTextDocumentParams {
+                    text_document: VersionedTextDocumentIdentifier {
+                        uri: uri.clone(),
+                        version,
+                    },
+                    content_changes: vec![TextDocumentContentChangeEvent {
+                        range: Some(Range::new(
+                            Position::new(line, 0),
+                            Position::new(line, 0),
+                        )),
+                        range_length: None,
+                        text: insert.to_string(),
+                    }],
+                })
+                .expect("serialize"),
+            );
+            let published = driver.await_publish();
+            check_update(dir.path(), 0, version, &model, &published)?;
+        }
         driver.shutdown();
     }
 }


### PR DESCRIPTION
Builds on the core `ryl server` language server (#226, PR #316) with the editor-integration
follow-ups tracked in #317, all behind the default-on `lsp` feature.

## What's added

- **Config-file watching** — a dynamic `workspace/didChangeWatchedFiles` registration
  re-lints open documents when a ryl/yamllint config changes on disk.
- **Code actions** — per-rule `source.fixAll.ryl.<rule>` (YAML only) plus `quickfix`
  disable-rule inserts (`# ryl disable-line` / first-line `# ryl disable-file`). They act
  only on ryl's own diagnostics (so a coexisting `yaml-language-server` can't trigger them)
  and are gated away from block-scalar content and Markdown hosts.
- **Pull diagnostics** — `textDocument/diagnostic` + `workspace/diagnostic`. The workspace
  scan runs on a background worker thread (the message loop stays responsive), lints files
  in parallel via `rayon`, has a per-entry-cancellable directory walk, is bounded (a new
  pull supersedes any in-flight one), and surfaces config failures as an error diagnostic
  rather than a silently-clean report.
- **Editor config** — `initializationOptions` / `workspace/didChangeConfiguration`
  (`configPath` / `configData` / `enable`), CLI-equivalent precedence.
- **Hover** — rule id + message + rules-reference link for a covered diagnostic.
- **Incremental document sync** — via a new CR-/encoding-aware `encoding::offset_at`
  inverse converter.
- **Anchor/alias rename** — `prepareRename` + `rename`, document-scoped, YAML only,
  rejecting colliding and non-`ns-anchor-char` names.

## Notes

- **No version bump** — rolls into the next release together with #226.
- Reviewed locally (`/code-review` high + several Codex adversarial passes); the one
  documented residual is that cancelling a workspace pull does not interrupt an
  *in-progress single-file read* (per ryl's threat model: realistic payloads, not a
  degraded-filesystem racer).
- Coexists with Red Hat's `yaml-language-server` (schema/completion); ryl is the linter
  half. See `docs/editor-integration.md`.

Closes #317.