### PR TITLE
ci: publish SHA256SUMS with each release (#322)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,6 +415,25 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-path: 'release-assets/*'
+      # Publish one authoritative SHA256SUMS covering every per-target archive so
+      # downstream consumers (the ryl-vscode extension, package managers, manual
+      # installers) can verify and regenerate the hashes. Generated after the attestation
+      # so the checksums file is not itself a build-provenance subject, and uploaded with
+      # the rest below. sha256sum runs inside release-assets so the lines carry bare
+      # archive names, not the release-assets/ prefix.
+      - name: Generate SHA256SUMS
+        working-directory: release-assets
+        shell: bash
+        run: |-
+          set -euo pipefail
+          shopt -s nullglob
+          archives=(ryl-*.tar.gz ryl-*.zip)
+          if [ "${#archives[@]}" -eq 0 ]; then
+            echo "No release archives found to checksum" >&2
+            exit 1
+          fi
+          sha256sum "${archives[@]}" > SHA256SUMS
+          cat SHA256SUMS
       - name: Ensure draft tag release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #322.

Publishes a single authoritative `SHA256SUMS` asset with each release so
downstream consumers (the `ryl-vscode` extension, package managers, manual
installers) can verify and regenerate the per-target binary hashes from one
source rather than self-computing them.

## Change

A `Generate SHA256SUMS` step in the `draft-github-release` job, after the
per-target archives are downloaded and after the build-provenance attestation
(so the checksums file is not itself an attested subject), runs
`sha256sum ryl-*.tar.gz ryl-*.zip > SHA256SUMS` inside `release-assets/` (bare
archive names, no path prefix). The existing upload step then ships it with the
rest of the assets. Assets upload while the release is still a draft, before
publish makes it immutable, so this takes effect from the next release (0.18.1)
onward.

## v0.18.0 intentionally not retro-fitted

The issue also floated retro-adding `SHA256SUMS` to v0.18.0. Releases are
immutable by design (a deliberate security choice), so existing releases are
left as-is; `SHA256SUMS` ships from 0.18.1 onward via this workflow step.

## Note

A same-origin checksums file verifies downloads against corruption, not a fully
compromised release (an attacker replacing the assets could replace the sums
too); downstream consumers still pin the expected hashes for that stronger
guarantee. The value here is a single authoritative source.
