### PR TITLE
v0.18.1: bump version, run CI coverage once (#326), combine dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,29 @@
 version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+
+# Combine cargo and github-actions version updates into a single weekly PR via a
+# Dependabot multi-ecosystem group (GA 2025-07), so each refresh is one PR, not one
+# per ecosystem. `cargo update` in update.yml still refreshes the lockfile within the
+# existing Cargo.toml ranges; Dependabot additionally bumps the Cargo.toml requirements
+# themselves (including major versions like hashlink 0.11 -> 0.12) that `cargo update`
+# leaves alone.
+multi-ecosystem-groups:
+  dependencies:
     schedule:
       interval: "weekly"
       day: "friday"
-    groups:
-      actions-dependencies:
-        patterns:
-          - "*"
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "cargo"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "dependencies"
     cooldown:
       default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run prek hooks (lint and static checks)
         env:
-          SKIP: no-commit-to-branch,nextest
+          SKIP: no-commit-to-branch
         run: prek run --all-files
 
       - name: Check the minimal build (LSP feature compiled out)
@@ -58,12 +58,15 @@ jobs:
       - name: Run tests with coverage (nextest + cargo-llvm-cov)
         run: |-
           set -euo pipefail
+          # Run the suite once; every report below is derived from this single run's
+          # cached profile data via `cargo llvm-cov report` (no re-execution).
+          cargo llvm-cov nextest --no-report
           echo '### Test Coverage (nextest + cargo-llvm-cov)' > coverage.md
           echo '```text' >> coverage.md
-          cargo llvm-cov nextest --summary-only | tee -a coverage.md
+          cargo llvm-cov report --summary-only | tee -a coverage.md
           echo '```' >> coverage.md
           # Produce LCOV for detailed per-line/branch analysis
-          cargo llvm-cov nextest --lcov --output-path lcov.info
+          cargo llvm-cov report --lcov --output-path lcov.info
           echo '' >> coverage.md
           echo '#### Missed Lines (per file)' >> coverage.md
           awk -F: '
@@ -114,7 +117,9 @@ jobs:
 
       - name: Enforce coverage thresholds
         run: |-
-          # Enforce zero missed lines and regions
-          cargo llvm-cov nextest --summary-only \
+          # Enforce zero missed lines and regions, reusing the single test run's data.
+          # Kept as the final step so the coverage report and PR comment are already
+          # produced when a coverage gap fails the job.
+          cargo llvm-cov report --summary-only \
             --fail-uncovered-lines 0 \
             --fail-uncovered-regions 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.18.0"
+  "version": "0.18.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.18.0"
+version = "0.18.1"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Cuts **0.18.1** and folds in two CI improvements to save a separate release-PR round.

## Release 0.18.1

Version bumped across the five version-bearing files (`Cargo.toml`,
`pyproject.toml`, `package.json`, `Cargo.lock`, `uv.lock`). Contents already on
`main`:

- **#323** (PR #324): `ryl server` no longer double-reports diagnostics. The
  `publishDiagnostics` push is gated on the client not advertising the pull model,
  so an editor merging both channels (VS Code) sees each diagnostic once; pull
  clients re-pull via `workspace/diagnostic/refresh` after a config change.
- **#322** (PR #325): each release now publishes a `SHA256SUMS` asset. **0.18.1 is
  the first release to carry it.**

## CI: run coverage once (closes #326)

The `checks` job ran the full suite under coverage three times (summary, LCOV,
gate). It now runs once with `cargo llvm-cov nextest --no-report` and derives all
three from the cached profile data via `cargo llvm-cov report` (verified locally:
each report ~1-2s, gate behaves identically). The gate stays the **final** step, so
a coverage failure still surfaces the missed-line report (artifact + PR comment)
first, and fork PRs still run + gate (only the comment is fork-gated). Also drops
the vestigial `nextest` from the prek `SKIP` (that hook no longer exists).

## Dependabot: cargo, combined into one PR

Adds the `cargo` ecosystem and combines it with `github-actions` into a single
weekly **multi-ecosystem-group** PR (7-day cooldown), so direct `Cargo.toml`
requirement bumps (including the major versions `cargo update` structurally leaves
alone, e.g. `hashlink` 0.11 to 0.12) arrive without a second PR stream.
`update.yml`'s `cargo update` still handles lockfile freshness within the existing
ranges.
