### PR TITLE
v0.19.0: config-precedence diagram, benchmark refresh, version bump

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -23,9 +23,25 @@ description: >-
   - Run `prek run --all-files` (re-run if files were auto-fixed).
 - Docs and notes:
   - Update README/AGENTS for behavior changes.
+  - **Refresh the benchmark image** so its version label tracks the release. Build the
+    release binary and point the script at it with `--ryl-bin` (the label is read from
+    that binary's `--version`, so it always matches what was timed; without `--ryl-bin`
+    the script benchmarks whatever `ryl` is on `PATH`): `cargo build --release && uv run
+    scripts/benchmark_perf_vs_yamllint.py --ryl-bin target/release/ryl`. The no-arg
+    defaults reproduce the committed 5x5/5-run matrix; copy the run's
+    `manual_outputs/benchmarks/<ts>/benchmark.svg` over the tracked
+    `img/benchmark-5x5-5runs.svg` (only that file is committed; `manual_outputs/` is
+    gitignored) and confirm the `ryl <version>` label reads the release version.
   - **Review the dev skills** in `.agents/skills/` for any procedure that changed
     in this release (a moved command, renamed test, new wiring step), and update
-    the affected `SKILL.md`.
+    the affected `SKILL.md`. If any `.agents/skills/` file changed, refresh the
+    gitignored local copies Claude Code loads (`.claude/skills/`) **from GitHub
+    pinned to the release tag, after the tag is pushed** — never `--from-local`
+    (that pins to unverified local state):
+    `gh skill install owenlamont/ryl --all --allow-hidden-dirs --agent claude-code
+    --scope project --pin vX.Y.Z --force` (then `gh skill update` for later
+    refreshes). Confirm the install pulls only the `.agents/skills/` dev skills and
+    not the published `skills/ryl`; scope by skill path if it does not.
   - Review the downstream agent skill `skills/ryl/SKILL.md` and the
     `docs/using-ryl-with-ai-agents.md` page for any behaviour, flag, format, or
     rule changes in this release. The `agent_skill_drift_guard` test catches a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,23 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
   disabled lines via `Directives::reconcile`. Works region-locally in embedded Markdown.
   Validate against yamllint with `tests/yamllint_compat_directives.rs`. User docs:
   `docs/directives.md`.
+- Config discovery (`config::discover_config_with`, precedence high→low): `-d` (inline
+  YAML) > `-c` (file: TOML/YAML by extension) > project config > `YAMLLINT_CONFIG_FILE`
+  > user-global. `-d`/`-c`/a present `YAMLLINT_CONFIG_FILE` trigger run-wide resolution
+  (`main::build_global_cfg`); otherwise project + user-global discovery is per file via
+  `discover_per_file` (cached per dir), so a monorepo gets a config per subtree. Run-wide
+  resolution still applies the full precedence, so a project config found from the inputs
+  precedes the env config. Project candidates run every ancestor to `HOME`,
+  TOML-first (`TOML_PROJECT_CONFIG_CANDIDATES`: `.ryl.toml` > `ryl.toml` >
+  `.config/.ryl.toml` > `.config/ryl.toml` > `pyproject.toml [tool.ryl]`) across every
+  ancestor first, then `.yamllint*` in a separate full ancestor walk
+  (`find_first_yaml_candidate`), so any TOML config up-tree outranks even a nearer
+  `.yamllint`. `.config/` is
+  TOML-only and anchors path globs/`ignore-from-file` at its parent (`config_base_dir`,
+  #218). `YAMLLINT_CONFIG_FILE` is yamllint-only: a `.toml` target errors (exit 2) before
+  the existence check (`try_env_config_core`, #332); use `-c`/`-d`/project discovery for
+  ryl TOML. User-global: ryl-native `<config-dir>/ryl/{.ryl,}.toml` then yamllint
+  `<config-dir>/yamllint/config`. Precedence diagram in `docs/getting-started/quickstart.md`.
 - ryl never enables a rule that wasn't explicitly turned on (no "default-on" rules). Two
   cases exit `2`, both stricter than yamllint: **no config found anywhere** (resolution
   falls back to an *empty* config — `ConfigContext::config_found == false` — not the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,8 +401,9 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
   TOML-only and anchors path globs/`ignore-from-file` at its parent (`config_base_dir`,
   #218). `YAMLLINT_CONFIG_FILE` is yamllint-only: a `.toml` target errors (exit 2) before
   the existence check (`try_env_config_core`, #332); use `-c`/`-d`/project discovery for
-  ryl TOML. User-global: ryl-native `<config-dir>/ryl/{.ryl,}.toml` then yamllint
-  `<config-dir>/yamllint/config`. Precedence diagram in `docs/getting-started/quickstart.md`.
+  ryl TOML. User-global: ryl-native `<config-dir>/ryl/.ryl.toml` or `ryl.toml`, then
+  yamllint `<config-dir>/yamllint/config`. Precedence diagram in
+  `docs/getting-started/quickstart.md`.
 - ryl never enables a rule that wasn't explicitly turned on (no "default-on" rules). Two
   cases exit `2`, both stricter than yamllint: **no config found anywhere** (resolution
   falls back to an *empty* config — `ConfigContext::config_found == false` — not the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -129,37 +129,18 @@ discovery runs per file, so a monorepo can hold many configs, each governing its
 own subtree. ryl recognises the same config sources as yamllint (`-d`/`-c`,
 project files, `YAMLLINT_CONFIG_FILE`, a user-global config) and adds ryl-native
 TOML for `-c`, project discovery, and the user-global config (but not
-`YAMLLINT_CONFIG_FILE`, which stays yamllint-YAML-only), but diverges in two ways
-the diagram makes precise: yamllint
-folds `YAMLLINT_CONFIG_FILE` into the user-global slot (the env var *replaces* it,
-and a missing target falls through to `extends: default`), whereas ryl keeps the
-env var and the user-global config as distinct fall-through tiers; and ryl
-requires the resolved config to enable at least one rule or it exits `2` (yamllint
-instead lints with its `default` preset when nothing is found, and silently
-accepts a rule-less config):
+`YAMLLINT_CONFIG_FILE`, which stays yamllint-YAML-only). It diverges from yamllint
+in two ways: yamllint folds `YAMLLINT_CONFIG_FILE` into the user-global slot (the
+env var *replaces* it, and a missing target falls through to `extends: default`),
+whereas ryl keeps the env var and the user-global config as distinct fall-through
+tiers; and ryl requires the resolved config to enable at least one rule or it
+exits `2` (yamllint instead lints with its `default` preset when nothing is found,
+and silently accepts a rule-less config).
 
-```mermaid
-flowchart TD
-    Start([resolve config]) --> D{"-d / --config-data?"}
-    D -->|yes| UseInline["use inline YAML"] --> Done([config resolved])
-    D -->|no| C{"-c / --config-file?"}
-    C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
-    C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
-    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml<br/>&gt; .config/.ryl.toml &gt; .config/ryl.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
-    P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
-    P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
-    E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]
-    E -->|"YAML and exists"| UseEnv["load as yamllint YAML"] --> Done
-    E -->|"missing or unset"| G{"user-global config?"}
-    G -->|"ryl TOML"| UseRyl["config-dir/ryl/.ryl.toml &gt; ryl.toml"] --> Done
-    G -->|"else yamllint YAML"| UseYl["config-dir/yamllint/config"] --> Done
-    G -->|none| Err2["error: no configuration found (exit 2)"]
-    Done --> R{"any rule enabled?"}
-    R -->|yes| OK([lint])
-    R -->|no| Err3["error: no rules enabled (exit 2)"]
-    classDef default stroke-width:3px;
-    linkStyle default stroke-width:3px;
-```
+See the [configuration precedence
+diagram](quickstart.md#configuration-precedence) in the Quick Start for the full
+resolution flow, rendered from `-d`/`-c` through project and user-global tiers to
+the rule-enabled gate.
 
 ## How ryl differs from yamllint
 

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -120,6 +120,47 @@ produced.
   working. The equivalent `# ryl …` spelling is preferred for new files; see
   [Inline directives](../directives.md).
 
+## Configuration discovery precedence
+
+ryl resolves the configuration governing **each file** it lints, trying these
+sources in order and stopping at the first hit. `-d`/`-c` and
+`YAMLLINT_CONFIG_FILE` pin a single config for the whole run; otherwise project
+discovery runs per file, so a monorepo can hold many configs, each governing its
+own subtree. ryl recognises the same config sources as yamllint (`-d`/`-c`,
+project files, `YAMLLINT_CONFIG_FILE`, a user-global config) and adds ryl-native
+TOML for `-c`, project discovery, and the user-global config (but not
+`YAMLLINT_CONFIG_FILE`, which stays yamllint-YAML-only), but diverges in two ways
+the diagram makes precise: yamllint
+folds `YAMLLINT_CONFIG_FILE` into the user-global slot (the env var *replaces* it,
+and a missing target falls through to `extends: default`), whereas ryl keeps the
+env var and the user-global config as distinct fall-through tiers; and ryl
+requires the resolved config to enable at least one rule or it exits `2` (yamllint
+instead lints with its `default` preset when nothing is found, and silently
+accepts a rule-less config):
+
+```mermaid
+flowchart TD
+    Start([resolve config]) --> D{"-d / --config-data?"}
+    D -->|yes| UseInline["use inline YAML"] --> Done([config resolved])
+    D -->|no| C{"-c / --config-file?"}
+    C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
+    C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
+    P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
+    E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]
+    E -->|"YAML and exists"| UseEnv["load as yamllint YAML"] --> Done
+    E -->|"missing or unset"| G{"user-global config?"}
+    G -->|"ryl TOML"| UseRyl["config-dir/ryl/.ryl.toml &gt; ryl.toml"] --> Done
+    G -->|"else yamllint YAML"| UseYl["config-dir/yamllint/config"] --> Done
+    G -->|none| Err2["error: no configuration found (exit 2)"]
+    Done --> R{"any rule enabled?"}
+    R -->|yes| OK([lint])
+    R -->|no| Err3["error: no rules enabled (exit 2)"]
+    classDef default stroke-width:3px;
+    linkStyle default stroke-width:3px;
+```
+
 ## How ryl differs from yamllint
 
 ryl is a drop-in replacement, but it intentionally diverges from yamllint in a

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -145,7 +145,7 @@ flowchart TD
     D -->|no| C{"-c / --config-file?"}
     C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
     C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
-    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml<br/>&gt; .config/.ryl.toml &gt; .config/ryl.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
     P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
     P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
     E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -206,7 +206,7 @@ flowchart TD
     D -->|no| C{"-c / --config-file?"}
     C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
     C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
-    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml<br/>&gt; .config/.ryl.toml &gt; .config/ryl.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
     P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
     P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
     E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -189,3 +189,35 @@ If you have a yamllint user-global config, `ryl --migrate-user-config
 --migrate-write` converts it to the ryl-native `ryl.toml` (see [Migrating from
 yamllint](migrating-from-yamllint.md)). Migration is optional, since ryl also
 reads the yamllint location directly.
+
+## Configuration precedence
+
+ryl resolves the configuration governing **each file** it lints, trying these
+sources in order and stopping at the first hit. `-d`/`-c` and
+`YAMLLINT_CONFIG_FILE` pin a single config for the whole run; otherwise project
+discovery runs per file, so a monorepo can hold many `.ryl.toml` files, each
+governing its own subtree. The winning config must enable at least one rule, or
+ryl exits `2`:
+
+```mermaid
+flowchart TD
+    Start([resolve config]) --> D{"-d / --config-data?"}
+    D -->|yes| UseInline["use inline YAML"] --> Done([config resolved])
+    D -->|no| C{"-c / --config-file?"}
+    C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
+    C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
+    P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
+    E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]
+    E -->|"YAML and exists"| UseEnv["load as yamllint YAML"] --> Done
+    E -->|"missing or unset"| G{"user-global config?"}
+    G -->|"ryl TOML"| UseRyl["config-dir/ryl/.ryl.toml &gt; ryl.toml"] --> Done
+    G -->|"else yamllint YAML"| UseYl["config-dir/yamllint/config"] --> Done
+    G -->|none| Err2["error: no configuration found (exit 2)"]
+    Done --> R{"any rule enabled?"}
+    R -->|yes| OK([lint])
+    R -->|no| Err3["error: no rules enabled (exit 2)"]
+    classDef default stroke-width:3px;
+    linkStyle default stroke-width:3px;
+```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -327,6 +327,38 @@ If you have a yamllint user-global config, `ryl --migrate-user-config
 yamllint](https://ryl-docs.pages.dev/getting-started/migrating-from-yamllint/)). Migration is optional, since ryl also
 reads the yamllint location directly.
 
+## Configuration precedence
+
+ryl resolves the configuration governing **each file** it lints, trying these
+sources in order and stopping at the first hit. `-d`/`-c` and
+`YAMLLINT_CONFIG_FILE` pin a single config for the whole run; otherwise project
+discovery runs per file, so a monorepo can hold many `.ryl.toml` files, each
+governing its own subtree. The winning config must enable at least one rule, or
+ryl exits `2`:
+
+```mermaid
+flowchart TD
+    Start([resolve config]) --> D{"-d / --config-data?"}
+    D -->|yes| UseInline["use inline YAML"] --> Done([config resolved])
+    D -->|no| C{"-c / --config-file?"}
+    C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
+    C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
+    P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
+    E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]
+    E -->|"YAML and exists"| UseEnv["load as yamllint YAML"] --> Done
+    E -->|"missing or unset"| G{"user-global config?"}
+    G -->|"ryl TOML"| UseRyl["config-dir/ryl/.ryl.toml &gt; ryl.toml"] --> Done
+    G -->|"else yamllint YAML"| UseYl["config-dir/yamllint/config"] --> Done
+    G -->|none| Err2["error: no configuration found (exit 2)"]
+    Done --> R{"any rule enabled?"}
+    R -->|yes| OK([lint])
+    R -->|no| Err3["error: no rules enabled (exit 2)"]
+    classDef default stroke-width:3px;
+    linkStyle default stroke-width:3px;
+```
+
 ---
 
 Source: https://ryl-docs.pages.dev/using-ryl-with-ai-agents/
@@ -499,6 +531,47 @@ produced.
   with the same grammar and semantics, so existing in-file suppressions keep
   working. The equivalent `# ryl …` spelling is preferred for new files; see
   [Inline directives](https://ryl-docs.pages.dev/directives/).
+
+## Configuration discovery precedence
+
+ryl resolves the configuration governing **each file** it lints, trying these
+sources in order and stopping at the first hit. `-d`/`-c` and
+`YAMLLINT_CONFIG_FILE` pin a single config for the whole run; otherwise project
+discovery runs per file, so a monorepo can hold many configs, each governing its
+own subtree. ryl recognises the same config sources as yamllint (`-d`/`-c`,
+project files, `YAMLLINT_CONFIG_FILE`, a user-global config) and adds ryl-native
+TOML for `-c`, project discovery, and the user-global config (but not
+`YAMLLINT_CONFIG_FILE`, which stays yamllint-YAML-only), but diverges in two ways
+the diagram makes precise: yamllint
+folds `YAMLLINT_CONFIG_FILE` into the user-global slot (the env var *replaces* it,
+and a missing target falls through to `extends: default`), whereas ryl keeps the
+env var and the user-global config as distinct fall-through tiers; and ryl
+requires the resolved config to enable at least one rule or it exits `2` (yamllint
+instead lints with its `default` preset when nothing is found, and silently
+accepts a rule-less config):
+
+```mermaid
+flowchart TD
+    Start([resolve config]) --> D{"-d / --config-data?"}
+    D -->|yes| UseInline["use inline YAML"] --> Done([config resolved])
+    D -->|no| C{"-c / --config-file?"}
+    C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
+    C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
+    P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
+    E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]
+    E -->|"YAML and exists"| UseEnv["load as yamllint YAML"] --> Done
+    E -->|"missing or unset"| G{"user-global config?"}
+    G -->|"ryl TOML"| UseRyl["config-dir/ryl/.ryl.toml &gt; ryl.toml"] --> Done
+    G -->|"else yamllint YAML"| UseYl["config-dir/yamllint/config"] --> Done
+    G -->|none| Err2["error: no configuration found (exit 2)"]
+    Done --> R{"any rule enabled?"}
+    R -->|yes| OK([lint])
+    R -->|no| Err3["error: no rules enabled (exit 2)"]
+    classDef default stroke-width:3px;
+    linkStyle default stroke-width:3px;
+```
 
 ## How ryl differs from yamllint
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -541,37 +541,18 @@ discovery runs per file, so a monorepo can hold many configs, each governing its
 own subtree. ryl recognises the same config sources as yamllint (`-d`/`-c`,
 project files, `YAMLLINT_CONFIG_FILE`, a user-global config) and adds ryl-native
 TOML for `-c`, project discovery, and the user-global config (but not
-`YAMLLINT_CONFIG_FILE`, which stays yamllint-YAML-only), but diverges in two ways
-the diagram makes precise: yamllint
-folds `YAMLLINT_CONFIG_FILE` into the user-global slot (the env var *replaces* it,
-and a missing target falls through to `extends: default`), whereas ryl keeps the
-env var and the user-global config as distinct fall-through tiers; and ryl
-requires the resolved config to enable at least one rule or it exits `2` (yamllint
-instead lints with its `default` preset when nothing is found, and silently
-accepts a rule-less config):
+`YAMLLINT_CONFIG_FILE`, which stays yamllint-YAML-only). It diverges from yamllint
+in two ways: yamllint folds `YAMLLINT_CONFIG_FILE` into the user-global slot (the
+env var *replaces* it, and a missing target falls through to `extends: default`),
+whereas ryl keeps the env var and the user-global config as distinct fall-through
+tiers; and ryl requires the resolved config to enable at least one rule or it
+exits `2` (yamllint instead lints with its `default` preset when nothing is found,
+and silently accepts a rule-less config).
 
-```mermaid
-flowchart TD
-    Start([resolve config]) --> D{"-d / --config-data?"}
-    D -->|yes| UseInline["use inline YAML"] --> Done([config resolved])
-    D -->|no| C{"-c / --config-file?"}
-    C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
-    C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
-    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml<br/>&gt; .config/.ryl.toml &gt; .config/ryl.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
-    P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
-    P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
-    E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]
-    E -->|"YAML and exists"| UseEnv["load as yamllint YAML"] --> Done
-    E -->|"missing or unset"| G{"user-global config?"}
-    G -->|"ryl TOML"| UseRyl["config-dir/ryl/.ryl.toml &gt; ryl.toml"] --> Done
-    G -->|"else yamllint YAML"| UseYl["config-dir/yamllint/config"] --> Done
-    G -->|none| Err2["error: no configuration found (exit 2)"]
-    Done --> R{"any rule enabled?"}
-    R -->|yes| OK([lint])
-    R -->|no| Err3["error: no rules enabled (exit 2)"]
-    classDef default stroke-width:3px;
-    linkStyle default stroke-width:3px;
-```
+See the [configuration precedence
+diagram](https://ryl-docs.pages.dev/getting-started/quickstart/#configuration-precedence) in the Quick Start for the full
+resolution flow, rendered from `-d`/`-c` through project and user-global tiers to
+the rule-enabled gate.
 
 ## How ryl differs from yamllint
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -343,7 +343,7 @@ flowchart TD
     D -->|no| C{"-c / --config-file?"}
     C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
     C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
-    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml<br/>&gt; .config/.ryl.toml &gt; .config/ryl.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
     P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
     P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
     E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]
@@ -557,7 +557,7 @@ flowchart TD
     D -->|no| C{"-c / --config-file?"}
     C -->|yes| UseFile["load file: TOML or YAML by extension"] --> Done
     C -->|no| P{"project config?<br/>walk up from inputs to HOME"}
-    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml &gt; .config/*.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
+    P -->|"TOML up-tree"| UseProjToml["nearest TOML:<br/>.ryl.toml &gt; ryl.toml<br/>&gt; .config/.ryl.toml &gt; .config/ryl.toml<br/>&gt; pyproject.toml [tool.ryl]"] --> Done
     P -->|"else .yamllint up-tree"| UseProjYaml["nearest .yamllint /<br/>.yamllint.yaml / .yamllint.yml"] --> Done
     P -->|none| E{"YAMLLINT_CONFIG_FILE set?"}
     E -->|"points at .toml"| Err1["error: use -c / project discovery<br/>for ryl TOML (exit 2)"]

--- a/img/benchmark-5x5-5runs.svg
+++ b/img/benchmark-5x5-5runs.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-31T11:21:40.794219</dc:date>
+    <dc:date>2026-06-17T00:17:32.399903</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 65.633182 357.54
 L 65.633182 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
@@ -104,7 +104,7 @@ z
      <g id="line2d_3">
       <path d="M 119.166136 357.54
 L 119.166136 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
@@ -153,7 +153,7 @@ z
      <g id="line2d_5">
       <path d="M 172.699091 357.54
 L 172.699091 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
@@ -189,7 +189,7 @@ z
      <g id="line2d_7">
       <path d="M 226.232045 357.54
 L 226.232045 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
@@ -231,7 +231,7 @@ z
      <g id="line2d_9">
       <path d="M 279.765 357.54
 L 279.765 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
@@ -278,7 +278,7 @@ z
      <g id="line2d_11">
       <path d="M 333.297955 357.54
 L 333.297955 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
@@ -305,7 +305,7 @@ z
      <g id="line2d_13">
       <path d="M 386.830909 357.54
 L 386.830909 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
@@ -361,7 +361,7 @@ z
      <g id="line2d_15">
       <path d="M 440.363864 357.54
 L 440.363864 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_8">
@@ -408,7 +408,7 @@ z
      <g id="line2d_17">
       <path d="M 493.896818 357.54
 L 493.896818 50.64
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_18"/>
      <g id="text_9">
@@ -747,14 +747,14 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 44.22 344.198029
-L 515.31 344.198029
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 344.223728
+L 515.31 344.223728
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_20"/>
      <g id="text_11">
       <!-- 0.0 -->
-      <g style="fill: #262626" transform="translate(24.816875 347.997248) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 348.022947) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794
 L 1344 794
@@ -772,14 +772,14 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 44.22 283.289669
-L 515.31 283.289669
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 283.526265
+L 515.31 283.526265
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_22"/>
      <g id="text_12">
       <!-- 0.5 -->
-      <g style="fill: #262626" transform="translate(24.816875 287.088887) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 287.325484) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
@@ -788,14 +788,14 @@ L 515.31 283.289669
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 44.22 222.381308
-L 515.31 222.381308
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 222.828801
+L 515.31 222.828801
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_24"/>
      <g id="text_13">
       <!-- 1.0 -->
-      <g style="fill: #262626" transform="translate(24.816875 226.180527) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 226.62802) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
@@ -804,14 +804,14 @@ L 515.31 222.381308
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 44.22 161.472948
-L 515.31 161.472948
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 162.131338
+L 515.31 162.131338
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_26"/>
      <g id="text_14">
       <!-- 1.5 -->
-      <g style="fill: #262626" transform="translate(24.816875 165.272167) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 165.930557) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
@@ -820,14 +820,14 @@ L 515.31 161.472948
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 44.22 100.564587
-L 515.31 100.564587
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 44.22 101.433874
+L 515.31 101.433874
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_28"/>
      <g id="text_15">
       <!-- 2.0 -->
-      <g style="fill: #262626" transform="translate(24.816875 104.363806) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.816875 105.233093) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
@@ -1012,118 +1012,118 @@ z
    </g>
    <g id="FillBetweenPolyCollection_1">
     <defs>
-     <path id="md9a63995a7" d="M 65.633182 -52.533119
+     <path id="m2ef767a1da" d="M 65.633182 -52.50325
 L 65.633182 -52.41
-L 172.699091 -52.459202
-L 279.765 -52.571938
-L 386.830909 -52.663265
-L 493.896818 -52.755785
-L 493.896818 -52.787149
-L 493.896818 -52.787149
-L 386.830909 -52.769039
-L 279.765 -52.686094
-L 172.699091 -52.548908
-L 65.633182 -52.533119
+L 172.699091 -52.52773
+L 279.765 -52.685074
+L 386.830909 -52.740128
+L 493.896818 -52.910647
+L 493.896818 -52.978689
+L 493.896818 -52.978689
+L 386.830909 -52.833583
+L 279.765 -52.88851
+L 172.699091 -52.646305
+L 65.633182 -52.50325
 z
 " style="stroke: #a6cee4; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#md9a63995a7" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m2ef767a1da" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_2">
     <defs>
-     <path id="mb3530a9b3d" d="M 65.633182 -52.495297
-L 65.633182 -52.454444
-L 172.699091 -52.714139
-L 279.765 -52.818549
-L 386.830909 -53.036496
-L 493.896818 -53.208964
-L 493.896818 -53.260741
-L 493.896818 -53.260741
-L 386.830909 -53.070424
-L 279.765 -52.85874
-L 172.699091 -52.754657
-L 65.633182 -52.495297
+     <path id="m61bb4cd241" d="M 65.633182 -52.625557
+L 65.633182 -52.461023
+L 172.699091 -52.755109
+L 279.765 -53.013484
+L 386.830909 -53.207318
+L 493.896818 -53.407681
+L 493.896818 -53.506173
+L 493.896818 -53.506173
+L 386.830909 -53.344846
+L 279.765 -53.128153
+L 172.699091 -52.821126
+L 65.633182 -52.625557
 z
 " style="stroke: #6aaed6; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#mb3530a9b3d" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m61bb4cd241" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_3">
     <defs>
-     <path id="m17d667fb6c" d="M 65.633182 -52.585756
-L 65.633182 -52.558285
-L 172.699091 -52.899091
-L 279.765 -53.115605
-L 386.830909 -53.542944
-L 493.896818 -53.634922
-L 493.896818 -53.707364
-L 493.896818 -53.707364
-L 386.830909 -53.593234
-L 279.765 -53.221285
-L 172.699091 -52.934647
-L 65.633182 -52.585756
+     <path id="m37283fce69" d="M 65.633182 -52.716137
+L 65.633182 -52.621387
+L 172.699091 -52.980147
+L 279.765 -53.262879
+L 386.830909 -53.579605
+L 493.896818 -54.001496
+L 493.896818 -54.044409
+L 493.896818 -54.044409
+L 386.830909 -53.70923
+L 279.765 -53.340201
+L 172.699091 -53.069106
+L 65.633182 -52.716137
 z
 " style="stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#m17d667fb6c" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m37283fce69" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_4">
     <defs>
-     <path id="mce8dbf758c" d="M 65.633182 -52.825042
-L 65.633182 -52.72379
-L 172.699091 -53.166312
-L 279.765 -53.514845
-L 386.830909 -53.927323
-L 493.896818 -54.445142
-L 493.896818 -54.505278
-L 493.896818 -54.505278
-L 386.830909 -54.000295
-L 279.765 -53.572128
-L 172.699091 -53.191574
-L 65.633182 -52.825042
+     <path id="m0e7cb8f0de" d="M 65.633182 -52.922369
+L 65.633182 -52.789199
+L 172.699091 -53.236225
+L 279.765 -53.607732
+L 386.830909 -53.9041
+L 493.896818 -54.479133
+L 493.896818 -54.760869
+L 493.896818 -54.760869
+L 386.830909 -54.135171
+L 279.765 -53.692943
+L 172.699091 -53.272598
+L 65.633182 -52.922369
 z
 " style="stroke: #1764ab; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#mce8dbf758c" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m0e7cb8f0de" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_5">
     <defs>
-     <path id="mf96da72052" d="M 65.633182 -52.89396
-L 65.633182 -52.767268
-L 172.699091 -53.242421
-L 279.765 -53.623796
-L 386.830909 -54.093459
-L 493.896818 -54.638065
-L 493.896818 -54.80114
-L 493.896818 -54.80114
-L 386.830909 -54.166553
-L 279.765 -53.801682
-L 172.699091 -53.354811
-L 65.633182 -52.89396
+     <path id="m85686d3338" d="M 65.633182 -53.276973
+L 65.633182 -53.148276
+L 172.699091 -53.550644
+L 279.765 -53.864897
+L 386.830909 -54.418798
+L 493.896818 -54.942918
+L 493.896818 -55.178918
+L 493.896818 -55.178918
+L 386.830909 -54.5949
+L 279.765 -54.043018
+L 172.699091 -53.769814
+L 65.633182 -53.276973
 z
 " style="stroke: #083c7d; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#mf96da72052" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m85686d3338" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="line2d_29">
-    <path d="M 65.633182 343.52844
-L 172.699091 343.495945
-L 279.765 343.370984
-L 386.830909 343.283848
-L 493.896818 343.228533
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.543375
+L 172.699091 343.412983
+L 279.765 343.213208
+L 386.830909 343.213145
+L 493.896818 343.055332
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m41e44083d9" d="M 0 3
+     <path id="m51718c9be3" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1135,23 +1135,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #a6cee4"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#m41e44083d9" x="65.633182" y="343.52844" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="172.699091" y="343.495945" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="279.765" y="343.370984" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="386.830909" y="343.283848" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="493.896818" y="343.228533" style="fill: #a6cee4; stroke: #a6cee4"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m51718c9be3" x="65.633182" y="343.543375" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="172.699091" y="343.412983" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="279.765" y="343.213208" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="386.830909" y="343.213145" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="493.896818" y="343.055332" style="fill: #a6cee4; stroke: #a6cee4"/>
     </g>
    </g>
    <g id="line2d_30">
-    <path d="M 65.633182 343.525129
-L 172.699091 343.265602
-L 279.765 343.161356
-L 386.830909 342.94654
-L 493.896818 342.765148
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.45671
+L 172.699091 343.211882
+L 279.765 342.929182
+L 386.830909 342.723918
+L 493.896818 342.543073
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="me10bdc34f0" d="M 0 3
+     <path id="m24788b9bb6" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1163,23 +1163,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #6aaed6"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#me10bdc34f0" x="65.633182" y="343.525129" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="172.699091" y="343.265602" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="279.765" y="343.161356" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="386.830909" y="342.94654" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="493.896818" y="342.765148" style="fill: #6aaed6; stroke: #6aaed6"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m24788b9bb6" x="65.633182" y="343.45671" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="172.699091" y="343.211882" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="279.765" y="342.929182" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="386.830909" y="342.723918" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="493.896818" y="342.543073" style="fill: #6aaed6; stroke: #6aaed6"/>
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 65.633182 343.42798
-L 172.699091 343.083131
-L 279.765 342.831555
-L 386.830909 342.431911
-L 493.896818 342.328857
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.331238
+L 172.699091 342.975374
+L 279.765 342.69846
+L 386.830909 342.355583
+L 493.896818 341.977047
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m15b5684f0d" d="M 0 3
+     <path id="m51807d90b5" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1191,23 +1191,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #3b8bc2"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#m15b5684f0d" x="65.633182" y="343.42798" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="172.699091" y="343.083131" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="279.765" y="342.831555" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="386.830909" y="342.431911" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="493.896818" y="342.328857" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m51807d90b5" x="65.633182" y="343.331238" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="172.699091" y="342.975374" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="279.765" y="342.69846" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="386.830909" y="342.355583" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="493.896818" y="341.977047" style="fill: #3b8bc2; stroke: #3b8bc2"/>
     </g>
    </g>
    <g id="line2d_32">
-    <path d="M 65.633182 343.225584
-L 172.699091 342.821057
-L 279.765 342.456514
-L 386.830909 342.036191
-L 493.896818 341.52479
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 343.144216
+L 172.699091 342.745588
+L 279.765 342.349662
+L 386.830909 341.980364
+L 493.896818 341.379999
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m9a16f8171c" d="M 0 3
+     <path id="m92eb8d5dcd" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1219,23 +1219,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1764ab"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#m9a16f8171c" x="65.633182" y="343.225584" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="172.699091" y="342.821057" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="279.765" y="342.456514" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="386.830909" y="342.036191" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="493.896818" y="341.52479" style="fill: #1764ab; stroke: #1764ab"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m92eb8d5dcd" x="65.633182" y="343.144216" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="172.699091" y="342.745588" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="279.765" y="342.349662" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="386.830909" y="341.980364" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="493.896818" y="341.379999" style="fill: #1764ab; stroke: #1764ab"/>
     </g>
    </g>
    <g id="line2d_33">
-    <path d="M 65.633182 343.169386
-L 172.699091 342.701384
-L 279.765 342.287261
-L 386.830909 341.869994
-L 493.896818 341.280397
-" clip-path="url(#pf7f0328271)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 65.633182 342.787375
+L 172.699091 342.339771
+L 279.765 342.046042
+L 386.830909 341.493151
+L 493.896818 340.939082
+" clip-path="url(#p277b402921)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m83ffa9e9bd" d="M 0 3
+     <path id="m809cc5d11e" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1247,12 +1247,12 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #083c7d"/>
     </defs>
-    <g clip-path="url(#pf7f0328271)">
-     <use xlink:href="#m83ffa9e9bd" x="65.633182" y="343.169386" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="172.699091" y="342.701384" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="279.765" y="342.287261" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="386.830909" y="341.869994" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="493.896818" y="341.280397" style="fill: #083c7d; stroke: #083c7d"/>
+    <g clip-path="url(#p277b402921)">
+     <use xlink:href="#m809cc5d11e" x="65.633182" y="342.787375" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="172.699091" y="342.339771" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="279.765" y="342.046042" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="386.830909" y="341.493151" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="493.896818" y="340.939082" style="fill: #083c7d; stroke: #083c7d"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1276,7 +1276,7 @@ L 515.31 50.64
 " style="fill: none; stroke: #cccccc; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_17">
-    <!-- ryl 0.11.0 -->
+    <!-- ryl 0.19.0 -->
     <g style="fill: #262626" transform="translate(251.089687 44.64) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325
@@ -1304,7 +1304,7 @@ z
      <use xlink:href="#DejaVuSans-30" transform="translate(159.863281 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(223.486328 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(255.273438 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(318.896484 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(318.896484 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(382.519531 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(414.306641 0)"/>
     </g>
@@ -1324,7 +1324,7 @@ z
      <g id="line2d_34">
       <path d="M 547.523182 357.54
 L 547.523182 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_35"/>
      <g id="text_18">
@@ -1339,7 +1339,7 @@ L 547.523182 50.64
      <g id="line2d_36">
       <path d="M 601.056136 357.54
 L 601.056136 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_37"/>
      <g id="text_19">
@@ -1354,7 +1354,7 @@ L 601.056136 50.64
      <g id="line2d_38">
       <path d="M 654.589091 357.54
 L 654.589091 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_39"/>
      <g id="text_20">
@@ -1369,7 +1369,7 @@ L 654.589091 50.64
      <g id="line2d_40">
       <path d="M 708.122045 357.54
 L 708.122045 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_41"/>
      <g id="text_21">
@@ -1384,7 +1384,7 @@ L 708.122045 50.64
      <g id="line2d_42">
       <path d="M 761.655 357.54
 L 761.655 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_43"/>
      <g id="text_22">
@@ -1399,7 +1399,7 @@ L 761.655 50.64
      <g id="line2d_44">
       <path d="M 815.187955 357.54
 L 815.187955 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_45"/>
      <g id="text_23">
@@ -1414,7 +1414,7 @@ L 815.187955 50.64
      <g id="line2d_46">
       <path d="M 868.720909 357.54
 L 868.720909 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_47"/>
      <g id="text_24">
@@ -1429,7 +1429,7 @@ L 868.720909 50.64
      <g id="line2d_48">
       <path d="M 922.253864 357.54
 L 922.253864 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_49"/>
      <g id="text_25">
@@ -1444,7 +1444,7 @@ L 922.253864 50.64
      <g id="line2d_50">
       <path d="M 975.786818 357.54
 L 975.786818 50.64
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_51"/>
      <g id="text_26">
@@ -1485,223 +1485,223 @@ L 975.786818 50.64
    <g id="matplotlib.axis_4">
     <g id="ytick_6">
      <g id="line2d_52">
-      <path d="M 526.11 344.198029
-L 997.2 344.198029
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 344.223728
+L 997.2 344.223728
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_53"/>
     </g>
     <g id="ytick_7">
      <g id="line2d_54">
-      <path d="M 526.11 283.289669
-L 997.2 283.289669
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 283.526265
+L 997.2 283.526265
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_55"/>
     </g>
     <g id="ytick_8">
      <g id="line2d_56">
-      <path d="M 526.11 222.381308
-L 997.2 222.381308
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 222.828801
+L 997.2 222.828801
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_57"/>
     </g>
     <g id="ytick_9">
      <g id="line2d_58">
-      <path d="M 526.11 161.472948
-L 997.2 161.472948
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 162.131338
+L 997.2 162.131338
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_59"/>
     </g>
     <g id="ytick_10">
      <g id="line2d_60">
-      <path d="M 526.11 100.564587
-L 997.2 100.564587
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 526.11 101.433874
+L 997.2 101.433874
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_61"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_6">
     <defs>
-     <path id="m283474c111" d="M 547.523182 -67.502057
-L 547.523182 -67.223115
-L 654.589091 -73.64916
-L 761.655 -80.259693
-L 868.720909 -86.871177
-L 975.786818 -93.266448
-L 975.786818 -93.647786
-L 975.786818 -93.647786
-L 868.720909 -87.48533
-L 761.655 -80.60386
-L 654.589091 -74.06225
-L 547.523182 -67.502057
+     <path id="m61987daa7e" d="M 547.523182 -67.879427
+L 547.523182 -67.316057
+L 654.589091 -74.20996
+L 761.655 -80.644367
+L 868.720909 -87.180264
+L 975.786818 -93.311706
+L 975.786818 -94.254957
+L 975.786818 -94.254957
+L 868.720909 -87.934287
+L 761.655 -81.294829
+L 654.589091 -74.636173
+L 547.523182 -67.879427
 z
 " style="stroke: #a6cee4; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m283474c111" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m61987daa7e" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_7">
     <defs>
-     <path id="m7acd664db4" d="M 547.523182 -80.13164
-L 547.523182 -78.85665
-L 654.589091 -96.710355
-L 761.655 -115.09823
-L 868.720909 -132.76269
-L 975.786818 -150.747719
-L 975.786818 -152.272864
-L 975.786818 -152.272864
-L 868.720909 -133.632405
-L 761.655 -116.11069
-L 654.589091 -97.607173
-L 547.523182 -80.13164
+     <path id="m14ba350982" d="M 547.523182 -79.73891
+L 547.523182 -78.78288
+L 654.589091 -97.525146
+L 761.655 -115.406501
+L 868.720909 -133.887758
+L 975.786818 -152.350114
+L 975.786818 -153.068162
+L 975.786818 -153.068162
+L 868.720909 -134.791917
+L 761.655 -116.353176
+L 654.589091 -98.224053
+L 547.523182 -79.73891
 z
 " style="stroke: #6aaed6; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m7acd664db4" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m14ba350982" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_8">
     <defs>
-     <path id="m881ac0bebb" d="M 547.523182 -91.268951
-L 547.523182 -90.35644
-L 654.589091 -119.496266
-L 761.655 -148.549358
-L 868.720909 -177.952965
-L 975.786818 -207.79135
-L 975.786818 -210.487656
-L 975.786818 -210.487656
-L 868.720909 -180.032803
-L 761.655 -150.721108
-L 654.589091 -121.01629
-L 547.523182 -91.268951
+     <path id="me179cc9c80" d="M 547.523182 -91.429355
+L 547.523182 -90.507077
+L 654.589091 -119.875201
+L 761.655 -150.269308
+L 868.720909 -179.304155
+L 975.786818 -208.987701
+L 975.786818 -211.537973
+L 975.786818 -211.537973
+L 868.720909 -181.624557
+L 761.655 -152.810808
+L 654.589091 -120.40605
+L 547.523182 -91.429355
 z
 " style="stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m881ac0bebb" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#me179cc9c80" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_9">
     <defs>
-     <path id="m3a1a05e78e" d="M 547.523182 -102.984276
-L 547.523182 -101.781527
-L 654.589091 -142.510671
-L 761.655 -184.050058
-L 868.720909 -223.886507
-L 975.786818 -264.915192
-L 975.786818 -269.181646
-L 975.786818 -269.181646
-L 868.720909 -227.411072
-L 761.655 -186.519558
-L 654.589091 -144.277125
-L 547.523182 -102.984276
+     <path id="me61cdf0626" d="M 547.523182 -103.088494
+L 547.523182 -102.081934
+L 654.589091 -143.292649
+L 761.655 -183.504678
+L 868.720909 -226.432359
+L 975.786818 -266.404753
+L 975.786818 -269.631247
+L 975.786818 -269.631247
+L 868.720909 -231.029814
+L 761.655 -184.700432
+L 654.589091 -144.561418
+L 547.523182 -103.088494
 z
 " style="stroke: #1764ab; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m3a1a05e78e" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#me61cdf0626" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_10">
     <defs>
-     <path id="m15969badb3" d="M 547.523182 -113.652859
-L 547.523182 -113.182527
-L 654.589091 -166.086202
-L 761.655 -218.520346
-L 868.720909 -270.78465
-L 975.786818 -322.120019
+     <path id="m7ee23bd04b" d="M 547.523182 -115.358617
+L 547.523182 -114.301928
+L 654.589091 -165.383934
+L 761.655 -218.709912
+L 868.720909 -271.733793
+L 975.786818 -328.739603
 L 975.786818 -331.41
 L 975.786818 -331.41
-L 868.720909 -276.834891
-L 761.655 -221.091892
-L 654.589091 -166.640048
-L 547.523182 -113.652859
+L 868.720909 -274.478997
+L 761.655 -220.469835
+L 654.589091 -169.16127
+L 547.523182 -115.358617
 z
 " style="stroke: #083c7d; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m15969badb3" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m7ee23bd04b" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="line2d_62">
-    <path d="M 547.523182 328.637414
-L 654.589091 322.144295
-L 761.655 315.568224
-L 868.720909 308.821747
-L 975.786818 302.542883
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m41e44083d9" x="547.523182" y="328.637414" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="654.589091" y="322.144295" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="761.655" y="315.568224" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="868.720909" y="308.821747" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m41e44083d9" x="975.786818" y="302.542883" style="fill: #a6cee4; stroke: #a6cee4"/>
+    <path d="M 547.523182 328.402258
+L 654.589091 321.576934
+L 761.655 315.030402
+L 868.720909 308.442724
+L 975.786818 302.216669
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m51718c9be3" x="547.523182" y="328.402258" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="654.589091" y="321.576934" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="761.655" y="315.030402" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="868.720909" y="308.442724" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m51718c9be3" x="975.786818" y="302.216669" style="fill: #a6cee4; stroke: #a6cee4"/>
     </g>
    </g>
    <g id="line2d_63">
-    <path d="M 547.523182 316.505855
-L 654.589091 298.841236
-L 761.655 280.39554
-L 868.720909 262.802453
-L 975.786818 244.489708
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#me10bdc34f0" x="547.523182" y="316.505855" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="654.589091" y="298.841236" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="761.655" y="280.39554" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="868.720909" y="262.802453" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#me10bdc34f0" x="975.786818" y="244.489708" style="fill: #6aaed6; stroke: #6aaed6"/>
+    <path d="M 547.523182 316.739105
+L 654.589091 298.125401
+L 761.655 280.120162
+L 868.720909 261.660163
+L 975.786818 243.290862
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m24788b9bb6" x="547.523182" y="316.739105" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="654.589091" y="298.125401" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="761.655" y="280.120162" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="868.720909" y="261.660163" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#m24788b9bb6" x="975.786818" y="243.290862" style="fill: #6aaed6; stroke: #6aaed6"/>
     </g>
    </g>
    <g id="line2d_64">
-    <path d="M 547.523182 305.187305
-L 654.589091 275.743722
-L 761.655 246.364767
-L 868.720909 217.007116
-L 975.786818 186.860497
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m15b5684f0d" x="547.523182" y="305.187305" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="654.589091" y="275.743722" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="761.655" y="246.364767" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="868.720909" y="217.007116" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m15b5684f0d" x="975.786818" y="186.860497" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+    <path d="M 547.523182 305.031784
+L 654.589091 275.859375
+L 761.655 244.459942
+L 868.720909 215.535644
+L 975.786818 185.737163
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m51807d90b5" x="547.523182" y="305.031784" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="654.589091" y="275.859375" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="761.655" y="244.459942" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="868.720909" y="215.535644" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m51807d90b5" x="975.786818" y="185.737163" style="fill: #3b8bc2; stroke: #3b8bc2"/>
     </g>
    </g>
    <g id="line2d_65">
-    <path d="M 547.523182 293.617099
-L 654.589091 252.606102
-L 761.655 210.715192
-L 868.720909 170.35121
-L 975.786818 128.951581
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m9a16f8171c" x="547.523182" y="293.617099" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="654.589091" y="252.606102" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="761.655" y="210.715192" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="868.720909" y="170.35121" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m9a16f8171c" x="975.786818" y="128.951581" style="fill: #1764ab; stroke: #1764ab"/>
+    <path d="M 547.523182 293.414786
+L 654.589091 252.072966
+L 761.655 211.897445
+L 868.720909 167.268913
+L 975.786818 127.982
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m92eb8d5dcd" x="547.523182" y="293.414786" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="654.589091" y="252.072966" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="761.655" y="211.897445" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="868.720909" y="167.268913" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m92eb8d5dcd" x="975.786818" y="127.982" style="fill: #1764ab; stroke: #1764ab"/>
     </g>
    </g>
    <g id="line2d_66">
-    <path d="M 547.523182 282.582307
-L 654.589091 229.636875
-L 761.655 176.193881
-L 868.720909 122.19023
-L 975.786818 69.23499
-" clip-path="url(#pfb2959b8e0)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#pfb2959b8e0)">
-     <use xlink:href="#m83ffa9e9bd" x="547.523182" y="282.582307" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="654.589091" y="229.636875" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="761.655" y="176.193881" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="868.720909" y="122.19023" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m83ffa9e9bd" x="975.786818" y="69.23499" style="fill: #083c7d; stroke: #083c7d"/>
+    <path d="M 547.523182 281.169728
+L 654.589091 228.727398
+L 761.655 176.410127
+L 868.720909 122.893605
+L 975.786818 65.925199
+" clip-path="url(#p41a759a97d)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#p41a759a97d)">
+     <use xlink:href="#m809cc5d11e" x="547.523182" y="281.169728" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="654.589091" y="228.727398" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="761.655" y="176.410127" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="868.720909" y="122.893605" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#m809cc5d11e" x="975.786818" y="65.925199" style="fill: #083c7d; stroke: #083c7d"/>
     </g>
    </g>
    <g id="patch_8">
@@ -1793,7 +1793,7 @@ L 545.11 78.416563
 L 555.11 78.416563
 " style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m41e44083d9" x="545.11" y="78.416563" style="fill: #a6cee4; stroke: #a6cee4"/>
+      <use xlink:href="#m51718c9be3" x="545.11" y="78.416563" style="fill: #a6cee4; stroke: #a6cee4"/>
      </g>
     </g>
     <g id="text_30">
@@ -1860,7 +1860,7 @@ L 545.11 93.094688
 L 555.11 93.094688
 " style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#me10bdc34f0" x="545.11" y="93.094688" style="fill: #6aaed6; stroke: #6aaed6"/>
+      <use xlink:href="#m24788b9bb6" x="545.11" y="93.094688" style="fill: #6aaed6; stroke: #6aaed6"/>
      </g>
     </g>
     <g id="text_31">
@@ -1879,7 +1879,7 @@ L 545.11 107.772813
 L 555.11 107.772813
 " style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m15b5684f0d" x="545.11" y="107.772813" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+      <use xlink:href="#m51807d90b5" x="545.11" y="107.772813" style="fill: #3b8bc2; stroke: #3b8bc2"/>
      </g>
     </g>
     <g id="text_32">
@@ -1898,7 +1898,7 @@ L 545.11 122.450938
 L 555.11 122.450938
 " style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m9a16f8171c" x="545.11" y="122.450938" style="fill: #1764ab; stroke: #1764ab"/>
+      <use xlink:href="#m92eb8d5dcd" x="545.11" y="122.450938" style="fill: #1764ab; stroke: #1764ab"/>
      </g>
     </g>
     <g id="text_33">
@@ -1917,7 +1917,7 @@ L 545.11 137.129063
 L 555.11 137.129063
 " style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m83ffa9e9bd" x="545.11" y="137.129063" style="fill: #083c7d; stroke: #083c7d"/>
+      <use xlink:href="#m809cc5d11e" x="545.11" y="137.129063" style="fill: #083c7d; stroke: #083c7d"/>
      </g>
     </g>
     <g id="text_34">
@@ -2050,10 +2050,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pf7f0328271">
+  <clipPath id="p277b402921">
    <rect x="44.22" y="50.64" width="471.09" height="306.9"/>
   </clipPath>
-  <clipPath id="pfb2959b8e0">
+  <clipPath id="p41a759a97d">
    <rect x="526.11" y="50.64" width="471.09" height="306.9"/>
   </clipPath>
  </defs>

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.18.1"
+  "version": "0.19.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.18.1"
+version = "0.19.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/scripts/benchmark_perf_vs_yamllint.py
+++ b/scripts/benchmark_perf_vs_yamllint.py
@@ -5,7 +5,6 @@
 #   "matplotlib>=3.9,<4",
 #   "orjson>=3.11,<4",
 #   "polars>=1.30,<2",
-#   "ryl",
 #   "tqdm>=4.67,<5",
 #   "typer>=0.16,<1",
 #   "yamllint",
@@ -234,7 +233,7 @@ def plot_results(
 @app.command()
 def main(
     file_counts: str = typer.Option(
-        "25,100,400,1000",
+        "20,40,60,80,100",
         help="Comma-separated file counts. Ignored when --file-count-start/end/step are set.",
     ),
     file_count_start: int | None = typer.Option(
@@ -247,7 +246,7 @@ def main(
         None, help="Increment for file-count range."
     ),
     file_sizes_kib: str = typer.Option(
-        "1,8,32,128",
+        "1,3,5,7,9",
         help="Comma-separated file sizes in KiB. Ignored when --file-size-start-kib/end/step are set.",
     ),
     file_size_start_kib: int | None = typer.Option(
@@ -259,8 +258,16 @@ def main(
     file_size_step_kib: int | None = typer.Option(
         None, help="Increment for file-size range in KiB."
     ),
-    runs: int = typer.Option(10, help="Number of hyperfine runs per point."),
-    warmup: int = typer.Option(2, help="Number of warmup runs per point."),
+    runs: int = typer.Option(5, help="Number of hyperfine runs per point."),
+    warmup: int = typer.Option(1, help="Number of warmup runs per point."),
+    ryl_bin: Path | None = typer.Option(
+        None,
+        "--ryl-bin",
+        help="ryl binary to benchmark and label (default: the `ryl` on PATH). "
+        "Point at this branch's target/release/ryl so the image reflects the "
+        "release build rather than a stale global install; the version label is "
+        "read from this binary's --version, so it always matches what was timed.",
+    ),
     seed: int = typer.Option(7331, help="Base RNG seed for synthetic YAML generation."),
     output_dir: Path = typer.Option(
         Path("manual_outputs") / "benchmarks",
@@ -312,7 +319,9 @@ def main(
     raw_dir = run_dir / "hyperfine-json"
     raw_dir.mkdir(parents=True, exist_ok=True)
 
-    ryl_bin = resolve_tool_path("ryl")
+    ryl_bin = ryl_bin if ryl_bin is not None else resolve_tool_path("ryl")
+    if not ryl_bin.is_file():
+        raise typer.BadParameter(f"--ryl-bin does not exist: {ryl_bin}")
     yamllint_bin = resolve_tool_path("yamllint")
     ryl_version = run_checked([str(ryl_bin), "--version"]).stdout.strip()
     yamllint_version = run_checked([str(yamllint_bin), "--version"]).stdout.strip()

--- a/skills/ryl/SKILL.md
+++ b/skills/ryl/SKILL.md
@@ -79,7 +79,8 @@ ryl --format github --format gitlab -o code-quality.json .
 ## Configuration: YAML vs TOML
 
 - **YAML** (`.yamllint`, `YAMLLINT_CONFIG_FILE`) is yamllint-compatible (`extends:
-  default`/`relaxed`, presets).
+  default`/`relaxed`, presets). `YAMLLINT_CONFIG_FILE` takes a YAML config only: a
+  `.toml` target errors (use `-c`/`-d` or project discovery for ryl TOML).
 - **TOML** (`ryl.toml`, `.ryl.toml`, `[tool.ryl]`) holds ryl-only features: `[files]`
   globs, `[markdown]` embedding, `[output]` destinations, per-line ignores, ryl-only
   rules.

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.18.1"
+version = "0.19.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/zensical.toml
+++ b/zensical.toml
@@ -110,6 +110,10 @@ pygments_lang_class = true
 [project.markdown_extensions.pymdownx.mark]
 [project.markdown_extensions.pymdownx.smartsymbols]
 [project.markdown_extensions.pymdownx.superfences]
+[[project.markdown_extensions.pymdownx.superfences.custom_fences]]
+name = "mermaid"
+class = "mermaid"
+format = "pymdownx.superfences.fence_code_format"
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
 combine_header_slug = true


### PR DESCRIPTION
## v0.19.0

Cuts the v0.19.0 release, bundling the two config-discovery features already merged to `main` since v0.18.1 and adding a config-precedence diagram. Closes #334.

### Included since v0.18.1
- Repo-local `.config/` ryl config discovery (#218, merged `10b5fd8`)
- `YAMLLINT_CONFIG_FILE` restricted to yamllint YAML configs (#332, merged `0dea166`)

### This PR
- **Config-precedence Mermaid diagram** in `quickstart.md` and `migrating-from-yamllint.md`, with `zensical.toml` `custom_fences` wiring (Zensical renders mermaid natively; GitHub does too). The diagram encodes the full hierarchy: `-d` > `-c` > project (TOML up-tree, else `.yamllint` up-tree) > `YAMLLINT_CONFIG_FILE` > user-global (ryl TOML, else yamllint YAML), then the rule-enabled gate.
- **Docs accuracy**: corrected "per run" → per-file resolution (monorepo many-configs), and the yamllint-divergence note (yamllint folds `YAMLLINT_CONFIG_FILE` into the user-global slot; ryl keeps them as distinct tiers).
- **AGENTS.md** gains a concise config-discovery precedence entry; **skills/ryl/SKILL.md** notes `YAMLLINT_CONFIG_FILE` is YAML-only.
- **Benchmark image refreshed** to ryl 0.19.0: the script now takes `--ryl-bin` (benchmark + label the release build, not a stale PyPI/global ryl) and no longer declares `ryl` as a PEP723 dep (the cause of the long-stale 0.9.1 label); no-arg defaults now reproduce the committed 5x5/5-run matrix.
- **Release dev-skill** updated: benchmark-refresh step, and dev-skill re-sync pinned to the release tag from GitHub (not `--from-local`).
- **Version bump** 0.18.1 → 0.19.0 across `Cargo.toml`, `pyproject.toml`, `package.json`, `Cargo.lock`, `uv.lock` (kept the `h2` 0.4.14 → 0.4.15 transitive bump).

### Verification
- No `src/` logic changes (config-discovery code already on `main`); `prek` green, `cargo test` green, coverage unaffected.
- Config-precedence prose/diagram verified against `discover_config_with` / `find_project_config_core` / `find_first_yaml_candidate` / `try_user_global_core` / `try_env_config_core` and `main::build_global_cfg`.
- Diagram rendered through mermaid@11 (the engine Zensical/GitHub use) to confirm syntax + `>`/line-break escaping.
