### PR TITLE
ci: auto-bump the pinned wingetcreate version (#339)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -901,9 +901,10 @@ jobs:
         shell: pwsh
         # Pin to a reviewed release and verify its published SHA256 before the next
         # step runs it with WINGET_PAT in scope, so a mutated download (or a
-        # compromised redirect) can never execute against the token. Bump the
-        # version and hash together; the hash is the `wingetcreate.exe.txt` checksum
-        # published alongside the release asset.
+        # compromised redirect) can never execute against the token. The version and
+        # hash are bumped together (the hash is the `wingetcreate.exe.txt` checksum
+        # published alongside the release asset); the weekly update.yml workflow
+        # opens a PR with that bump when a newer winget-create release ships.
         env:
           WINGETCREATE_VERSION: v1.12.8.0
           WINGETCREATE_SHA256: 8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,6 +39,39 @@ jobs:
       - name: Run prek autoupdate
         run: prek autoupdate --cooldown-days 7
 
+      - name: Bump pinned wingetcreate version
+        # Keep release.yml's reviewed wingetcreate pin (version + verified SHA256)
+        # current. The checksum is read from the release's `wingetcreate.exe.txt`
+        # asset (UTF-16) rather than recomputed, so the pin stays a value Microsoft
+        # published. No-op when already current, so the diff gate below decides
+        # whether a PR is opened.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          set -euo pipefail
+          release_file=.github/workflows/release.yml
+          current=$(grep -oP 'WINGETCREATE_VERSION:\s*\K\S+' "$release_file")
+          latest=$(gh api repos/microsoft/winget-create/releases/latest --jq .tag_name)
+          # latest is interpolated into the sed below, so reject anything but a
+          # vX.Y... tag: a sed metachar (&, |, \) in the tag must never reach it.
+          if [[ ! "$latest" =~ ^v[0-9.]+$ ]]; then
+            echo "Unexpected winget-create tag '$latest'" >&2
+            exit 1
+          fi
+          if [ "$current" = "$latest" ]; then
+            echo "wingetcreate already pinned to $current"
+            exit 0
+          fi
+          echo "Bumping wingetcreate $current -> $latest"
+          url="https://github.com/microsoft/winget-create/releases/download/${latest}/wingetcreate.exe.txt"
+          sha=$(curl -fsSL "$url" | iconv -f UTF-16 -t UTF-8 | tr -dc '0-9A-Fa-f')
+          if [ "${#sha}" -ne 64 ]; then
+            echo "Unexpected SHA256 length ${#sha} from ${url}" >&2
+            exit 1
+          fi
+          sed -i -E "s|(WINGETCREATE_VERSION: ).*|\1${latest}|" "$release_file"
+          sed -i -E "s|(WINGETCREATE_SHA256: ).*|\1${sha}|" "$release_file"
+
       - name: Check for changes
         id: check_diff
         run: |-
@@ -69,6 +102,10 @@ jobs:
             Automated dependency and linter refresh:
             - Ran `cargo update`
             - Ran `prek autoupdate --cooldown-days 7`
+            - Checked the pinned `wingetcreate` version against the latest `winget-create` release
+
+            If the `wingetcreate` pin changed, verify the version and SHA256 against
+            https://github.com/microsoft/winget-create/releases/latest before merging.
           branch: bot/update-deps-and-linters
           author: GitHub Actions <actions@github.com>
           delete-branch: true


### PR DESCRIPTION
Closes #339.

## What

Adds a step to the weekly "Update Dependencies and Linters" workflow
(`update.yml`) that keeps the `wingetcreate` pin in `release.yml`'s
`publish-winget` job current. It reads the currently pinned
`WINGETCREATE_VERSION`, fetches `microsoft/winget-create`'s latest release
tag, and on a newer release rewrites both `WINGETCREATE_VERSION` and
`WINGETCREATE_SHA256`. The SHA256 is read from the release's
`wingetcreate.exe.txt` asset (UTF-16, decoded and hex-extracted) rather than
recomputed, so the pin stays a value Microsoft published.

## Why this shape

Folded into the existing weekly workflow (issue option 1, the maintainer
preference) rather than a standalone workflow: the pin changes rarely, so the
bump rides along in the existing `chore: refresh dependencies and linters` PR
and reuses its diff gate + create-pull-request + app-token flow with no new
secrets. The diff gate decides whether a PR opens, so the step is a no-op when
the pin is already current (today it is: latest is `v1.12.8.0`, which we pin).

## Robustness

- The fetched tag is validated against `^v[0-9.]+$` before it reaches the
  `sed` replacement, so a tag with a `sed` metachar can never corrupt the edit.
- A malformed/unexpected-length checksum fails the step (64-hex guard).
- Failures are fail-loud by design (no `continue-on-error`), so an upstream
  asset rename or fetch error surfaces immediately.
- The PR body gained a merge-time pointer to cross-check any pin change against
  the upstream release page.

## Verification

- `prek run --all-files` green, including `zizmor`.
- Bump logic dry-run against a copy of `release.yml`; SHA extraction verified
  against the live `wingetcreate.exe.txt` asset (matches the current pin);
  tag-validation regex unit-checked.
- Local reviews clean (Claude `/code-review` + local Codex adversarial:
  approve).

https://claude.ai/code/session_01FPuR23BFPdtQnLGZobPhYB