### PR TITLE
feat(config): discover repo-local .config/ ryl config (#218)

### DIFF
--- a/.agents/skills/retrospective/retro-extract.py
+++ b/.agents/skills/retrospective/retro-extract.py
@@ -6,7 +6,7 @@
 # [tool.uv]
 # # One-week dependency cooldown (rolling): ignore releases newer than one week
 # # before each run as a supply-chain-safety buffer.
-# exclude-newer = "1 week ago"
+# exclude-newer = "1 week"
 # ///
 
 """Cheap, deterministic friction extraction from Claude Code session transcripts.

--- a/docs/config-presets.md
+++ b/docs/config-presets.md
@@ -8,12 +8,12 @@ nothing, so what it enables is the file's whole ruleset, with no default-on
 rules.
 
 ryl resolves one config per file by searching upward from the file. A TOML
-config (`.ryl.toml`, `ryl.toml`, or `pyproject.toml` `[tool.ryl]`) found
-anywhere up the tree is preferred over a `.yamllint`, even a nearer one;
-among configs of the same kind the nearest wins. A monorepo can therefore
-hold many `ryl.toml` files, one per subtree, each governing its own files. If
-the upward search finds no project config, ryl falls back to a single
-user-global config; see the
+config (`.ryl.toml`, `ryl.toml`, `.config/.ryl.toml`, `.config/ryl.toml`, or
+`pyproject.toml` `[tool.ryl]`, in that precedence order) found anywhere up the
+tree is preferred over a `.yamllint`, even a nearer one; among configs of the
+same kind the nearest wins. A monorepo can therefore hold many `ryl.toml`
+files, one per subtree, each governing its own files. If the upward search
+finds no project config, ryl falls back to a single user-global config; see the
 [quick start](getting-started/quickstart.md).
 
 Presets are starting points for that config, not something ryl inherits behind

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -147,6 +147,23 @@ discovered automatically. TOML is the recommended format for ryl-specific
 features (such as fix selection) that have no upstream yamllint
 equivalent.
 
+To keep config out of the project root, ryl also discovers a ryl-native TOML
+config inside a repo-local `.config/` directory (the RuboCop/rumdl convention).
+At each directory in the upward search the candidates are tried in this order,
+and the first match wins:
+
+1. `.ryl.toml`
+2. `ryl.toml`
+3. `.config/.ryl.toml`
+4. `.config/ryl.toml`
+5. `pyproject.toml` (only when it has a `[tool.ryl]` table)
+
+`.config/` holds ryl-native TOML only: the legacy `.yamllint`/`.yamllint.yaml`/
+`.yamllint.yml` files are discovered at the directory level, never inside
+`.config/`. A `.config/ryl.toml` is a true drop-in for a root `ryl.toml`: its
+`[files]`/`ignore` globs and relative `ignore-from-file` paths resolve against
+the project root (the directory containing `.config/`), not `.config/` itself.
+
 If you already have a yamllint configuration, use the built-in converter:
 
 ```bash

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -284,6 +284,23 @@ discovered automatically. TOML is the recommended format for ryl-specific
 features (such as fix selection) that have no upstream yamllint
 equivalent.
 
+To keep config out of the project root, ryl also discovers a ryl-native TOML
+config inside a repo-local `.config/` directory (the RuboCop/rumdl convention).
+At each directory in the upward search the candidates are tried in this order,
+and the first match wins:
+
+1. `.ryl.toml`
+2. `ryl.toml`
+3. `.config/.ryl.toml`
+4. `.config/ryl.toml`
+5. `pyproject.toml` (only when it has a `[tool.ryl]` table)
+
+`.config/` holds ryl-native TOML only: the legacy `.yamllint`/`.yamllint.yaml`/
+`.yamllint.yml` files are discovered at the directory level, never inside
+`.config/`. A `.config/ryl.toml` is a true drop-in for a root `ryl.toml`: its
+`[files]`/`ignore` globs and relative `ignore-from-file` paths resolve against
+the project root (the directory containing `.config/`), not `.config/` itself.
+
 If you already have a yamllint configuration, use the built-in converter:
 
 ```bash
@@ -884,12 +901,12 @@ nothing, so what it enables is the file's whole ruleset, with no default-on
 rules.
 
 ryl resolves one config per file by searching upward from the file. A TOML
-config (`.ryl.toml`, `ryl.toml`, or `pyproject.toml` `[tool.ryl]`) found
-anywhere up the tree is preferred over a `.yamllint`, even a nearer one;
-among configs of the same kind the nearest wins. A monorepo can therefore
-hold many `ryl.toml` files, one per subtree, each governing its own files. If
-the upward search finds no project config, ryl falls back to a single
-user-global config; see the
+config (`.ryl.toml`, `ryl.toml`, `.config/.ryl.toml`, `.config/ryl.toml`, or
+`pyproject.toml` `[tool.ryl]`, in that precedence order) found anywhere up the
+tree is preferred over a `.yamllint`, even a nearer one; among configs of the
+same kind the nearest wins. A monorepo can therefore hold many `ryl.toml`
+files, one per subtree, each governing its own files. If the upward search
+finds no project config, ryl falls back to a single user-global config; see the
 [quick start](https://ryl-docs.pages.dev/getting-started/quickstart/).
 
 Presets are starting points for that config, not something ryl inherits behind

--- a/scripts/gen_llms_txt.py
+++ b/scripts/gen_llms_txt.py
@@ -6,7 +6,7 @@
 # [tool.uv]
 # # One-week dependency cooldown (rolling): ignore releases newer than one week
 # # before each run as a supply-chain-safety buffer.
-# exclude-newer = "1 week ago"
+# exclude-newer = "1 week"
 # ///
 
 """Generate ``docs/llms.txt`` and ``docs/llms-full.txt`` from the Zensical docs.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1536,15 +1536,46 @@ pub fn discover_per_file_with(
 }
 
 // Testable core helpers below.
+/// Project root for a config at `p`: normally its parent directory, but a `.config/`
+/// discovery candidate (`.config/.ryl.toml` or `.config/ryl.toml`) anchors at that
+/// directory's parent. `.config/` is a config container by convention (XDG/dot-config),
+/// never a content root, so `.config/ryl.toml` is a true drop-in for a root `ryl.toml` —
+/// path-based `[files]`/`ignore` globs and relative `ignore-from-file` paths resolve
+/// against the project root, not `.config/`. Applies to discovered and explicit (`-c`,
+/// `YAMLLINT_CONFIG_FILE`) configs alike so the same file behaves identically however it
+/// is reached. Gated on the candidate *filenames* (not just "any TOML in `.config/`") so
+/// discovery and explicit modes agree for exactly the names discovery recognizes: an
+/// arbitrarily-named TOML or a yamllint-compat YAML config explicitly pointed at inside a
+/// `.config/` folder keeps its parent-directory base, like any other explicit path. An
+/// empty grandparent (a relative `.config/<file>` in the cwd) resolves to the cwd.
+fn config_base_dir(envx: &dyn Env, p: &Path) -> PathBuf {
+    let base = p
+        .parent()
+        .map_or_else(|| envx.current_dir(), Path::to_path_buf);
+    let is_config_candidate = base.file_name().and_then(|name| name.to_str())
+        == Some(".config")
+        && matches!(
+            p.file_name().and_then(|name| name.to_str()),
+            Some(".ryl.toml" | "ryl.toml")
+        );
+    if !is_config_candidate {
+        return base;
+    }
+    match base.parent() {
+        Some(grandparent) if !grandparent.as_os_str().is_empty() => {
+            grandparent.to_path_buf()
+        }
+        _ => envx.current_dir(),
+    }
+}
+
 fn ctx_from_config_path_core(
     envx: &dyn Env,
     p: &Path,
     allow_missing_pyproject: bool,
     notices: Vec<String>,
 ) -> Result<ConfigContext, String> {
-    let base = p
-        .parent()
-        .map_or_else(|| envx.current_dir(), Path::to_path_buf);
+    let base = config_base_dir(envx, p);
     let cfg = load_config_from_path_core(envx, p, &base, allow_missing_pyproject)?
         .expect("missing [tool.ryl] should be filtered or returned as an error before this point");
     finalize_context(envx, cfg, base, Some(p.to_path_buf()), notices, true)
@@ -1667,8 +1698,23 @@ fn try_yamllint_user_global_core(
         .transpose()
 }
 
-const TOML_PROJECT_CONFIG_CANDIDATES: [&str; 3] =
-    [".ryl.toml", "ryl.toml", "pyproject.toml"];
+// Project-level TOML config candidates, highest precedence first, checked at every
+// ancestor up to HOME. The `.config/` entries are the repo-local config-dir variants
+// (RuboCop/rumdl convention): a `.config/` directory keeps config out of the project
+// root, and we accept both the hidden (`.ryl.toml`) and plain (`ryl.toml`) names there
+// since a user relocating an existing dotfile into `.config/` keeps the dot. `/` is a
+// portable separator
+// (Windows accepts it too), but `candidate_path` splits and re-joins so the resolved
+// path uses the native separator and displays cleanly. The `.config/` variants are not
+// mirrored in the legacy YAML fallback (`YAML_PROJECT_CONFIG_CANDIDATES`): `.config/`
+// holds ryl-native TOML only, never the yamllint-compatible YAML configs.
+const TOML_PROJECT_CONFIG_CANDIDATES: [&str; 5] = [
+    ".ryl.toml",
+    "ryl.toml",
+    ".config/.ryl.toml",
+    ".config/ryl.toml",
+    "pyproject.toml",
+];
 const YAML_PROJECT_CONFIG_CANDIDATES: [&str; 3] =
     [".yamllint", ".yamllint.yaml", ".yamllint.yml"];
 // ryl-native user-global candidates (TOML only); checked inside `<config-dir>/ryl/`.
@@ -1721,6 +1767,14 @@ fn load_config_from_path_core(
 
 fn is_toml_path(path: &Path) -> bool {
     path.extension().is_some_and(|ext| ext == "toml")
+}
+
+/// Join a `/`-separated candidate (e.g. `.config/ryl.toml`) onto `dir` component by
+/// component so the result uses the platform-native separator rather than embedding a
+/// literal `/` that would render mixed-separator paths on Windows.
+fn candidate_path(dir: &Path, name: &str) -> PathBuf {
+    name.split('/')
+        .fold(dir.to_path_buf(), |path, part| path.join(part))
 }
 
 fn build_project_search_starts(envx: &dyn Env, inputs: &[PathBuf]) -> Vec<PathBuf> {
@@ -1794,7 +1848,7 @@ fn find_project_config_core(
         let mut dir = start.clone();
         loop {
             for name in TOML_PROJECT_CONFIG_CANDIDATES {
-                let candidate = dir.join(name);
+                let candidate = candidate_path(&dir, name);
                 if !envx.path_exists(&candidate) {
                     continue;
                 }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -226,14 +226,24 @@ fn rename_destination(source: &Path, suffix: &str) -> PathBuf {
 }
 
 /// An existing ryl-native TOML config *file* in `target`'s directory that a migration into
-/// `target` would overwrite or be shadowed by (`.ryl.toml` outranks `ryl.toml` in
-/// discovery, so either is a collision). A non-file (e.g. a directory) is not treated as a
-/// collision so the write path still reports it.
+/// `target` would overwrite or be shadowed by. Covers the root names (`.ryl.toml` outranks
+/// `ryl.toml` in discovery, so either is a collision) and the repo-local `.config/`
+/// candidates (`.config/.ryl.toml`/`.config/ryl.toml`): migrating writes `<dir>/.ryl.toml`,
+/// which outranks an existing `.config/` config and would silently shadow it, so that is a
+/// collision too. A non-file (e.g. a directory) is not treated as a collision so the write
+/// path still reports it.
 fn existing_ryl_native_config(target: &Path) -> Option<PathBuf> {
     target
         .parent()
         .into_iter()
-        .flat_map(|dir| [".ryl.toml", "ryl.toml"].map(|name| dir.join(name)))
+        .flat_map(|dir| {
+            [
+                dir.join(".ryl.toml"),
+                dir.join("ryl.toml"),
+                dir.join(".config").join(".ryl.toml"),
+                dir.join(".config").join("ryl.toml"),
+            ]
+        })
         .find(|candidate| candidate.is_file())
 }
 

--- a/tests/config_toml_discovery.rs
+++ b/tests/config_toml_discovery.rs
@@ -482,6 +482,286 @@ fn explicit_invalid_pyproject_toml_reports_parse_error() {
 }
 
 #[test]
+fn config_dir_plain_toml_is_discovered() {
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_file(
+            PathBuf::from("/repo/.config/ryl.toml"),
+            "locale = 'fr_FR.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_exists(PathBuf::from("/repo/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("`.config/ryl.toml` should be discovered");
+    assert_eq!(
+        ctx.source.as_deref(),
+        Some(Path::new("/repo/.config/ryl.toml"))
+    );
+    assert_eq!(ctx.config.locale(), Some("fr_FR.UTF-8"));
+}
+
+#[test]
+fn config_dir_dotted_toml_is_discovered() {
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_file(
+            PathBuf::from("/repo/.config/.ryl.toml"),
+            "locale = 'de_DE.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_exists(PathBuf::from("/repo/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("`.config/.ryl.toml` should be discovered");
+    assert_eq!(
+        ctx.source.as_deref(),
+        Some(Path::new("/repo/.config/.ryl.toml"))
+    );
+    assert_eq!(ctx.config.locale(), Some("de_DE.UTF-8"));
+}
+
+#[test]
+fn config_dir_dotted_beats_plain() {
+    // Within `.config/`, the hidden name wins, mirroring the root-level `.ryl.toml` >
+    // `ryl.toml` ordering so the dotted/plain precedence is uniform across both dirs.
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_file(
+            PathBuf::from("/repo/.config/.ryl.toml"),
+            "locale = 'fr_FR.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_file(
+            PathBuf::from("/repo/.config/ryl.toml"),
+            "locale = 'de_DE.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_exists(PathBuf::from("/repo/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("dotted config-dir name should win");
+    assert_eq!(
+        ctx.source.as_deref(),
+        Some(Path::new("/repo/.config/.ryl.toml"))
+    );
+    assert_eq!(ctx.config.locale(), Some("fr_FR.UTF-8"));
+}
+
+#[test]
+fn root_toml_beats_config_dir() {
+    // A root-level `ryl.toml` outranks any `.config/` variant in the same directory.
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_file(
+            PathBuf::from("/repo/ryl.toml"),
+            "locale = 'fr_FR.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_file(
+            PathBuf::from("/repo/.config/.ryl.toml"),
+            "locale = 'de_DE.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_exists(PathBuf::from("/repo/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("root `ryl.toml` should win over `.config/`");
+    assert_eq!(ctx.source.as_deref(), Some(Path::new("/repo/ryl.toml")));
+    assert_eq!(ctx.config.locale(), Some("fr_FR.UTF-8"));
+}
+
+#[test]
+fn config_dir_beats_pyproject() {
+    // `.config/ryl.toml` outranks a `pyproject.toml [tool.ryl]` in the same directory.
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_file(
+            PathBuf::from("/repo/.config/ryl.toml"),
+            "locale = 'fr_FR.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_file(
+            PathBuf::from("/repo/pyproject.toml"),
+            "[project]\nname = 'demo'\nversion = '0.1.0'\n[tool.ryl]\nlocale = 'de_DE.UTF-8'\n",
+        )
+        .with_exists(PathBuf::from("/repo/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("`.config/ryl.toml` should win over pyproject");
+    assert_eq!(
+        ctx.source.as_deref(),
+        Some(Path::new("/repo/.config/ryl.toml"))
+    );
+    assert_eq!(ctx.config.locale(), Some("fr_FR.UTF-8"));
+}
+
+#[test]
+fn config_dir_resolves_from_ancestor() {
+    // The `.config/` candidate is checked at every ancestor, so a config-dir config at
+    // the repo root resolves for a file nested several directories deep.
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_var("HOME", "/repo")
+        .with_file(
+            PathBuf::from("/repo/.config/ryl.toml"),
+            "locale = 'fr_FR.UTF-8'\n[rules]\nanchors = 'disable'\n",
+        )
+        .with_exists(PathBuf::from("/repo/sub/deep/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/sub/deep/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("ancestor `.config/ryl.toml` should resolve");
+    assert_eq!(
+        ctx.source.as_deref(),
+        Some(Path::new("/repo/.config/ryl.toml"))
+    );
+}
+
+#[test]
+fn config_dir_does_not_discover_legacy_yaml() {
+    // `.config/` holds ryl-native TOML only; a `.config/.yamllint` is invisible to
+    // discovery (the legacy YAML fallback only checks root-level yamllint names).
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_var("HOME", "/repo")
+        .with_file(
+            PathBuf::from("/repo/.config/.yamllint"),
+            "locale: en_US.UTF-8\nrules: {}\n",
+        )
+        .with_exists(PathBuf::from("/repo/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("discovery should succeed with no config found");
+    assert_eq!(
+        ctx.source, None,
+        "`.config/.yamllint` must not be discovered as a config source"
+    );
+}
+
+#[test]
+fn config_dir_anchors_path_globs_at_project_root() {
+    // A `.config/ryl.toml` must anchor path-based `[files]` globs at the project root
+    // (`.config/`'s parent), not at `.config/`, so it is a true drop-in for a root
+    // config; with the wrong base, `configs/**/*.yaml` would never match the repo's
+    // `configs/` and discovery would silently lint nothing.
+    let env = FakeEnv::new()
+        .with_cwd(PathBuf::from("/repo"))
+        .with_var("HOME", "/repo")
+        .with_file(
+            PathBuf::from("/repo/.config/ryl.toml"),
+            "[files]\nyaml = ['configs/**/*.yaml']\n[rules]\ntrailing-spaces = 'enable'\n",
+        )
+        .with_exists(PathBuf::from("/repo/file.yaml"));
+    let ctx = discover_config_with(
+        &[PathBuf::from("/repo/file.yaml")],
+        &Overrides::default(),
+        &env,
+    )
+    .expect("`.config/ryl.toml` should be discovered");
+    assert_eq!(ctx.base_dir, Path::new("/repo"));
+    assert!(
+        ctx.config
+            .is_yaml_candidate(Path::new("/repo/configs/app.yaml"), &ctx.base_dir),
+        "path glob must match relative to the project root, not `.config/`"
+    );
+}
+
+#[test]
+fn config_dir_explicit_c_anchors_at_project_root() {
+    // The `.config/` anchoring applies to an explicit `-c` too (the "all routes"
+    // choice), so `-c .config/ryl.toml` is not a silent dead end for path-based globs.
+    let cfg = PathBuf::from("/repo/.config/ryl.toml");
+    let env = FakeEnv::new().with_cwd(PathBuf::from("/repo")).with_file(
+        cfg.clone(),
+        "[files]\nyaml = ['configs/**/*.yaml']\n[rules]\ntrailing-spaces = 'enable'\n",
+    );
+    let ctx = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(cfg),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("explicit `-c .config/ryl.toml` should load");
+    assert_eq!(ctx.base_dir, Path::new("/repo"));
+    assert!(
+        ctx.config
+            .is_yaml_candidate(Path::new("/repo/configs/app.yaml"), &ctx.base_dir),
+        "explicit `-c` config in `.config/` must anchor globs at the project root"
+    );
+}
+
+#[test]
+fn config_dir_relative_explicit_c_anchors_at_cwd() {
+    // A relative `-c .config/ryl.toml` has an empty grandparent, so the project root
+    // resolves to the cwd (the directory the relative `.config/` sits in).
+    let env = FakeEnv::new().with_cwd(PathBuf::from("/repo")).with_file(
+        PathBuf::from(".config/ryl.toml"),
+        "[files]\nyaml = ['configs/**/*.yaml']\n[rules]\ntrailing-spaces = 'enable'\n",
+    );
+    let ctx = discover_config_with(
+        &[],
+        &Overrides {
+            config_file: Some(PathBuf::from(".config/ryl.toml")),
+            config_data: None,
+        },
+        &env,
+    )
+    .expect("relative explicit `-c .config/ryl.toml` should load");
+    assert_eq!(ctx.base_dir, Path::new("/repo"));
+}
+
+#[test]
+fn config_dir_non_candidate_configs_keep_parent_base() {
+    // Only the `.config/` discovery candidate names (`.ryl.toml`/`ryl.toml`) re-anchor.
+    // An arbitrarily-named TOML or a yamllint-compat YAML config explicitly pointed at
+    // inside a `.config/` folder keeps its parent base, like any other `-c <path>` (so
+    // explicit mode never re-bases names discovery can't find, and yamllint-compat YAML
+    // semantics, including relative extends/ignore-from-file, stay intact).
+    for (name, body) in [
+        (
+            "custom.toml",
+            "[files]\nyaml = ['configs/**/*.yaml']\n[rules]\ntrailing-spaces = 'enable'\n",
+        ),
+        ("custom.yaml", "locale: en_US.UTF-8\nrules: {}\n"),
+    ] {
+        let cfg = PathBuf::from("/repo/.config").join(name);
+        let env = FakeEnv::new()
+            .with_cwd(PathBuf::from("/repo"))
+            .with_file(cfg.clone(), body);
+        let ctx = discover_config_with(
+            &[],
+            &Overrides {
+                config_file: Some(cfg),
+                config_data: None,
+            },
+            &env,
+        )
+        .expect("explicit non-candidate config in `.config/` should load");
+        assert_eq!(
+            ctx.base_dir,
+            Path::new("/repo/.config"),
+            "non-candidate `{name}` in `.config/` must keep its parent base"
+        );
+    }
+}
+
+#[test]
 fn yaml_extends_toml_is_rejected() {
     let cfg = PathBuf::from("/repo/.yamllint");
     let env = FakeEnv::new()

--- a/tests/migrate_module.rs
+++ b/tests/migrate_module.rs
@@ -330,6 +330,50 @@ fn migrate_project_skips_when_ryl_native_config_exists() {
 }
 
 #[test]
+fn migrate_project_skips_when_config_dir_ryl_config_exists() {
+    // A `.config/ryl.toml` is the project's active config; migrating a legacy `.yamllint`
+    // would write a root `.ryl.toml` that outranks and silently shadows it, so the
+    // collision guard must treat the `.config/` config as a collision and skip.
+    let td = tempdir().unwrap();
+    fs::write(
+        td.path().join(".yamllint"),
+        "rules: { key-duplicates: enable }\n",
+    )
+    .unwrap();
+    fs::create_dir(td.path().join(".config")).unwrap();
+    fs::write(
+        td.path().join(".config").join("ryl.toml"),
+        "[rules]\nkey-duplicates = \"enable\"\n",
+    )
+    .unwrap();
+    let opts = MigrateOptions {
+        project_root: Some(td.path().to_path_buf()),
+        user_config: None,
+        write_mode: WriteMode::Write,
+        output_mode: OutputMode::SummaryOnly,
+        cleanup: SourceCleanup::Delete,
+    };
+    let res = migrate_configs(&opts).unwrap();
+    assert!(
+        res.entries.is_empty(),
+        "no migration when a `.config/` ryl-native config exists"
+    );
+    assert!(
+        res.warnings.iter().any(|w| w.contains("already exists")),
+        "expected a collision warning: {:?}",
+        res.warnings
+    );
+    assert!(
+        !td.path().join(".ryl.toml").exists(),
+        "migration must not write a root config that shadows the `.config/` one"
+    );
+    assert!(
+        td.path().join(".yamllint").exists(),
+        "source preserved when migration is skipped"
+    );
+}
+
+#[test]
 fn migrate_user_config_skips_when_ryl_toml_exists() {
     let td = tempdir().unwrap();
     let source = td.path().join("yamllint").join("config");


### PR DESCRIPTION
Adds the repo-local `.config/` convention (RuboCop/rumdl) to config discovery.

- Discovers `.config/.ryl.toml` and `.config/ryl.toml` in the upward search,
  ranked below root `.ryl.toml`/`ryl.toml`, above `pyproject.toml`.
- TOML-only: legacy `.yamllint*` is never discovered inside `.config/`.
- A `.config/` candidate config anchors its `[files]`/`ignore` globs and
  relative paths at the project root (parent of `.config/`), so it is a true
  drop-in for a root config. Gated to the canonical candidate names, so an
  explicit `-c`/`YAMLLINT_CONFIG_FILE` pointing at an arbitrarily-named TOML or
  a yamllint-compat YAML inside a `.config/` folder keeps its parent base.
- `--migrate-configs` collision guard now treats an existing `.config/` ryl
  config as a collision, so migrating a legacy `.yamllint` can't write a root
  `.ryl.toml` that silently shadows it.

Also folds in a small unrelated fix: PEP 723 scripts use the canonical
`exclude-newer = "1 week"` instead of the non-portable `"1 week ago"`.

Verified behaviorally consistent with rumdl 0.2.17. Docs updated.

Closes #218.
Closes #329.
