### PR TITLE
codex-review-watch: detect Codex's auto-started first review (#319)

### DIFF
--- a/.agents/skills/codex-review-watch/SKILL.md
+++ b/.agents/skills/codex-review-watch/SKILL.md
@@ -16,7 +16,8 @@ Run the watcher **as a background command** (it polls and blocks until a verdict
 timeout; backgrounding lets you keep working and get notified on exit):
 
 ```bash
-uv run .agents/skills/codex-review-watch/watch.py <PR> [--repo owner/repo] [--no-trigger]
+uv run .agents/skills/codex-review-watch/watch.py <PR> [--repo owner/repo] \
+  [--first-review] [--no-trigger]
 ```
 
 - Default: prints a **quota preflight**, posts `@codex review` (after capturing
@@ -24,8 +25,18 @@ uv run .agents/skills/codex-review-watch/watch.py <PR> [--repo owner/repo] [--no
   Verdict detection compares against the baseline captured at startup, so in
   `--no-trigger` mode the verdict must land *after* you start watching; a review that
   already completed before startup is in the baseline and is not reported as new.
+- **First review on a freshly-opened PR:** pass `--first-review`. Codex almost always
+  *auto-starts* a review on PR open (acked by a transient 👀 on the **PR body**, with no
+  `@codex review` comment), so blindly posting `@codex review` double-triggers it.
+  `--first-review` baselines all bot channels at zero (the fresh PR's true pre-state),
+  then watches for that auto-start — a body 👀 ack, or a verdict landing within
+  `--auto-wait` (default 90s) — and **skips** posting. It falls back to posting `@codex
+  review` only if no auto-start fires in that window (so the worst case is exactly the
+  default behavior, no regression). Use it **only** for the first review; **subsequent**
+  (post-push) reviews have no auto-start and need the explicit prompt, so leave it off.
 - `--repo` defaults to the current repo (`gh repo view`). Needs `gh` authenticated.
-- Tunables: `--interval` (default 45s), `--max-polls` (default 40 ≈ 30 min).
+- Tunables: `--interval` (default 45s), `--max-polls` (default 40 ≈ 30 min),
+  `--auto-wait` (default 90s, `--first-review` only).
 
 For a **standalone quota check** (no PR, no trigger, consumes no quota):
 
@@ -58,9 +69,15 @@ of:
 - **The 👀 ack is transient** — added within ~1 min, then removed when the verdict
   posts. So absence of 👀 *after* a verdict is normal (map trigger→verdict by
   **timestamp**, ~3 min apart), but absence *early on* (first ~2 min, no verdict) means
-  Codex never picked the trigger up — the watcher warns on that.
-- **Auto-review is unreliable** — only PR-open sometimes triggers; re-post `@codex
-  review` after every push you want reviewed.
+  Codex never picked the trigger up — the watcher warns on that. The ack attaches to the
+  **trigger comment** for a manual `@codex review`, but to the **PR body** for the
+  auto-started first review (which has no comment) — `reactions()` reads whichever
+  applies.
+- **The first review auto-starts; subsequent ones don't.** On PR open Codex usually
+  posts a review on its own (the 👀-on-body auto-start), so for the first review pass
+  `--first-review` to detect it instead of double-triggering. The auto-start is *only*
+  on PR open — after every push, re-post `@codex review` (the default mode, no
+  `--first-review`) to get the next review.
 
 ## Quota / rate limits
 

--- a/.agents/skills/codex-review-watch/SKILL.md
+++ b/.agents/skills/codex-review-watch/SKILL.md
@@ -34,9 +34,20 @@ uv run .agents/skills/codex-review-watch/watch.py <PR> [--repo owner/repo] \
   review` only if no auto-start fires in that window (so the worst case is exactly the
   default behavior, no regression). Use it **only** for the first review; **subsequent**
   (post-push) reviews have no auto-start and need the explicit prompt, so leave it off.
+  - The auto-review also stalls the *other* way — it acks with 👀 then silently posts
+    nothing ("stuck eyes," a real Codex flake). So `--first-review` trusts the 👀 ack
+    but not forever: after `--stuck-after` (default 600s ≈ 10 min) of monitoring with no
+    verdict it **escalates once** with an explicit `@codex review`. The default is
+    deliberately generous — a healthy Codex review can genuinely take several minutes,
+    and escalating too eagerly re-introduces the double-trigger this mode exists to
+    avoid. A merely-slow review that lands first means the watchdog never fires; set
+    `--stuck-after 0` to disable it. Keep `--stuck-after` comfortably below the overall
+    `--max-polls × --interval` budget (default 30 min) so the escalated review still has
+    time to land.
 - `--repo` defaults to the current repo (`gh repo view`). Needs `gh` authenticated.
 - Tunables: `--interval` (default 45s), `--max-polls` (default 40 ≈ 30 min),
-  `--auto-wait` (default 90s, `--first-review` only).
+  `--auto-wait` (default 90s) + `--stuck-after` (default 600s ≈ 10 min), both
+  `--first-review` only.
 
 For a **standalone quota check** (no PR, no trigger, consumes no quota):
 
@@ -78,6 +89,16 @@ of:
   `--first-review` to detect it instead of double-triggering. The auto-start is *only*
   on PR open — after every push, re-post `@codex review` (the default mode, no
   `--first-review`) to get the next review.
+- **Writing `@codex` is itself a trigger — even inside backticks.** Per OpenAI's docs,
+  `@codex review` requests a review, but `@codex` followed by *any other text* starts a
+  cloud **task** (the autonomous agent) using the PR as context. It fires from a PR/issue
+  **body or comment**, and (observed on this repo) backtick-quoting does **not** shield
+  it: a PR description full of backticked `@codex review` mentions got routed to the task
+  agent, which ran ~20 min then posted a phantom "committed / opened a follow-up PR"
+  summary that never actually touched the repo. So when writing *about* the trigger (a PR
+  body, an upstream issue), neutralize the mention — write `&#64;codex` (renders as
+  `@codex`, no literal `@` token) — and only post a bare `@codex review` when you truly
+  want a review.
 
 ## Quota / rate limits
 

--- a/.agents/skills/codex-review-watch/watch.py
+++ b/.agents/skills/codex-review-watch/watch.py
@@ -31,6 +31,10 @@ Each gotcha below was a real mistake this script exists to prevent:
     and skips re-posting @codex review, falling back to posting only if no auto-start
     fires. Leave it OFF for subsequent (post-push) reviews: those have no auto-start
     and need an explicit @codex review.
+  * The auto-review also fails the OTHER way: it acks (eyes) then silently STALLS
+    without posting a verdict (Codex's "stuck eyes" flake). So under ``--first-review``
+    the eyes ack is trusted, but not forever -- after ``--stuck-after``s of monitoring
+    with no verdict the watchdog escalates once with an explicit @codex review.
 """
 
 from __future__ import annotations
@@ -221,6 +225,15 @@ def main(
             "(eyes on the PR body) before falling back to posting '@codex review'"
         ),
     ] = 90,
+    stuck_after: Annotated[
+        int,
+        typer.Option(
+            help="--first-review: if a detected auto-review posts no verdict within "
+            "this many seconds of monitoring, escalate once with '@codex review' "
+            "(handles Codex's stuck-eyes flake). Generous by default since a healthy "
+            "review can genuinely run several minutes. 0 disables the escalation."
+        ),
+    ] = 600,
     ack_timeout: Annotated[
         int,
         typer.Option(
@@ -263,6 +276,19 @@ def main(
 
     def inlines() -> list:
         return by_bot(gh_json(f"repos/{repo}/pulls/{pr}/comments"))
+
+    def latest_trigger_id() -> int | None:
+        """Id of the most recent '@codex review' comment (ours or a human's), or None."""
+        triggers = [
+            c
+            for c in gh_json(f"repos/{repo}/issues/{pr}/comments")
+            if c.get("body") == "@codex review"
+        ]
+        return triggers[-1]["id"] if triggers else None
+
+    def post_trigger() -> int | None:
+        gh("pr", "comment", pr, "--repo", repo, "--body", "@codex review")
+        return latest_trigger_id()
 
     auto_started = False
     # Set once a '@codex review' comment exists (posted by us or found in --no-trigger).
@@ -330,7 +356,12 @@ def main(
     # before posting so we don't double-trigger it; only fall back to posting if no
     # auto-start fires within --auto-wait.
     if first_review:
-        auto_base_thumbs, _ = reactions()  # trig_id is None here -> PR-body reactions
+        # Zero the body-thumbs baseline like every other channel: a fresh PR carries no
+        # prior Codex output, so any bot thumbs-up on the body IS the auto-review's clean
+        # verdict -- including one that already landed before this watcher started (eyes
+        # already gone). Baselining it at the current count would miss that clean verdict
+        # and fall back to a redundant @codex review.
+        auto_base_thumbs = 0
         waited = 0
         while True:
             rev, iss, inl = reviews(), issues(), inlines()
@@ -354,16 +385,10 @@ def main(
         if auto_started:
             trigger = False  # the auto-review is running; monitor it, don't re-trigger
 
-    if trigger:
-        gh("pr", "comment", pr, "--repo", repo, "--body", "@codex review")
-    # Locate the latest @codex review trigger comment whether we posted it or are
-    # monitoring an existing one (--no-trigger), so reactions() can see its verdict.
-    triggers = [
-        c
-        for c in gh_json(f"repos/{repo}/issues/{pr}/comments")
-        if c.get("body") == "@codex review"
-    ]
-    trig_id = triggers[-1]["id"] if triggers else None
+    # Post (or, in --no-trigger, just locate) the @codex review comment so reactions()
+    # can see its verdict. auto-monitor mode (auto_started) posts nothing here -- it
+    # relies on the running auto-review until the watchdog escalates.
+    trig_id = post_trigger() if trigger else latest_trigger_id()
     if trigger:
         typer.echo(f"posted @codex review (trigger id={trig_id})")
     elif auto_started:
@@ -373,10 +398,12 @@ def main(
     else:
         typer.echo("monitoring without a trigger (no '@codex review' comment found)")
 
-    # Baseline the ack target's reactions like the other channels: an existing trigger
-    # (or, in auto-review monitor mode, the PR body) may already carry a bot thumbs-up,
-    # so only a NEW one is a clean verdict.
-    base_thumbs, _ = reactions()
+    # Baseline the ack target's reactions like the other channels. In --first-review the
+    # baseline is zero (a fresh PR's body has no prior bot thumbs-up, and a just-posted
+    # fallback trigger has none either), so an already-present clean thumbs-up still
+    # counts. Otherwise an existing trigger may already carry one, so only a NEW
+    # thumbs-up is a clean verdict.
+    base_thumbs = 0 if first_review else reactions()[0]
 
     # Fail fast on a missing ack: Codex normally adds an eyes/thumbs reaction within a
     # minute of the trigger, so its ABSENCE within `ack_timeout`s means the trigger was
@@ -408,12 +435,30 @@ def main(
             raise typer.Exit(code=1)
 
     # Acked (or --no-trigger / auto-review monitor): poll the three channels for verdict.
+    # Watchdog: a detected auto-review that acked (eyes) then silently stalled (Codex's
+    # stuck-eyes flake) would otherwise be monitored to timeout. After `stuck_after`s of
+    # monitoring with no verdict, escalate ONCE with an explicit @codex review. Gated on
+    # auto_started, so the normal/--no-trigger paths (which already have a trigger or
+    # chose not to) never escalate.
+    monitored = 0
+    escalated = False
     for i in range(1, max_polls + 1):
         time.sleep(interval)
+        monitored += interval
         rev, iss, inl = reviews(), issues(), inlines()
         thumbs, _eyes = reactions()
         if report_verdict(rev, iss, inl, thumbs, base_thumbs):
             return
+        if auto_started and stuck_after and not escalated and monitored >= stuck_after:
+            typer.echo(
+                f"auto-review stalled (no verdict after {monitored}s); "
+                "escalating with @codex review"
+            )
+            trig_id = post_trigger()
+            base_thumbs, _ = reactions()
+            escalated = True
+            typer.echo(f"posted @codex review (trigger id={trig_id})")
+            continue
         typer.echo(
             f"poll {i}/{max_polls}: reviews={len(rev)} issue={len(iss)} "
             f"inline={len(inl)} thumbs={thumbs} (no verdict)"

--- a/.agents/skills/codex-review-watch/watch.py
+++ b/.agents/skills/codex-review-watch/watch.py
@@ -3,7 +3,8 @@
 # dependencies = ["typer"]
 # ///
 """Trigger and/or monitor a Codex CI code review on a GitHub PR, then classify the
-verdict. Run with: ``uv run watch.py <pr> [--repo owner/repo] [--no-trigger]``, or
+verdict. Run with: ``uv run watch.py <pr> [--repo owner/repo] [--no-trigger]``
+(add ``--first-review`` for the first review on a freshly-opened PR), or
 ``uv run watch.py --quota-only`` to just print the Codex quota snapshot.
 
 Each gotcha below was a real mistake this script exists to prevent:
@@ -23,6 +24,13 @@ Each gotcha below was a real mistake this script exists to prevent:
     TUI-only), but the CLI caches the rate-limit snapshot from each response into its
     session rollout, which this reads as a preflight so a near-exhausted quota is
     flagged before a trigger silently stalls.
+  * On a freshly-opened PR Codex usually AUTO-starts a review (no @codex review
+    comment), acked by a transient eyes reaction on the PR BODY (the manual-prompt
+    eyes land on the @codex review comment instead). ``--first-review`` watches for
+    that auto-start -- a body eyes ack or a verdict landing within ``--auto-wait`` --
+    and skips re-posting @codex review, falling back to posting only if no auto-start
+    fires. Leave it OFF for subsequent (post-push) reviews: those have no auto-start
+    and need an explicit @codex review.
 """
 
 from __future__ import annotations
@@ -193,11 +201,26 @@ def main(
             help="post '@codex review' first (use --no-trigger to only monitor)"
         ),
     ] = True,
+    first_review: Annotated[
+        bool,
+        typer.Option(
+            help="first review on a freshly-opened PR: detect Codex's auto-started "
+            "review (transient eyes on the PR body) before posting '@codex review', "
+            "to avoid double-triggering. Leave OFF for subsequent (post-push) reviews."
+        ),
+    ] = False,
     quota_only: Annotated[
         bool, typer.Option(help="print the Codex quota snapshot and exit")
     ] = False,
     max_polls: Annotated[int, typer.Option(help="maximum poll attempts")] = 40,
     interval: Annotated[int, typer.Option(help="seconds between polls")] = 45,
+    auto_wait: Annotated[
+        int,
+        typer.Option(
+            help="--first-review: seconds to wait for the auto-started review's ack "
+            "(eyes on the PR body) before falling back to posting '@codex review'"
+        ),
+    ] = 90,
     ack_timeout: Annotated[
         int,
         typer.Option(
@@ -241,42 +264,39 @@ def main(
     def inlines() -> list:
         return by_bot(gh_json(f"repos/{repo}/pulls/{pr}/comments"))
 
-    base_rev, base_iss, base_inl = len(reviews()), len(issues()), len(inlines())
+    auto_started = False
+    # Set once a '@codex review' comment exists (posted by us or found in --no-trigger).
+    trig_id: int | None = None
+
+    if first_review:
+        # A freshly-opened PR: Codex has produced nothing yet, so baseline every bot
+        # channel at zero -- any bot review/comment/reaction below IS the auto-review.
+        base_rev = base_iss = base_inl = 0
+    else:
+        base_rev, base_iss, base_inl = len(reviews()), len(issues()), len(inlines())
     typer.echo(
         f"baseline: reviews={base_rev} issue_comments={base_iss} inline={base_inl}"
     )
 
-    if trigger:
-        gh("pr", "comment", pr, "--repo", repo, "--body", "@codex review")
-    # Locate the latest @codex review trigger comment whether we posted it or are
-    # monitoring an existing one (--no-trigger), so reactions() can see its verdict.
-    triggers = [
-        c
-        for c in gh_json(f"repos/{repo}/issues/{pr}/comments")
-        if c.get("body") == "@codex review"
-    ]
-    trig_id = triggers[-1]["id"] if triggers else None
-    typer.echo(
-        f"posted @codex review (trigger id={trig_id})"
-        if trigger
-        else f"monitoring existing trigger id={trig_id}"
-    )
-
     def reactions() -> tuple[int, int]:
-        """(thumbs, eyes) from the bot on the trigger comment, or (0, 0) without one."""
-        if not trig_id:
-            return 0, 0
-        reacts = by_bot(gh_json(f"repos/{repo}/issues/comments/{trig_id}/reactions"))
+        """(thumbs, eyes) from the bot on the verdict's ack target: the '@codex review'
+        trigger comment when one exists, else the PR body (Codex's auto-started review
+        on PR open has no comment, so it acks on the body).
+        """
+        path = (
+            f"repos/{repo}/issues/comments/{trig_id}/reactions"
+            if trig_id
+            else f"repos/{repo}/issues/{pr}/reactions"
+        )
+        reacts = by_bot(gh_json(path))
         return (
             sum(1 for r in reacts if r.get("content") == "+1"),
             sum(1 for r in reacts if r.get("content") == "eyes"),
         )
 
-    # Baseline the trigger's reactions like the other channels: in --no-trigger mode an
-    # existing trigger may already carry the bot's thumbs-up, so only a NEW one is clean.
-    base_thumbs, _ = reactions()
-
-    def report_verdict(rev: list, iss: list, inl: list, thumbs: int) -> bool:
+    def report_verdict(
+        rev: list, iss: list, inl: list, thumbs: int, base_thumbs: int
+    ) -> bool:
         """Print the verdict if one has landed on any of the three channels; return
         True when it has (caller should stop).
         """
@@ -292,7 +312,7 @@ def main(
                 typer.echo(f"RESULT: ISSUE-COMMENT (read it) -- {body[:300]}")
             return True
         if thumbs > base_thumbs:
-            typer.echo("RESULT: CLEAN -- thumbs-up on the trigger comment")
+            typer.echo("RESULT: CLEAN -- thumbs-up ack")
             return True
         if len(rev) > base_rev:  # new review = findings (inline comments)
             new = inl[base_inl:]
@@ -305,10 +325,65 @@ def main(
             return True
         return False
 
+    # First review on a freshly-opened PR: Codex usually AUTO-starts a review, acked by
+    # a transient eyes reaction on the PR body (no '@codex review' comment). Detect that
+    # before posting so we don't double-trigger it; only fall back to posting if no
+    # auto-start fires within --auto-wait.
+    if first_review:
+        auto_base_thumbs, _ = reactions()  # trig_id is None here -> PR-body reactions
+        waited = 0
+        while True:
+            rev, iss, inl = reviews(), issues(), inlines()
+            thumbs, eyes = reactions()
+            if report_verdict(rev, iss, inl, thumbs, auto_base_thumbs):
+                return  # the auto-review already landed (or finished before we looked)
+            if eyes > 0:
+                auto_started = True
+                typer.echo(
+                    f"auto-review underway (eyes on PR body, ~{waited}s); "
+                    "not re-triggering"
+                )
+                break
+            if waited >= auto_wait:
+                typer.echo(f"auto-detect: no auto-started review within {auto_wait}s")
+                break
+            step = min(ack_interval, auto_wait - waited)
+            time.sleep(step)
+            waited += step
+            typer.echo(f"auto-detect {waited}/{auto_wait}s: no auto-review ack yet")
+        if auto_started:
+            trigger = False  # the auto-review is running; monitor it, don't re-trigger
+
+    if trigger:
+        gh("pr", "comment", pr, "--repo", repo, "--body", "@codex review")
+    # Locate the latest @codex review trigger comment whether we posted it or are
+    # monitoring an existing one (--no-trigger), so reactions() can see its verdict.
+    triggers = [
+        c
+        for c in gh_json(f"repos/{repo}/issues/{pr}/comments")
+        if c.get("body") == "@codex review"
+    ]
+    trig_id = triggers[-1]["id"] if triggers else None
+    if trigger:
+        typer.echo(f"posted @codex review (trigger id={trig_id})")
+    elif auto_started:
+        typer.echo("monitoring Codex's auto-started review (no trigger posted)")
+    elif trig_id:
+        typer.echo(f"monitoring existing trigger id={trig_id}")
+    else:
+        typer.echo("monitoring without a trigger (no '@codex review' comment found)")
+
+    # Baseline the ack target's reactions like the other channels: an existing trigger
+    # (or, in auto-review monitor mode, the PR body) may already carry a bot thumbs-up,
+    # so only a NEW one is a clean verdict.
+    base_thumbs, _ = reactions()
+
     # Fail fast on a missing ack: Codex normally adds an eyes/thumbs reaction within a
     # minute of the trigger, so its ABSENCE within `ack_timeout`s means the trigger was
     # never picked up (rate-limited/stalled) -- bail instead of burning the full poll
-    # window. A verdict that lands during this short phase short-circuits too.
+    # window. A verdict that lands during this short phase short-circuits too. Skipped in
+    # auto-review monitor mode (trig_id is None): we already saw the auto-start's eyes,
+    # and that ack is transient, so its absence now is not a dropped trigger.
     if trig_id:
         waited = 0
         acked = False
@@ -318,7 +393,7 @@ def main(
             waited += step
             rev, iss, inl = reviews(), issues(), inlines()
             thumbs, eyes = reactions()
-            if report_verdict(rev, iss, inl, thumbs):
+            if report_verdict(rev, iss, inl, thumbs, base_thumbs):
                 return
             if eyes > 0 or thumbs > 0:
                 acked = True
@@ -332,12 +407,12 @@ def main(
             )
             raise typer.Exit(code=1)
 
-    # Acked (or --no-trigger monitor-only): poll the three channels for the verdict.
+    # Acked (or --no-trigger / auto-review monitor): poll the three channels for verdict.
     for i in range(1, max_polls + 1):
         time.sleep(interval)
         rev, iss, inl = reviews(), issues(), inlines()
         thumbs, _eyes = reactions()
-        if report_verdict(rev, iss, inl, thumbs):
+        if report_verdict(rev, iss, inl, thumbs, base_thumbs):
             return
         typer.echo(
             f"poll {i}/{max_polls}: reviews={len(rev)} issue={len(iss)} "


### PR DESCRIPTION
## What

Adds an opt-in `--first-review` mode to the `codex-review-watch` dev skill's `watch.py` so the watcher detects Codex's **auto-started** review on a freshly-opened PR instead of double-triggering it, plus a watchdog for when that auto-review stalls.

## Why

On PR open, Codex's bot almost always auto-starts a review, acked by a transient eyes reaction on the **PR body** (no comment). The old `watch.py` unconditionally posted a review request, double-triggering that first review and burning quota.

## How

- New `--first-review` flag (default off) + `--auto-wait` (default 90s) + `--stuck-after` (default 600s).
- When set, baselines every bot channel at zero (a fresh PR's true pre-state) and:
  - reports an already/just-landed verdict (including an auto-review that finished with a clean thumbs-up on the body before the watcher started);
  - on a body eyes ack, **skips** posting and monitors the running auto-review;
  - if no auto-start fires within `--auto-wait`, falls back to posting a review request (worst case = today's behavior, no regression).
- **Watchdog:** the auto-review also stalls the other way (acks with eyes then posts nothing). After `--stuck-after` of monitoring with no verdict, escalate once with an explicit review request.
- `reactions()` reads the trigger comment when one exists, else the PR body — so the auto-review's ack is visible without a trigger comment.
- Default mode is byte-for-byte unchanged. **Subsequent (post-push) reviews** have no auto-start and still need an explicit review request, so leave `--first-review` off for those.

`SKILL.md` documents the first-vs-subsequent distinction, the stuck-eyes watchdog, and a newly-discovered footgun: a Codex `@`-mention in a PR body/comment (even backtick-quoted) is itself a live trigger.

Closes #319.