### PR TITLE
ci: use client-id instead of deprecated app-id for app-token (#345)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -961,7 +961,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ secrets.AUTH_APP_CLIENT_ID }}
+          client-id: ${{ secrets.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: owenlamont
           repositories: ryl-pre-commit

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTH_APP_CLIENT_ID }}
+          client-id: ${{ secrets.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
Closes #345.

`actions/create-github-app-token@v3.2.0` deprecated its `app-id` input in
favor of `client-id`, so every token-generating run logged:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

This switches `update.yml` and `release.yml` to `client-id`, bringing them in
line with `sync-schemastore.yml` (which already uses it). The secret value
(`secrets.AUTH_APP_CLIENT_ID`) is unchanged.

## Verified safe

- The secret is a GitHub App client ID: sync-schemastore run
  https://github.com/owenlamont/ryl/actions/runs/27017324267 generated a token
  with `client-id` + that exact secret successfully.
- `client-id` is the documented replacement (`app-id` carries
  `deprecationMessage: "Use 'client-id' instead."`).
- Already on `v3.2.0` (latest), so no version bump needed.

prek (incl. zizmor) green.

https://claude.ai/code/session_01FPuR23BFPdtQnLGZobPhYB