### PR TITLE
v0.18.0: language server release; temporarily disable winget

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -55,10 +55,17 @@ description: >-
   creation is deferred until after crates.io/PyPI/NPM publishing succeeds, kept as a
   draft until assets upload, with auto-generated notes; reruns skip publish steps for a
   version that already exists.
-- After the release is un-drafted, the `publish-winget` job submits a winget-pkgs PR via
-  `wingetcreate update owenlamont.ryl` (token: the classic `public_repo` `WINGET_PAT`
-  secret in the `automation` environment). It requires the package to already exist in
-  winget-pkgs from the one-time `wingetcreate new` bootstrap; `update` preserves the
-  nested-portable config and `Microsoft.VCRedist.2015+` dependencies, swapping only
-  version, URLs, and SHA256. Re-running a published version would attempt a duplicate
-  winget PR (no existence guard, unlike the crates/PyPI/NPM steps).
+- The `publish-winget` job is currently **commented out** in `release.yml` (and the
+  winget install instructions are removed from the docs) pending the winget-pkgs
+  New-Package bootstrap PR microsoft/winget-pkgs#387703, which is still stuck in upstream
+  moderation. `wingetcreate update` requires the package to already exist in winget-pkgs,
+  so until that PR lands the package does not exist upstream and the job would fail every
+  release. Re-enable both once it merges and `winget install owenlamont.ryl` works.
+- When re-enabled, after the release is un-drafted the `publish-winget` job submits a
+  winget-pkgs PR via `wingetcreate update owenlamont.ryl` (token: the classic
+  `public_repo` `WINGET_PAT` secret in the `automation` environment). It requires the
+  package to already exist in winget-pkgs from the one-time `wingetcreate new` bootstrap;
+  `update` preserves the nested-portable config and `Microsoft.VCRedist.2015+`
+  dependencies, swapping only version, URLs, and SHA256. Re-running a published version
+  would attempt a duplicate winget PR (no existence guard, unlike the crates/PyPI/NPM
+  steps).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -863,53 +863,63 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: gh release edit "$RELEASE_TAG" -R "${GITHUB_REPOSITORY}" --draft=false
 
-  publish-winget:
-    name: Publish to winget
-    # Must follow finalize-github-release: wingetcreate downloads each release
-    # asset to recompute its SHA256, so the assets have to be publicly
-    # downloadable (un-drafted) first.
-    needs:
-      - finalize-github-release
-    if: >-
-      startsWith(github.ref, 'refs/tags/v') &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
-    runs-on: windows-latest
-    environment: automation
-    permissions:
-      contents: read
-    steps:
-      - name: Download and verify wingetcreate
-        shell: pwsh
-        # Pin to a reviewed release and verify its published SHA256 before the next
-        # step runs it with WINGET_PAT in scope, so a mutated download (or a
-        # compromised redirect) can never execute against the token. Bump the
-        # version and hash together; the hash is the `wingetcreate.exe.txt` checksum
-        # published alongside the release asset.
-        env:
-          WINGETCREATE_VERSION: v1.12.8.0
-          WINGETCREATE_SHA256: 8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D
-        run: |-
-          $ErrorActionPreference = 'Stop'
-          $url = "https://github.com/microsoft/winget-create/releases/download/${env:WINGETCREATE_VERSION}/wingetcreate.exe"
-          Invoke-WebRequest $url -OutFile wingetcreate.exe
-          $actual = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash
-          if ($actual -ne ${env:WINGETCREATE_SHA256}) {
-            throw "wingetcreate.exe SHA256 mismatch: expected ${env:WINGETCREATE_SHA256}, got $actual"
-          }
-      - name: Submit ryl to winget-pkgs
-        shell: pwsh
-        env:
-          # wingetcreate reads the classic public_repo PAT from this env var (its
-          # documented CI path), keeping the token out of argv and process logs.
-          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-        run: |-
-          $ErrorActionPreference = 'Stop'
-          $version = ${env:GITHUB_REF_NAME} -replace '^v', ''
-          $base = "https://github.com/${env:GITHUB_REPOSITORY}/releases/download/${env:GITHUB_REF_NAME}"
-          .\wingetcreate.exe update owenlamont.ryl `
-            --version $version `
-            --submit `
-            --urls "${base}/ryl-x86_64-pc-windows-msvc.zip|x64" "${base}/ryl-aarch64-pc-windows-msvc.zip|arm64"
+# ---------------------------------------------------------------------------
+# publish-winget is TEMPORARILY DISABLED (commented out) pending the winget-pkgs
+# New-Package bootstrap PR microsoft/winget-pkgs#387703, which is still stuck in
+# upstream moderation. `wingetcreate update owenlamont.ryl` requires the package
+# to already exist in winget-pkgs, so until that PR lands the package does not
+# exist upstream and this job would fail on every release. To re-enable: strip
+# the leading `# ` from the job below (originally added in #312, commit d1efb05)
+# once the bootstrap PR merges and `winget install owenlamont.ryl` works, and
+# restore the winget install instructions removed from the docs at the same time.
+# ---------------------------------------------------------------------------
+#   publish-winget:
+#     name: Publish to winget
+#     # Must follow finalize-github-release: wingetcreate downloads each release
+#     # asset to recompute its SHA256, so the assets have to be publicly
+#     # downloadable (un-drafted) first.
+#     needs:
+#       - finalize-github-release
+#     if: >-
+#       startsWith(github.ref, 'refs/tags/v') &&
+#       (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
+#     runs-on: windows-latest
+#     environment: automation
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Download and verify wingetcreate
+#         shell: pwsh
+#         # Pin to a reviewed release and verify its published SHA256 before the next
+#         # step runs it with WINGET_PAT in scope, so a mutated download (or a
+#         # compromised redirect) can never execute against the token. Bump the
+#         # version and hash together; the hash is the `wingetcreate.exe.txt` checksum
+#         # published alongside the release asset.
+#         env:
+#           WINGETCREATE_VERSION: v1.12.8.0
+#           WINGETCREATE_SHA256: 8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D
+#         run: |-
+#           $ErrorActionPreference = 'Stop'
+#           $url = "https://github.com/microsoft/winget-create/releases/download/${env:WINGETCREATE_VERSION}/wingetcreate.exe"
+#           Invoke-WebRequest $url -OutFile wingetcreate.exe
+#           $actual = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash
+#           if ($actual -ne ${env:WINGETCREATE_SHA256}) {
+#             throw "wingetcreate.exe SHA256 mismatch: expected ${env:WINGETCREATE_SHA256}, got $actual"
+#           }
+#       - name: Submit ryl to winget-pkgs
+#         shell: pwsh
+#         env:
+#           # wingetcreate reads the classic public_repo PAT from this env var (its
+#           # documented CI path), keeping the token out of argv and process logs.
+#           WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+#         run: |-
+#           $ErrorActionPreference = 'Stop'
+#           $version = ${env:GITHUB_REF_NAME} -replace '^v', ''
+#           $base = "https://github.com/${env:GITHUB_REPOSITORY}/releases/download/${env:GITHUB_REF_NAME}"
+#           .\wingetcreate.exe update owenlamont.ryl `
+#             --version $version `
+#             --submit `
+#             --urls "${base}/ryl-x86_64-pc-windows-msvc.zip|x64" "${base}/ryl-aarch64-pc-windows-msvc.zip|arm64"
 
   sync-schemastore:
     name: Sync SchemaStore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ npm install -g @owenlamont/ryl      # npm
 pip install ryl                     # pip
 cargo install ryl                   # cargo
 pixi global install ryl             # conda-forge
-winget install owenlamont.ryl       # winget (Windows)
 ```
 
 ## Status and scope

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,12 +28,6 @@ toolchain.
     # or: conda install -c conda-forge ryl
     ```
 
-=== "winget (Windows)"
-
-    ```powershell
-    winget install owenlamont.ryl
-    ```
-
 === "Prebuilt binary"
 
     Download a release artifact from the

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,9 +60,6 @@ npm install --global @owenlamont/ryl
 # Or with conda (conda-forge)
 pixi global install ryl
 
-# Or with winget (Windows)
-winget install owenlamont.ryl
-
 # Lint a file or directory
 ryl path/to/file.yaml
 ryl .

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -36,12 +36,6 @@ toolchain.
     # or: conda install -c conda-forge ryl
     ```
 
-=== "winget (Windows)"
-
-    ```powershell
-    winget install owenlamont.ryl
-    ```
-
 === "Prebuilt binary"
 
     Download a release artifact from the

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.17.0"
+  "version": "0.18.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.17.0"
+version = "0.18.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## v0.18.0

Headline: the `ryl server` language server (LSP) plus its follow-up nice-to-haves, which also unblocks the upcoming ryl-vscode extension.

### Included since v0.17.0
- `ryl server` language server / LSP (#316)
- LSP nice-to-have features (#318)
- conda-forge install instructions (#313)
- dependency and linter refresh (#314)
- codex-review-watch dev tooling (#320)

### This PR
- Bump version to 0.18.0 across `Cargo.toml`, `pyproject.toml`, `package.json`; refresh `Cargo.lock` and `uv.lock`.
- Temporarily disable winget publishing. The winget-pkgs New-Package bootstrap PR (microsoft/winget-pkgs#387703) is still stuck in upstream moderation, so the package does not exist in winget-pkgs and `wingetcreate update owenlamont.ryl` would fail on every release. The `publish-winget` job is commented out verbatim (with re-enable instructions) and the winget install instructions are removed from the README and docs. Restore both once that PR merges. Winget (#312) landed after v0.17.0 but was never functional, so it is not a v0.18.0 release-note item.