### PR TITLE
feat(config): restrict YAMLLINT_CONFIG_FILE to yamllint YAML configs

### DIFF
--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -106,6 +106,9 @@ produced.
   yamllint's `<config-dir>/yamllint/config` (see
   [ryl-native user-global config](#ryl-native-user-global-config) for how
   `<config-dir>` resolves per platform).
+- `YAMLLINT_CONFIG_FILE` honours only a yamllint YAML config; pointing it at a
+  `.toml` errors (see
+  [`YAMLLINT_CONFIG_FILE` rejects TOML](#yamllint_config_file-rejects-toml)).
 - The three built-in presets &mdash; `default`, `relaxed`, and `empty` &mdash;
   match yamllint's behaviour. YAML configs can still use `extends:` to
   reference them; TOML configs must inline the `default`/`relaxed` content (see
@@ -288,6 +291,29 @@ config dir (`~/.config/ryl` on Linux, `~/Library/Application Support/ryl` on mac
 `%APPDATA%\ryl` on Windows). Being ryl-only, the ryl-native path is TOML; the
 yamllint-compatible path stays YAML and, matching yamllint, always resolves under
 `$XDG_CONFIG_HOME` or `~/.config` (not the native dir).
+
+### `YAMLLINT_CONFIG_FILE` rejects TOML
+
+`YAMLLINT_CONFIG_FILE` is yamllint's env var, so ryl honours it only as a yamllint
+**YAML** config. Pointing it at a `.toml` errors (even when the file is absent),
+directing you to `-c`/`--config-file` or project discovery for ryl-native TOML. A
+YAML (or extension-less) target keeps full yamllint compatibility, including
+yamllint's behaviour of **silently ignoring a missing target** and falling through
+to the next config source.
+
+| `YAMLLINT_CONFIG_FILE` target | ryl | yamllint |
+| :--- | :--- | :--- |
+| present `.toml` | **error** (use `-c`) | parsed as YAML (not TOML) |
+| missing `.toml` | **error** (use `-c`) | ignored, falls through |
+| missing `.yml`/`config` | ignored, falls through | ignored, falls through |
+
+**Why ryl differs:** TOML is never a valid yamllint config, so there is no
+compatibility to preserve for a `.toml` target &mdash; loading one through the
+yamllint-named var was an accidental overlap with ryl's own format. ryl fails loudly
+on it and keeps ryl-native TOML on its dedicated channels (`-c`/`--config-file`,
+project discovery). yamllint's `-c` flag likewise errors on a missing file (only its
+env var is lenient), and biome's `BIOME_CONFIG_PATH` errors on a missing target
+outright, so failing loudly on the always-wrong `.toml` case is well-precedented.
 
 ## Side-by-side example
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -182,7 +182,8 @@ platform-native config dir (`~/.config/ryl` on Linux, `~/Library/Application
 Support/ryl` on macOS, `%APPDATA%\ryl` on Windows) &mdash; then falls back to
 yamllint's `<config-dir>/yamllint/config` for compatibility. A project config,
 `-c`/`-d`, or `YAMLLINT_CONFIG_FILE` all take precedence over the user-global
-config.
+config. `YAMLLINT_CONFIG_FILE` accepts only a yamllint YAML config (pointing it
+at a `.toml` errors); use `-c`/`-d` or project discovery for ryl-native TOML.
 
 If you have a yamllint user-global config, `ryl --migrate-user-config
 --migrate-write` converts it to the ryl-native `ryl.toml` (see [Migrating from

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -319,7 +319,8 @@ platform-native config dir (`~/.config/ryl` on Linux, `~/Library/Application
 Support/ryl` on macOS, `%APPDATA%\ryl` on Windows) &mdash; then falls back to
 yamllint's `<config-dir>/yamllint/config` for compatibility. A project config,
 `-c`/`-d`, or `YAMLLINT_CONFIG_FILE` all take precedence over the user-global
-config.
+config. `YAMLLINT_CONFIG_FILE` accepts only a yamllint YAML config (pointing it
+at a `.toml` errors); use `-c`/`-d` or project discovery for ryl-native TOML.
 
 If you have a yamllint user-global config, `ryl --migrate-user-config
 --migrate-write` converts it to the ryl-native `ryl.toml` (see [Migrating from
@@ -485,6 +486,9 @@ produced.
   yamllint's `<config-dir>/yamllint/config` (see
   [ryl-native user-global config](#ryl-native-user-global-config) for how
   `<config-dir>` resolves per platform).
+- `YAMLLINT_CONFIG_FILE` honours only a yamllint YAML config; pointing it at a
+  `.toml` errors (see
+  [`YAMLLINT_CONFIG_FILE` rejects TOML](#yamllint_config_file-rejects-toml)).
 - The three built-in presets &mdash; `default`, `relaxed`, and `empty` &mdash;
   match yamllint's behaviour. YAML configs can still use `extends:` to
   reference them; TOML configs must inline the `default`/`relaxed` content (see
@@ -667,6 +671,29 @@ config dir (`~/.config/ryl` on Linux, `~/Library/Application Support/ryl` on mac
 `%APPDATA%\ryl` on Windows). Being ryl-only, the ryl-native path is TOML; the
 yamllint-compatible path stays YAML and, matching yamllint, always resolves under
 `$XDG_CONFIG_HOME` or `~/.config` (not the native dir).
+
+### `YAMLLINT_CONFIG_FILE` rejects TOML
+
+`YAMLLINT_CONFIG_FILE` is yamllint's env var, so ryl honours it only as a yamllint
+**YAML** config. Pointing it at a `.toml` errors (even when the file is absent),
+directing you to `-c`/`--config-file` or project discovery for ryl-native TOML. A
+YAML (or extension-less) target keeps full yamllint compatibility, including
+yamllint's behaviour of **silently ignoring a missing target** and falling through
+to the next config source.
+
+| `YAMLLINT_CONFIG_FILE` target | ryl | yamllint |
+| :--- | :--- | :--- |
+| present `.toml` | **error** (use `-c`) | parsed as YAML (not TOML) |
+| missing `.toml` | **error** (use `-c`) | ignored, falls through |
+| missing `.yml`/`config` | ignored, falls through | ignored, falls through |
+
+**Why ryl differs:** TOML is never a valid yamllint config, so there is no
+compatibility to preserve for a `.toml` target &mdash; loading one through the
+yamllint-named var was an accidental overlap with ryl's own format. ryl fails loudly
+on it and keeps ryl-native TOML on its dedicated channels (`-c`/`--config-file`,
+project discovery). yamllint's `-c` flag likewise errors on a missing file (only its
+env var is lenient), and biome's `BIOME_CONFIG_PATH` errors on a missing target
+outright, so failing loudly on the always-wrong `.toml` case is well-precedented.
 
 ## Side-by-side example
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1592,11 +1592,25 @@ fn expand_user_path(envx: &dyn Env, raw: &str) -> PathBuf {
 }
 
 fn try_env_config_core(envx: &dyn Env) -> Result<Option<ConfigContext>, String> {
-    envx.env_var("YAMLLINT_CONFIG_FILE")
-        .map(|raw| expand_user_path(envx, &raw))
-        .filter(|p| envx.path_exists(p))
-        .map(|p| ctx_from_config_path_core(envx, &p, false, Vec::new()))
-        .transpose()
+    let Some(raw) = envx.env_var("YAMLLINT_CONFIG_FILE") else {
+        return Ok(None);
+    };
+    let path = expand_user_path(envx, &raw);
+    // YAMLLINT_CONFIG_FILE is yamllint's env var, so it accepts only yamllint YAML configs;
+    // a `.toml` target used to load as a ryl-native config (#332). Rejecting by extension
+    // (the loader's sole YAML-vs-TOML signal) fires before the existence check, since the
+    // value alone flags the misuse: `-c`/project discovery are the route for ryl TOML.
+    if is_toml_path(&path) {
+        return Err(format!(
+            "YAMLLINT_CONFIG_FILE points at a TOML file ({}); it accepts only yamllint YAML \
+             configs. Use -c/--config-file or project config discovery for ryl-native TOML.",
+            path.display()
+        ));
+    }
+    if !envx.path_exists(&path) {
+        return Ok(None);
+    }
+    ctx_from_config_path_core(envx, &path, false, Vec::new()).map(Some)
 }
 
 // no separate try_env_config_with; discover_config_with_env uses ClosureEnv + discover_config_with

--- a/tests/config_env_errors.rs
+++ b/tests/config_env_errors.rs
@@ -21,3 +21,25 @@ fn env_points_to_unreadable_path_errors() {
         "expected error when env points to a directory, got {res:?}"
     );
 }
+
+#[test]
+fn env_toml_target_is_rejected_even_when_missing() {
+    // The `.toml` rejection keys on the extension (the loader's sole YAML-vs-TOML signal)
+    // and fires before the existence check, so pointing yamllint's env var at ryl-native
+    // TOML is flagged regardless of whether the file is present (unlike a missing YAML
+    // target, which is silently ignored).
+    let td = tempdir().unwrap();
+    let missing = td.path().join("ryl.toml");
+    let inputs = vec![td.path().join("input.yaml")];
+    let err = discover_config_with_env(&inputs, &Overrides::default(), &|k| match k {
+        "YAMLLINT_CONFIG_FILE" => Some(missing.display().to_string()),
+        // HOME bounds the project-config walk to the tempdir.
+        "HOME" => Some(td.path().display().to_string()),
+        _ => None,
+    })
+    .unwrap_err();
+    assert!(
+        err.contains("only yamllint YAML"),
+        "expected TOML rejection, got: {err}"
+    );
+}

--- a/tests/config_env_shim.rs
+++ b/tests/config_env_shim.rs
@@ -161,6 +161,22 @@ fn shim_env_var_tilde_without_home_keeps_literal_path() {
 }
 
 #[test]
+fn shim_env_var_rejects_toml_target_pointing_at_native_config() {
+    // YAMLLINT_CONFIG_FILE is yamllint's env var (YAML configs only). A `.toml` target
+    // used to load as a ryl-native config; it must now error and steer the user to
+    // -c / project discovery instead of silently loading TOML (#332).
+    let env = FakeEnv::default()
+        .with_cwd("/tmp/cwd")
+        .add_file("/proj/ryl.toml", "[rules]\nkey-duplicates = 'enable'\n")
+        .set_var("YAMLLINT_CONFIG_FILE", "/proj/ryl.toml");
+    let err = discover_config_with(&[], &Overrides::default(), &env).unwrap_err();
+    assert!(
+        err.contains("YAMLLINT_CONFIG_FILE") && err.contains("--config-file"),
+        "expected an actionable TOML-rejection error, got: {err}"
+    );
+}
+
+#[test]
 fn system_env_home_dir_accessible() {
     let env = SystemEnv;
     let _ = env.home_dir();


### PR DESCRIPTION
## Summary

Restricts the `YAMLLINT_CONFIG_FILE` env var to yamllint **YAML** configs. Pointing it
at a `.toml` now errors with a message directing users to `-c`/`--config-file` or project
discovery for ryl-native TOML, instead of silently loading the TOML as a ryl-native config
(the old drop-in compromise).

`-c`/`--config-file` is unchanged and still accepts ryl-native TOML, exactly as ruff
`--config`, rumdl `-c`, and yamllint `-c` accept their own formats. Only the
yamllint-named env var is now yamllint-shaped.

Closes #332.

## Behavior

The gate lives in `try_env_config_core` (the env-var entry point) only; the shared loader
and the `-c`/discovery paths are untouched.

| `YAMLLINT_CONFIG_FILE` target | ryl | yamllint |
| :--- | :--- | :--- |
| present `.toml` | **error** (use `-c`) | parsed as YAML (not TOML) |
| missing `.toml` | **error** (use `-c`) | ignored, falls through |
| missing `.yml`/`config` | ignored, falls through | ignored, falls through |
| present `.yml`/`config` | loaded as YAML | loaded as YAML |

### Why reject a *missing* `.toml`, but ignore a *missing* `.yml`?

The rejection keys on the `.toml` extension (the loader's sole YAML-vs-TOML signal) and
fires **before** the existence check, so a stale/typo'd `.toml` env target fails loud
rather than silently falling through. This is a deliberate, maintainer-approved divergence,
not an oversight:

- TOML is **never** a valid yamllint config, so there is no yamllint compatibility to
  preserve for a `.toml` target. Failing loud on the always-wrong format is the
  pit-of-success.
- A *YAML* (or extension-less) target keeps full yamllint compatibility, **including
  yamllint's own behavior of silently ignoring a missing target** (verified against
  yamllint 1.38.0: a missing `YAMLLINT_CONFIG_FILE` is ignored and resolution falls
  through; only the explicit `-c` flag errors on a missing file).
- Precedent for failing loud on a missing env-config target: yamllint's `-c` errors, and
  biome's `BIOME_CONFIG_PATH` errors on a missing target outright (verified against biome
  2.5.0).

## Tests

- `config_env_shim.rs` — an existing `.toml` env target errors (the case that previously
  loaded as ryl-native TOML).
- `config_env_errors.rs` — a *missing* `.toml` env target also errors (pins the
  reject-before-existence invariant).
- Existing missing-`.yml` "ignored, falls through" coverage is unchanged.

## Docs

`migrating-from-yamllint.md` gains a "`YAMLLINT_CONFIG_FILE` rejects TOML" entry in the
"How ryl differs from yamllint" catalog (with the table and rationale above); `quickstart.md`
notes the YAML-only restriction; `llms-full.txt` regenerated.
