### PR TITLE
fix(lsp): emit one diagnostics channel per client (#323)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,7 +456,10 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
   loop/dispatch; the connection-free logic lives in submodules so it is unit/property
   testable: `encoding` (position math + `uri_to_path`/`path_to_uri`), `analysis`
   (lint/fix → LSP), `actions` (code-action builders), `hover`, `rename`. Capabilities:
-  push diagnostics (`publishDiagnostics`); pull diagnostics (`textDocument/diagnostic` +
+  push diagnostics (`publishDiagnostics`, gated on `Server::push_diagnostics` =
+  `!client_supports_pull_diagnostics` so a pull-capable client gets diagnostics once via
+  pull, not twice — clients like VS Code merge the two channels); pull diagnostics
+  (`textDocument/diagnostic` +
   `workspace/diagnostic`, the latter over a per-entry-cancellable
   `discover::gather_yaml_from_dir_cancellable` walk of every root, deduped, full report
   each call, no result-id caching; it runs on a background worker thread — so the message
@@ -475,9 +478,12 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
   fix; code actions honour `context.only`. Config is resolved per document via
   `discover_config` (full CLI precedence incl. `YAMLLINT_CONFIG_FILE`), layering the
   client's `Settings` (`initializationOptions` / `workspace/didChangeConfiguration`:
-  `configPath`/`configData`/`enable`, CLI-equivalent precedence). Config-file changes
-  re-lint open docs via a dynamic `didChangeWatchedFiles` registration (push model;
-  `workspace/configuration` pull is deferred). A rule-less/absent config or `enable:false`
+  `configPath`/`configData`/`enable`, CLI-equivalent precedence). Config-file changes go
+  through `handle_config_change` via a dynamic `didChangeWatchedFiles` registration: a push
+  client gets a re-lint+re-push, a pull client (whose pushes are gated off) is asked to
+  re-pull via `workspace/diagnostic/refresh` when it advertised `refreshSupport`
+  (`client_supports_diagnostic_refresh`), else it re-pulls on its own cadence.
+  `workspace/configuration` pull is deferred. A rule-less/absent config or `enable:false`
   lints nothing silently; a malformed one lints nothing but is surfaced once via
   `window/showMessage` (no hard exit-2). **Position encoding is the one load-bearing
   piece:** LSP columns are UTF-16 code units by default (NOT ryl's 1-based code-point

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -14,7 +14,7 @@ hover only explains ryl's own diagnostics.
 
 | Capability | LSP feature | Behaviour |
 | --- | --- | --- |
-| Diagnostics (push) | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change |
+| Diagnostics (push) | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change. Sent only to a client that does *not* advertise the pull model (see below) |
 | Diagnostics (pull) | `textDocument/diagnostic`, `workspace/diagnostic` | On-demand diagnostics for one document or every `*.yaml`/`*.yml` under the workspace root |
 | Fix all | `source.fixAll.ryl` code action | Applies every safe fix to the document (the `--fix` set) |
 | Fix all of one rule | `source.fixAll.ryl.<rule>` code action | Applies just one safe-fixable rule's fixes (offered per rule with a diagnostic) |
@@ -22,7 +22,7 @@ hover only explains ryl's own diagnostics.
 | Formatting | `textDocument/formatting` | Same as "fix all": formatting *is* applying safe fixes |
 | Hover | `textDocument/hover` | The rule and message for a diagnostic under the cursor, with a link to the rules reference |
 | Rename | `textDocument/rename`, `textDocument/prepareRename` | Rename a YAML anchor/alias and every same-name use in its document |
-| Config watching | `workspace/didChangeWatchedFiles` | Re-lints open documents when a ryl/yamllint config file changes on disk |
+| Config watching | `workspace/didChangeWatchedFiles` | When a ryl/yamllint config file changes on disk, re-lints open documents (push clients) or asks pull clients to re-pull via `workspace/diagnostic/refresh` |
 
 The fix-all action and formatting both apply ryl's whole-file safe fixes; ryl has no
 per-occurrence "fix just this one" action, because its fix engine operates per file (the
@@ -111,6 +111,16 @@ format-on-save via `editor.defaultFormatter`.
 - **Rename** targets YAML anchors/aliases only (not Markdown-embedded YAML), and is scoped
   to the document the anchor lives in: a name reused across a `---`/`...` boundary is a
   distinct anchor and is left untouched.
+- **Push vs pull is chosen per client, never both.** The server advertises the pull model
+  (`textDocument/diagnostic`) *and* can push (`textDocument/publishDiagnostics`), but emits
+  only one per document: if the client advertises pull support, the server relies on pull and
+  does not push. The LSP spec does not say how the two models interact when a server supports
+  both, and clients that keep them in separate diagnostic collections (VS Code via
+  `vscode-languageclient`) would otherwise show every problem twice. A client that does not
+  advertise pull (older editors) still gets pushes as before. After a config change, a pull
+  client is asked to re-pull via `workspace/diagnostic/refresh` (if it advertised
+  `refreshSupport`), since its gated-off push results would otherwise leave stale diagnostics
+  on screen; a pull client without that capability re-pulls only on its own cadence.
 - **Workspace pull diagnostics** cover `*.yaml`/`*.yml` files under each workspace root
   (git-ignored files excluded); Markdown and files matched only by custom `[files]` globs
   are diagnosed when opened or pulled individually. The scan runs on a background thread

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1645,7 +1645,7 @@ hover only explains ryl's own diagnostics.
 
 | Capability | LSP feature | Behaviour |
 | --- | --- | --- |
-| Diagnostics (push) | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change |
+| Diagnostics (push) | `textDocument/publishDiagnostics` | Every enabled rule, re-linted on open and on each change. Sent only to a client that does *not* advertise the pull model (see below) |
 | Diagnostics (pull) | `textDocument/diagnostic`, `workspace/diagnostic` | On-demand diagnostics for one document or every `*.yaml`/`*.yml` under the workspace root |
 | Fix all | `source.fixAll.ryl` code action | Applies every safe fix to the document (the `--fix` set) |
 | Fix all of one rule | `source.fixAll.ryl.<rule>` code action | Applies just one safe-fixable rule's fixes (offered per rule with a diagnostic) |
@@ -1653,7 +1653,7 @@ hover only explains ryl's own diagnostics.
 | Formatting | `textDocument/formatting` | Same as "fix all": formatting *is* applying safe fixes |
 | Hover | `textDocument/hover` | The rule and message for a diagnostic under the cursor, with a link to the rules reference |
 | Rename | `textDocument/rename`, `textDocument/prepareRename` | Rename a YAML anchor/alias and every same-name use in its document |
-| Config watching | `workspace/didChangeWatchedFiles` | Re-lints open documents when a ryl/yamllint config file changes on disk |
+| Config watching | `workspace/didChangeWatchedFiles` | When a ryl/yamllint config file changes on disk, re-lints open documents (push clients) or asks pull clients to re-pull via `workspace/diagnostic/refresh` |
 
 The fix-all action and formatting both apply ryl's whole-file safe fixes; ryl has no
 per-occurrence "fix just this one" action, because its fix engine operates per file (the
@@ -1742,6 +1742,16 @@ format-on-save via `editor.defaultFormatter`.
 - **Rename** targets YAML anchors/aliases only (not Markdown-embedded YAML), and is scoped
   to the document the anchor lives in: a name reused across a `---`/`...` boundary is a
   distinct anchor and is left untouched.
+- **Push vs pull is chosen per client, never both.** The server advertises the pull model
+  (`textDocument/diagnostic`) *and* can push (`textDocument/publishDiagnostics`), but emits
+  only one per document: if the client advertises pull support, the server relies on pull and
+  does not push. The LSP spec does not say how the two models interact when a server supports
+  both, and clients that keep them in separate diagnostic collections (VS Code via
+  `vscode-languageclient`) would otherwise show every problem twice. A client that does not
+  advertise pull (older editors) still gets pushes as before. After a config change, a pull
+  client is asked to re-pull via `workspace/diagnostic/refresh` (if it advertised
+  `refreshSupport`), since its gated-off push results would otherwise leave stale diagnostics
+  on screen; a pull client without that capability re-pulls only on its own cadence.
 - **Workspace pull diagnostics** cover `*.yaml`/`*.yml` files under each workspace root
   (git-ignored files excluded); Markdown and files matched only by custom `[files]` globs
   are diagnosed when opened or pulled individually. The scan runs on a background thread

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -104,6 +104,9 @@ pub fn serve(connection: &Connection) -> SessionOutcome {
     let Ok((id, raw_params)) = connection.initialize_start() else {
         return SessionOutcome::Clean;
     };
+    // Read before `from_value` consumes `raw_params`: this capability lives at a JSON key
+    // `lsp-types` cannot reach (see `client_supports_diagnostic_refresh`).
+    let supports_diagnostic_refresh = client_supports_diagnostic_refresh(&raw_params);
     let params: InitializeParams = match serde_json::from_value(raw_params) {
         Ok(params) => params,
         Err(error) => {
@@ -164,7 +167,7 @@ pub fn serve(connection: &Connection) -> SessionOutcome {
             .and_then(|workspace_edit| workspace_edit.document_changes)
             .unwrap_or(false),
         push_diagnostics: !client_supports_pull_diagnostics(&params),
-        supports_diagnostic_refresh: client_supports_diagnostic_refresh(&params),
+        supports_diagnostic_refresh,
         next_refresh_id: 0,
         settings,
         documents: HashMap::new(),
@@ -232,13 +235,17 @@ fn client_supports_pull_diagnostics(params: &InitializeParams) -> bool {
 /// pull client needs it: a config change re-pushes for a push client, but a pull client's
 /// results are gated off, so without a refresh it would keep showing diagnostics computed
 /// under the old config.
-fn client_supports_diagnostic_refresh(params: &InitializeParams) -> bool {
-    params
-        .capabilities
-        .workspace
-        .as_ref()
-        .and_then(|workspace| workspace.diagnostic.as_ref())
-        .and_then(|diagnostic| diagnostic.refresh_support)
+///
+/// Read from the *raw* initialize JSON, not `InitializeParams`: the spec's key is the
+/// plural `workspace.diagnostics.refreshSupport`, but `lsp-types` 0.97 deserializes its
+/// `WorkspaceClientCapabilities::diagnostic` from the singular `workspace.diagnostic` key
+/// (no rename — a known bug, tower-lsp-community/tower-lsp-server#50), so the typed field
+/// is always `None` for a conforming client (VS Code included). The textDocument pull
+/// capability above is genuinely singular per spec, so it stays on the typed path.
+fn client_supports_diagnostic_refresh(raw_params: &serde_json::Value) -> bool {
+    raw_params
+        .pointer("/capabilities/workspace/diagnostics/refreshSupport")
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false)
 }
 

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -163,6 +163,9 @@ pub fn serve(connection: &Connection) -> SessionOutcome {
             .and_then(|workspace| workspace.workspace_edit.as_ref())
             .and_then(|workspace_edit| workspace_edit.document_changes)
             .unwrap_or(false),
+        push_diagnostics: !client_supports_pull_diagnostics(&params),
+        supports_diagnostic_refresh: client_supports_diagnostic_refresh(&params),
+        next_refresh_id: 0,
         settings,
         documents: HashMap::new(),
         reported_errors: HashSet::new(),
@@ -207,6 +210,35 @@ fn client_supports_watch_registration(params: &InitializeParams) -> bool {
         .as_ref()
         .and_then(|workspace| workspace.did_change_watched_files.as_ref())
         .and_then(|watched| watched.dynamic_registration)
+        .unwrap_or(false)
+}
+
+/// Whether the client uses the LSP 3.17 pull-diagnostics model (it advertised the
+/// `textDocument/diagnostic` capability). When it does, the server must *not* also
+/// push `publishDiagnostics`: clients that keep the push and pull channels in
+/// separate collections (e.g. VS Code via `vscode-languageclient`) would then list
+/// every diagnostic twice. The spec is silent on how the two models interact, so the
+/// robust, client-agnostic rule is to emit only one model per document.
+fn client_supports_pull_diagnostics(params: &InitializeParams) -> bool {
+    params
+        .capabilities
+        .text_document
+        .as_ref()
+        .and_then(|text_document| text_document.diagnostic.as_ref())
+        .is_some()
+}
+
+/// Whether the client accepts a server-initiated `workspace/diagnostic/refresh`. Only a
+/// pull client needs it: a config change re-pushes for a push client, but a pull client's
+/// results are gated off, so without a refresh it would keep showing diagnostics computed
+/// under the old config.
+fn client_supports_diagnostic_refresh(params: &InitializeParams) -> bool {
+    params
+        .capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.diagnostic.as_ref())
+        .and_then(|diagnostic| diagnostic.refresh_support)
         .unwrap_or(false)
 }
 
@@ -271,6 +303,24 @@ fn register_config_watchers(connection: &Connection, config_file: Option<&Path>)
             RequestId::from("ryl-register-watchers".to_string()),
             "client/registerCapability".to_string(),
             params,
+        )),
+    );
+}
+
+/// Ask a pull-capable client to re-pull every diagnostic (LSP `workspace/diagnostic/refresh`,
+/// which takes no params). Fire-and-forget — the response is ignored by the message loop —
+/// but `seq` still makes the id unique so a client can correlate concurrent refreshes.
+///
+/// `Value::Null` is the spec-correct no-params shape here, not a malformed `"params":null`:
+/// `lsp_server::Request` tags `params` with `skip_serializing_if = Value::is_null`, so a null
+/// is omitted from the wire entirely (`{"id":..,"method":..}`).
+fn request_diagnostic_refresh(connection: &Connection, seq: i32) {
+    send(
+        connection,
+        Message::Request(Request::new(
+            RequestId::from(format!("ryl-refresh-diagnostics-{seq}")),
+            "workspace/diagnostic/refresh".to_string(),
+            serde_json::Value::Null,
         )),
     );
 }
@@ -348,6 +398,17 @@ struct Server {
     roots: Vec<PathBuf>,
     /// Whether the client supports `WorkspaceEdit.documentChanges` (versioned edits).
     supports_document_changes: bool,
+    /// Whether to proactively push `publishDiagnostics`. False when the client uses the
+    /// pull model (see [`client_supports_pull_diagnostics`]), so it gets diagnostics
+    /// once via pull instead of twice.
+    push_diagnostics: bool,
+    /// Whether the client accepts `workspace/diagnostic/refresh`, so a pull client can be
+    /// asked to re-pull after a config change (see [`client_supports_diagnostic_refresh`]).
+    supports_diagnostic_refresh: bool,
+    /// Monotonic counter for `workspace/diagnostic/refresh` request ids. Each refresh needs
+    /// a distinct id so a client can correlate its response (JSON-RPC forbids reusing an id
+    /// for a still-outstanding request, and config changes can fire several in a row).
+    next_refresh_id: i32,
     /// Client-provided overrides and on/off toggle.
     settings: Settings,
     /// Open documents, keyed by their URI string.
@@ -485,21 +546,16 @@ impl Server {
                 if let Some(params) = parse::<DidCloseTextDocumentParams>(&params) {
                     let uri = params.text_document.uri;
                     self.documents.remove(uri.as_str());
-                    publish(connection, uri, None, Vec::new());
+                    self.push(connection, uri, None, Vec::new());
                 }
             }
-            // A watched config file changed: config is resolved per request (no cache),
-            // so just re-lint open docs. Clear the surfaced-errors set so a still-broken
-            // config re-reports once.
-            "workspace/didChangeWatchedFiles" => {
-                self.reported_errors.clear();
-                self.relint_open_documents(connection);
-            }
+            // A watched config file changed: config is resolved per request (no cache), so
+            // make open documents' diagnostics catch up (see `handle_config_change`).
+            "workspace/didChangeWatchedFiles" => self.handle_config_change(connection),
             "workspace/didChangeConfiguration" => {
                 if let Some(params) = parse::<DidChangeConfigurationParams>(&params) {
                     self.settings = Settings::from_options(Some(&params.settings));
-                    self.reported_errors.clear();
-                    self.relint_open_documents(connection);
+                    self.handle_config_change(connection);
                 }
             }
             // Cancel an in-flight workspace scan: flip its cancel flag so the worker stops
@@ -575,7 +631,41 @@ impl Server {
                 text,
             },
         );
-        publish(connection, uri, Some(version), diagnostics);
+        self.push(connection, uri, Some(version), diagnostics);
+    }
+
+    /// Push diagnostics to the client, unless it uses the pull model (then it owns
+    /// when to fetch them and a second push would double-report). Both the `update`
+    /// republish and the `didClose` clear route through here so the policy lives in
+    /// one place.
+    fn push(
+        &self,
+        connection: &Connection,
+        uri: Uri,
+        version: Option<i32>,
+        diagnostics: Vec<Diagnostic>,
+    ) {
+        if self.push_diagnostics {
+            publish(connection, uri, version, diagnostics);
+        }
+    }
+
+    /// React to a config or watched-file change. A push client gets a fresh re-push of
+    /// every open document; a pull client (whose push results are gated off) is asked to
+    /// re-pull via `workspace/diagnostic/refresh`, so it does not keep showing diagnostics
+    /// computed under the old config — config errors included, which it surfaces as a pull
+    /// diagnostic. A pull client that did not advertise refresh support re-pulls only on
+    /// its own cadence (an unavoidable client limitation).
+    fn handle_config_change(&mut self, connection: &Connection) {
+        // Clear the surfaced-errors set so a still-broken config re-reports once (push
+        // path); the pull path resurfaces it per document on the triggered re-pull.
+        self.reported_errors.clear();
+        if self.push_diagnostics {
+            self.relint_open_documents(connection);
+        } else if self.supports_diagnostic_refresh {
+            self.next_refresh_id += 1;
+            request_diagnostic_refresh(connection, self.next_refresh_id);
+        }
     }
 
     /// Re-lint and republish every open document (after a config or watched-file change).

--- a/tests/lsp_server.rs
+++ b/tests/lsp_server.rs
@@ -13,15 +13,16 @@ use std::thread::{self, JoinHandle};
 use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
     ClientCapabilities, CodeActionContext, CodeActionKind, CodeActionOrCommand,
-    CodeActionParams, CodeActionResponse, Diagnostic, DidChangeTextDocumentParams,
+    CodeActionParams, CodeActionResponse, Diagnostic, DiagnosticClientCapabilities,
+    DiagnosticWorkspaceClientCapabilities, DidChangeTextDocumentParams,
     DidChangeWatchedFilesClientCapabilities, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DocumentChanges, DocumentDiagnosticReport,
     DocumentFormattingParams, FormattingOptions, GeneralClientCapabilities, Hover,
     HoverContents, InitializeParams, InitializeResult, NumberOrString, OneOf,
     PartialResultParams, Position, PositionEncodingKind, PrepareRenameResponse,
-    PublishDiagnosticsParams, Range, TextDocumentContentChangeEvent,
-    TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri,
-    VersionedTextDocumentIdentifier, WorkDoneProgressParams,
+    PublishDiagnosticsParams, Range, TextDocumentClientCapabilities,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, TextEdit,
+    Uri, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
     WorkspaceClientCapabilities, WorkspaceDiagnosticReport,
     WorkspaceDocumentDiagnosticReport, WorkspaceEdit, WorkspaceEditClientCapabilities,
     WorkspaceFolder,
@@ -57,6 +58,30 @@ fn project(config: &str) -> TempDir {
     dir
 }
 
+/// Assert none of the drained notifications is a diagnostics push — the invariant a
+/// pull-capable client relies on: it gets diagnostics only via pull, never an extra
+/// push that a client merging the two channels (VS Code) would double-count.
+fn assert_no_diagnostics_push(notifications: &[Notification]) {
+    assert!(
+        notifications
+            .iter()
+            .all(|note| note.method != "textDocument/publishDiagnostics"),
+        "a pull-capable client must not receive a publishDiagnostics push"
+    );
+}
+
+/// The diagnostic items from a `textDocument/diagnostic` full-report response (ryl never
+/// caches result ids, so the report is always full).
+fn pull_items(response: Response) -> Vec<Diagnostic> {
+    let report: DocumentDiagnosticReport =
+        serde_json::from_value(response.result.expect("diagnostic result"))
+            .expect("DocumentDiagnosticReport");
+    let DocumentDiagnosticReport::Full(report) = report else {
+        panic!("expected a full report");
+    };
+    report.full_document_diagnostic_report.items
+}
+
 /// A one-character ryl diagnostic for `rule` at a 0-based position, as a client echoes
 /// back in a code-action request's context (carrying ryl's `source` as the real server
 /// does, so the source filter accepts it).
@@ -90,16 +115,7 @@ impl Client {
 
     /// Launch advertising several workspace folders (a multi-root workspace).
     fn launch_roots(roots: &[&Path]) -> (Self, InitializeResult) {
-        let (server, client) = Connection::memory();
-        let thread = thread::spawn(move || {
-            let _ = ryl::lsp::serve(&server);
-        });
-        let mut this = Client {
-            conn: Some(client),
-            thread: Some(thread),
-            next_id: 0,
-        };
-        let params = InitializeParams {
+        Self::launch_params(InitializeParams {
             workspace_folders: Some(
                 roots
                     .iter()
@@ -110,6 +126,59 @@ impl Client {
                     .collect(),
             ),
             ..Default::default()
+        })
+    }
+
+    /// Launch advertising the LSP 3.17 pull-diagnostics client capability (plus versioned
+    /// edits, as a real pull client like VS Code does). The server must then rely on pull
+    /// and never push `publishDiagnostics`. `refresh_support` advertises
+    /// `workspace/diagnostic/refresh` so a config change can ask the client to re-pull.
+    fn launch_pull(
+        root: Option<&Path>,
+        refresh_support: bool,
+    ) -> (Self, InitializeResult) {
+        Self::launch_params(InitializeParams {
+            capabilities: ClientCapabilities {
+                text_document: Some(TextDocumentClientCapabilities {
+                    diagnostic: Some(DiagnosticClientCapabilities::default()),
+                    ..Default::default()
+                }),
+                workspace: Some(WorkspaceClientCapabilities {
+                    workspace_edit: Some(WorkspaceEditClientCapabilities {
+                        document_changes: Some(true),
+                        ..Default::default()
+                    }),
+                    diagnostic: refresh_support.then_some(
+                        DiagnosticWorkspaceClientCapabilities {
+                            refresh_support: Some(true),
+                        },
+                    ),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            workspace_folders: root.map(|path| {
+                vec![WorkspaceFolder {
+                    uri: file_uri(path, ""),
+                    name: "root".to_string(),
+                }]
+            }),
+            ..Default::default()
+        })
+    }
+
+    /// Spawn a server thread and complete the `initialize`/`initialized` handshake with
+    /// the given client capabilities. The bespoke launches build their own params; the
+    /// positional `launch_with` chain goes through `initialize` instead.
+    fn launch_params(params: InitializeParams) -> (Self, InitializeResult) {
+        let (server, client) = Connection::memory();
+        let thread = thread::spawn(move || {
+            let _ = ryl::lsp::serve(&server);
+        });
+        let mut this = Client {
+            conn: Some(client),
+            thread: Some(thread),
+            next_id: 0,
         };
         let id = this.request("initialize", params);
         let response = this.response(&id);
@@ -194,6 +263,42 @@ impl Client {
             match self.conn().receiver.recv().expect("recv") {
                 Message::Response(response) if &response.id == id => return response,
                 _ => {}
+            }
+        }
+    }
+
+    /// Drain messages up to and including the response to `id`, returning every
+    /// notification seen on the way. Because the server's loop is single-threaded and
+    /// in-order, any push triggered by an earlier notification arrives before this
+    /// response — so a test can assert a pull-capable client got *no* `publishDiagnostics`.
+    fn notifications_until_response(
+        &self,
+        id: &RequestId,
+    ) -> (Vec<Notification>, Response) {
+        let mut notifications = Vec::new();
+        loop {
+            match self.conn().receiver.recv().expect("recv") {
+                Message::Response(response) if &response.id == id => {
+                    return (notifications, response);
+                }
+                Message::Notification(note) => notifications.push(note),
+                _ => {}
+            }
+        }
+    }
+
+    /// Drain messages up to and including the response to `id`, returning every message
+    /// (server-to-client requests *and* notifications) seen on the way. Lets a test assert
+    /// the server sent a particular request — e.g. `workspace/diagnostic/refresh` — while
+    /// confirming no diagnostics push escaped.
+    fn messages_until_response(&self, id: &RequestId) -> (Vec<Message>, Response) {
+        let mut messages = Vec::new();
+        loop {
+            match self.conn().receiver.recv().expect("recv") {
+                Message::Response(response) if &response.id == id => {
+                    return (messages, response);
+                }
+                other => messages.push(other),
             }
         }
     }
@@ -590,6 +695,155 @@ fn did_close_clears_diagnostics() {
     assert!(
         client.diagnostics().is_empty(),
         "closing clears diagnostics"
+    );
+}
+
+// Regression for #323: when the client advertises the pull model, the server must not
+// *also* push `publishDiagnostics`. A client that keeps the push and pull channels in
+// separate collections (VS Code via `vscode-languageclient`) would otherwise list every
+// diagnostic twice. Every other test launches a push-only client, so they pin that the
+// push path still works; these pin the pull path stays silent across open/change/close.
+#[test]
+fn pull_capable_client_receives_no_push_on_open() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch_pull(None, false);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    // A pull request flushes the loop: any stray push from didOpen would arrive ahead
+    // of this response. The response must still carry the violation (pull works).
+    let id = client.request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": doc } }),
+    );
+    let (notifications, response) = client.notifications_until_response(&id);
+    assert_no_diagnostics_push(&notifications);
+    assert_eq!(
+        pull_items(response).len(),
+        1,
+        "pull still reports the trailing space"
+    );
+}
+
+#[test]
+fn pull_capable_client_receives_no_push_on_change() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch_pull(None, false);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1\n");
+    client.did_change(doc.clone(), "a: 1 \n");
+    let id = client.request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": doc } }),
+    );
+    let (notifications, response) = client.notifications_until_response(&id);
+    assert_no_diagnostics_push(&notifications);
+    // The change introduced the trailing space; pull must reflect the new state, not the
+    // clean text opened a moment ago.
+    assert_eq!(
+        pull_items(response).len(),
+        1,
+        "pull reflects the post-change buffer"
+    );
+}
+
+#[test]
+fn pull_capable_client_receives_no_clear_on_close() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch_pull(None, false);
+    let doc = file_uri(dir.path(), "x.yaml");
+    client.did_open(doc.clone(), "a: 1 \n");
+    client.did_close(doc);
+    // The didClose clear is a push too; probe with an unhandled request so any escaped
+    // clear arrives before the probe's error response.
+    let id = client.request(UNHANDLED_METHOD, Value::Null);
+    let (notifications, response) = client.notifications_until_response(&id);
+    assert_no_diagnostics_push(&notifications);
+    assert!(response.error.is_some(), "the probe is still answered");
+}
+
+// A pull client's diagnostics are gated off, so after a config change it must be told to
+// re-pull (LSP `workspace/diagnostic/refresh`) or it would keep showing diagnostics from
+// the old config. Push clients re-push instead (covered by the *_relints tests above).
+#[test]
+fn pull_client_is_asked_to_refresh_after_config_change() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch_pull(Some(dir.path()), true);
+    client.did_open(file_uri(dir.path(), "x.yaml"), "a: 1 \n");
+    // Simulate the watched config file changing on disk.
+    client.notify("workspace/didChangeWatchedFiles", json!({ "changes": [] }));
+    // Flush with a probe; any refresh request / stray push arrives before its response.
+    let id = client.request(UNHANDLED_METHOD, Value::Null);
+    let (messages, response) = client.messages_until_response(&id);
+    assert!(response.error.is_some(), "the probe is still answered");
+    let refreshes = messages
+        .iter()
+        .filter(|message| {
+            matches!(message, Message::Request(request)
+                if request.method == "workspace/diagnostic/refresh")
+        })
+        .count();
+    assert_eq!(
+        refreshes, 1,
+        "a pull client is asked to re-pull after a config change"
+    );
+    assert!(
+        messages.iter().all(|message| {
+            !matches!(message, Message::Notification(note)
+                if note.method == "textDocument/publishDiagnostics")
+        }),
+        "the refresh replaces a push for a pull client, it does not accompany one"
+    );
+}
+
+#[test]
+fn repeated_config_changes_send_distinct_refresh_request_ids() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch_pull(Some(dir.path()), true);
+    client.did_open(file_uri(dir.path(), "x.yaml"), "a: 1 \n");
+    // Two changes before any response: their refresh requests are concurrently outstanding,
+    // so reusing one id would break the client's response correlation (JSON-RPC).
+    client.notify("workspace/didChangeWatchedFiles", json!({ "changes": [] }));
+    client.notify("workspace/didChangeWatchedFiles", json!({ "changes": [] }));
+    let id = client.request(UNHANDLED_METHOD, Value::Null);
+    let (messages, response) = client.messages_until_response(&id);
+    assert!(response.error.is_some(), "the probe is still answered");
+    let refresh_ids: Vec<_> = messages
+        .iter()
+        .filter_map(|message| match message {
+            Message::Request(request)
+                if request.method == "workspace/diagnostic/refresh" =>
+            {
+                Some(request.id.clone())
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        refresh_ids.len(),
+        2,
+        "each config change asks for a refresh"
+    );
+    assert_ne!(
+        refresh_ids[0], refresh_ids[1],
+        "concurrent refreshes use distinct ids so the client can correlate responses"
+    );
+}
+
+#[test]
+fn pull_client_without_refresh_support_gets_no_refresh() {
+    let dir = project(TRAILING);
+    let (mut client, _init) = Client::launch_pull(Some(dir.path()), false);
+    client.did_open(file_uri(dir.path(), "x.yaml"), "a: 1 \n");
+    client.notify("workspace/didChangeWatchedFiles", json!({ "changes": [] }));
+    let id = client.request(UNHANDLED_METHOD, Value::Null);
+    let (messages, response) = client.messages_until_response(&id);
+    assert!(response.error.is_some(), "the probe is still answered");
+    assert!(
+        messages.iter().all(|message| {
+            !matches!(message, Message::Request(request)
+                if request.method == "workspace/diagnostic/refresh")
+        }),
+        "no refresh is sent to a client that did not advertise support for it"
     );
 }
 

--- a/tests/lsp_server.rs
+++ b/tests/lsp_server.rs
@@ -14,15 +14,15 @@ use lsp_server::{Connection, Message, Notification, Request, RequestId, Response
 use lsp_types::{
     ClientCapabilities, CodeActionContext, CodeActionKind, CodeActionOrCommand,
     CodeActionParams, CodeActionResponse, Diagnostic, DiagnosticClientCapabilities,
-    DiagnosticWorkspaceClientCapabilities, DidChangeTextDocumentParams,
-    DidChangeWatchedFilesClientCapabilities, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DocumentChanges, DocumentDiagnosticReport,
-    DocumentFormattingParams, FormattingOptions, GeneralClientCapabilities, Hover,
-    HoverContents, InitializeParams, InitializeResult, NumberOrString, OneOf,
-    PartialResultParams, Position, PositionEncodingKind, PrepareRenameResponse,
-    PublishDiagnosticsParams, Range, TextDocumentClientCapabilities,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, TextEdit,
-    Uri, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
+    DidChangeTextDocumentParams, DidChangeWatchedFilesClientCapabilities,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DocumentChanges,
+    DocumentDiagnosticReport, DocumentFormattingParams, FormattingOptions,
+    GeneralClientCapabilities, Hover, HoverContents, InitializeParams,
+    InitializeResult, NumberOrString, OneOf, PartialResultParams, Position,
+    PositionEncodingKind, PrepareRenameResponse, PublishDiagnosticsParams, Range,
+    TextDocumentClientCapabilities, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri,
+    VersionedTextDocumentIdentifier, WorkDoneProgressParams,
     WorkspaceClientCapabilities, WorkspaceDiagnosticReport,
     WorkspaceDocumentDiagnosticReport, WorkspaceEdit, WorkspaceEditClientCapabilities,
     WorkspaceFolder,
@@ -137,7 +137,7 @@ impl Client {
         root: Option<&Path>,
         refresh_support: bool,
     ) -> (Self, InitializeResult) {
-        Self::launch_params(InitializeParams {
+        let mut params = serde_json::to_value(InitializeParams {
             capabilities: ClientCapabilities {
                 text_document: Some(TextDocumentClientCapabilities {
                     diagnostic: Some(DiagnosticClientCapabilities::default()),
@@ -148,11 +148,6 @@ impl Client {
                         document_changes: Some(true),
                         ..Default::default()
                     }),
-                    diagnostic: refresh_support.then_some(
-                        DiagnosticWorkspaceClientCapabilities {
-                            refresh_support: Some(true),
-                        },
-                    ),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -165,12 +160,22 @@ impl Client {
             }),
             ..Default::default()
         })
+        .expect("serialize initialize params");
+        if refresh_support {
+            // A real client (VS Code) advertises refresh support at the spec's plural
+            // `workspace.diagnostics.refreshSupport`; lsp-types can only emit the singular
+            // `diagnostic` key, so inject the plural key the server actually reads. Sending
+            // the lsp-types field instead would mask the very bug the server works around.
+            params["capabilities"]["workspace"]["diagnostics"] =
+                json!({ "refreshSupport": true });
+        }
+        Self::launch_params(params)
     }
 
     /// Spawn a server thread and complete the `initialize`/`initialized` handshake with
     /// the given client capabilities. The bespoke launches build their own params; the
     /// positional `launch_with` chain goes through `initialize` instead.
-    fn launch_params(params: InitializeParams) -> (Self, InitializeResult) {
+    fn launch_params<P: serde::Serialize>(params: P) -> (Self, InitializeResult) {
         let (server, client) = Connection::memory();
         let thread = thread::spawn(move || {
             let _ = ryl::lsp::serve(&server);

--- a/tests/property_lsp_protocol.rs
+++ b/tests/property_lsp_protocol.rs
@@ -19,19 +19,21 @@
 #[path = "property_check/strategy.rs"]
 mod strategy;
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use lsp_server::{Connection, Message, Notification, Request, RequestId};
+use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
-    CodeActionContext, CodeActionParams, DidChangeTextDocumentParams,
-    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DocumentFormattingParams,
-    FormattingOptions, InitializeParams, PartialResultParams, Position,
-    PublishDiagnosticsParams, Range, TextDocumentContentChangeEvent,
-    TextDocumentIdentifier, TextDocumentItem, Uri, VersionedTextDocumentIdentifier,
-    WorkDoneProgressParams,
+    ClientCapabilities, CodeActionContext, CodeActionParams, Diagnostic,
+    DiagnosticClientCapabilities, DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DocumentDiagnosticReport,
+    DocumentFormattingParams, FormattingOptions, InitializeParams, PartialResultParams,
+    Position, PublishDiagnosticsParams, Range, TextDocumentClientCapabilities,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Uri,
+    VersionedTextDocumentIdentifier, WorkDoneProgressParams,
 };
 use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
@@ -57,7 +59,30 @@ struct Driver {
 }
 
 impl Driver {
+    /// Default client capabilities -> a push client (the server negotiates UTF-16 and
+    /// pushes diagnostics).
     fn start() -> Self {
+        Self::launch(to_value(InitializeParams::default()).expect("serialize init"))
+    }
+
+    /// A pull-capable client (it advertises `textDocument/diagnostic`). The server must
+    /// then rely on pull and never push `publishDiagnostics`.
+    fn start_pull() -> Self {
+        let init = to_value(InitializeParams {
+            capabilities: ClientCapabilities {
+                text_document: Some(TextDocumentClientCapabilities {
+                    diagnostic: Some(DiagnosticClientCapabilities::default()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .expect("serialize init");
+        Self::launch(init)
+    }
+
+    fn launch(init: Value) -> Self {
         let (server, client) = Connection::memory();
         let thread = thread::spawn(move || {
             let _ = ryl::lsp::serve(&server);
@@ -67,8 +92,6 @@ impl Driver {
             thread: Some(thread),
             next_id: 0,
         };
-        // Default client capabilities -> the server negotiates UTF-16.
-        let init = to_value(InitializeParams::default()).expect("serialize init");
         let id = driver.request("initialize", init);
         let _ = driver.await_response(&id);
         driver.notify("initialized", Value::Null);
@@ -87,6 +110,51 @@ impl Driver {
                 params,
             )))
             .expect("send notification");
+    }
+
+    // The document-lifecycle notifications, shared by every replay loop so the message
+    // shapes have a single source of truth (a `range`-less change is a full replace).
+    fn open(&self, uri: &Uri, version: i32, text: &str) {
+        self.notify(
+            "textDocument/didOpen",
+            to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "yaml".to_string(),
+                    version,
+                    text: text.to_string(),
+                },
+            })
+            .expect("serialize"),
+        );
+    }
+
+    fn change_full(&self, uri: &Uri, version: i32, text: &str) {
+        self.notify(
+            "textDocument/didChange",
+            to_value(DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: uri.clone(),
+                    version,
+                },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: text.to_string(),
+                }],
+            })
+            .expect("serialize"),
+        );
+    }
+
+    fn close(&self, uri: &Uri) {
+        self.notify(
+            "textDocument/didClose",
+            to_value(DidCloseTextDocumentParams {
+                text_document: TextDocumentIdentifier { uri: uri.clone() },
+            })
+            .expect("serialize"),
+        );
     }
 
     fn request(&mut self, method: &str, params: Value) -> RequestId {
@@ -115,6 +183,26 @@ impl Driver {
             let message = self.recv();
             if matches!(&message, Message::Response(response) if &response.id == id) {
                 return message;
+            }
+        }
+    }
+
+    /// Drain messages up to the response to `id`, returning every notification seen on
+    /// the way plus that response. The loop is single-threaded and in-order, so any push
+    /// an earlier op triggered arrives before this response — letting the pull-client
+    /// test assert no `publishDiagnostics` escaped while still inspecting the pull result.
+    fn notifications_until_response(
+        &self,
+        id: &RequestId,
+    ) -> (Vec<Notification>, Response) {
+        let mut notifications = Vec::new();
+        loop {
+            match self.recv() {
+                Message::Response(response) if &response.id == id => {
+                    return (notifications, response);
+                }
+                Message::Notification(note) => notifications.push(note),
+                _ => {}
             }
         }
     }
@@ -222,6 +310,60 @@ fn arb_op() -> impl Strategy<Value = Op> {
     ]
 }
 
+/// The document-lifecycle ops — the only ones that publish diagnostics — for the
+/// capability-respecting property. Separate from [`Op`] so that test replays just the
+/// channel-relevant ops (request ops never push, so they would only dilute the property).
+#[derive(Debug, Clone)]
+enum DocOp {
+    Open(u8, String),
+    Change(u8, String),
+    Close(u8),
+}
+
+impl DocOp {
+    fn index(&self) -> u8 {
+        match self {
+            DocOp::Open(index, _) | DocOp::Change(index, _) | DocOp::Close(index) => {
+                *index
+            }
+        }
+    }
+}
+
+fn arb_doc_op() -> impl Strategy<Value = DocOp> {
+    let index = 0u8..DOC_POOL;
+    prop_oneof![
+        (
+            index.clone(),
+            any::<bool>(),
+            arb_document().prop_map(|document| document.render())
+        )
+            .prop_map(|(index, is_open, text)| if is_open {
+                DocOp::Open(index, text)
+            } else {
+                DocOp::Change(index, text)
+            }),
+        index.prop_map(DocOp::Close),
+    ]
+}
+
+/// A fresh lint of `text` as the document at `dir/doc{index}.yaml`, computed the same
+/// way the server does (per-document config discovery, UTF-16 columns). Both diagnostic
+/// channels must reproduce this exactly, so it is the oracle for push and pull alike.
+fn fresh_lint(dir: &Path, index: u8, text: &str) -> Vec<Diagnostic> {
+    let path = doc_path(dir, index);
+    let context = discover_config(std::slice::from_ref(&path), &Overrides::default())
+        .expect("config discovers");
+    diagnostics(
+        text,
+        &path,
+        &context.config,
+        &context.base_dir,
+        SourceKind::Yaml,
+        PositionEncoding::Utf16,
+    )
+}
+
 /// didOpen/didChange handling is identical server-side (store + publish); verify
 /// the version echo and that the published diagnostics match a fresh lint.
 fn check_update(
@@ -236,20 +378,9 @@ fn check_update(
         Some(version),
         "publishDiagnostics echoes the document version"
     );
-    let path = doc_path(dir, index);
-    let context = discover_config(std::slice::from_ref(&path), &Overrides::default())
-        .expect("config discovers");
-    let expected = diagnostics(
-        text,
-        &path,
-        &context.config,
-        &context.base_dir,
-        SourceKind::Yaml,
-        PositionEncoding::Utf16,
-    );
     prop_assert_eq!(
         &diagnostics_params.diagnostics,
-        &expected,
+        &fresh_lint(dir, index, text),
         "published diagnostics match a fresh lint of the current text"
     );
     Ok(())
@@ -299,50 +430,18 @@ proptest! {
             match op {
                 Op::Open(index, text) => {
                     version += 1;
-                    let document = TextDocumentItem {
-                        uri: doc_uri(dir.path(), index),
-                        language_id: "yaml".to_string(),
-                        version,
-                        text: text.clone(),
-                    };
-                    driver.notify(
-                        "textDocument/didOpen",
-                        to_value(DidOpenTextDocumentParams { text_document: document })
-                            .expect("serialize"),
-                    );
+                    driver.open(&doc_uri(dir.path(), index), version, &text);
                     let published = driver.await_publish();
                     check_update(dir.path(), index, version, &text, &published)?;
                 }
                 Op::Change(index, text) => {
                     version += 1;
-                    driver.notify(
-                        "textDocument/didChange",
-                        to_value(DidChangeTextDocumentParams {
-                            text_document: VersionedTextDocumentIdentifier {
-                                uri: doc_uri(dir.path(), index),
-                                version,
-                            },
-                            content_changes: vec![TextDocumentContentChangeEvent {
-                                range: None,
-                                range_length: None,
-                                text: text.clone(),
-                            }],
-                        })
-                        .expect("serialize"),
-                    );
+                    driver.change_full(&doc_uri(dir.path(), index), version, &text);
                     let published = driver.await_publish();
                     check_update(dir.path(), index, version, &text, &published)?;
                 }
                 Op::Close(index) => {
-                    driver.notify(
-                        "textDocument/didClose",
-                        to_value(DidCloseTextDocumentParams {
-                            text_document: TextDocumentIdentifier {
-                                uri: doc_uri(dir.path(), index),
-                            },
-                        })
-                        .expect("serialize"),
-                    );
+                    driver.close(&doc_uri(dir.path(), index));
                     let published = driver.await_publish();
                     prop_assert!(
                         published.diagnostics.is_empty(),
@@ -449,6 +548,95 @@ proptest! {
             );
             let published = driver.await_publish();
             check_update(dir.path(), 0, version, &model, &published)?;
+        }
+        driver.shutdown();
+    }
+
+    /// #323 regression, generalized over the advertised capability. A mock client either
+    /// advertises pull support or not, then replays a random didOpen/didChange/didClose
+    /// sequence. The server must use the channel the client asked for — pull-capable ⟹ no
+    /// `publishDiagnostics` push ever (diagnostics arrive only when pulled); push-only ⟹ a
+    /// push per op — and on whichever channel the diagnostics must be a faithful, complete
+    /// lint of the document's current state. Together these pin that an editor merging the
+    /// two channels (VS Code) can neither double-count nor see the channels disagree, for
+    /// either kind of client. Also pins liveness (clean shutdown). `pull` is the only
+    /// client capability that changes diagnostic behaviour, so randomizing it covers the
+    /// relevant capability space.
+    #[test]
+    fn server_respects_diagnostic_capability(
+        pull in any::<bool>(),
+        ops in prop::collection::vec(arb_doc_op(), 0..12),
+    ) {
+        let dir = tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".ryl.toml"), CONFIG).expect("write config");
+        let mut driver = if pull { Driver::start_pull() } else { Driver::start() };
+        let mut version = 0;
+        // Mirror the server's open-buffer store so the expected diagnostics are a fresh
+        // lint of the current buffer (or empty once the doc is closed — the server then
+        // reads the absent on-disk file). A range-less change is a full replace, so the
+        // buffer becomes `text` whether or not the doc was already open.
+        let mut open_text: HashMap<u8, String> = HashMap::new();
+
+        for op in ops {
+            let index = op.index();
+            let uri = doc_uri(dir.path(), index);
+            match op {
+                DocOp::Open(_, text) => {
+                    version += 1;
+                    open_text.insert(index, text.clone());
+                    driver.open(&uri, version, &text);
+                }
+                DocOp::Change(_, text) => {
+                    version += 1;
+                    open_text.insert(index, text.clone());
+                    driver.change_full(&uri, version, &text);
+                }
+                DocOp::Close(_) => {
+                    open_text.remove(&index);
+                    driver.close(&uri);
+                }
+            }
+            let expected = open_text
+                .get(&index)
+                .map(|text| fresh_lint(dir.path(), index, text))
+                .unwrap_or_default();
+
+            if pull {
+                // No push may escape; a flushing pull returns the faithful diagnostics
+                // (any push the op triggered would arrive ahead of this response).
+                let id = driver.request(
+                    "textDocument/diagnostic",
+                    json!({ "textDocument": { "uri": uri } }),
+                );
+                let (notifications, response) =
+                    driver.notifications_until_response(&id);
+                prop_assert!(
+                    notifications
+                        .iter()
+                        .all(|note| note.method != "textDocument/publishDiagnostics"),
+                    "a pull-capable client must never receive a publishDiagnostics push"
+                );
+                let report: DocumentDiagnosticReport =
+                    serde_json::from_value(response.result.expect("pull result"))
+                        .expect("DocumentDiagnosticReport");
+                let DocumentDiagnosticReport::Full(report) = report else {
+                    unreachable!("ryl never caches result ids, so every report is full");
+                };
+                prop_assert_eq!(
+                    report.full_document_diagnostic_report.items,
+                    expected,
+                    "pull returns a faithful, complete lint of the current state"
+                );
+            } else {
+                // A push-only client gets a publishDiagnostics for this op, carrying the
+                // faithful diagnostics (empty once the doc is closed).
+                let published = driver.await_publish();
+                prop_assert_eq!(
+                    published.diagnostics,
+                    expected,
+                    "push carries a faithful, complete lint of the current state"
+                );
+            }
         }
         driver.shutdown();
     }


### PR DESCRIPTION
Closes #323.

## Problem

`ryl server` pushed `textDocument/publishDiagnostics` on every open/change/close
and also advertised the pull model (`textDocument/diagnostic`,
`workspace/diagnostic`). The LSP spec does not define how the two interact when a
server supports both, and clients that keep them in separate collections (VS Code
via `vscode-languageclient`) show every diagnostic twice: a document with 12
problems showed 24.

## Fix

- Gate the proactive push on the client not advertising pull support
  (`textDocument.diagnostic`), captured at `initialize` as
  `Server::push_diagnostics`. Both emission sites (`update` and the `didClose`
  clear) route through one `Server::push` that no-ops for a pull client. Pull
  request handlers are unchanged, so a pull client gets exactly one set via pull
  and a push-only client (older editors) is unaffected.
- After a config change a pull client's relint results would be discarded by the
  gate, leaving stale diagnostics on screen. It is now asked to re-pull via
  `workspace/diagnostic/refresh` when it advertised `refreshSupport` (push
  clients still re-push). Each refresh uses a per-server monotonic id so
  concurrent refreshes stay correlatable.

## Tests

- Deterministic pull-client tests: no push on open/change/close, pull still
  reports faithfully, refresh sent (and not sent without `refreshSupport`),
  distinct ids for concurrent refreshes.
- `server_respects_diagnostic_capability`: a capability-parameterized property
  that randomizes pull support over random open/change/close sequences and
  asserts the server uses the advertised channel and is faithful either way.
- Every new guard was verified to fail without the fix.

## Docs

`docs/editor-integration.md`, the LSP section of `AGENTS.md`, and `llms.txt`.
