### PR TITLE
fix: bump granit to 0.0.6 and close a %TAG-split tags-rule evasion (#352)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599a28c6c3171864dbf7fdb3a666f7ac301fab54c2b6e71534f413959cd37b49"
+checksum = "14668345710c92cb04181d9268407067689327d4b055273e3c4179a0777ee6a1"
 dependencies = [
  "arraydeque",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ globset = "0.4.18"
 ignore = "0.4.25"
 rayon = "1.11.0"
 schemars = { version = "1.2.1", features = ["derive"] }
-granit-parser = "0.0.5"
+granit-parser = "0.0.6"
 hashlink = "0.12.0"
 ordered-float = "5"
 dirs-next = "2.0.0"

--- a/src/rules/key_duplicates.rs
+++ b/src/rules/key_duplicates.rs
@@ -47,7 +47,7 @@ use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver, Tag}
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::mapping_key_walker::Walker;
-use crate::yaml_dom::{Scalar, ScalarOwned, core_schema_suffix, is_core_schema};
+use crate::yaml_dom::{Scalar, ScalarOwned, is_core_schema};
 
 pub const ID: &str = "key-duplicates";
 
@@ -149,26 +149,15 @@ fn hash_of(value: &impl Hash) -> Vid {
     hasher.finish()
 }
 
-/// The core schema's default tags (those an untagged node resolves to) don't
-/// distinguish a value; any other tag does.
-const DEFAULT_TAG_SUFFIXES: [&str; 7] =
-    ["map", "seq", "str", "int", "float", "bool", "null"];
-
 /// A tag's contribution to a node's `Vid`: a local tag (`!foo`) or a non-default
 /// core tag (`!!set`, `!!omap`) distinguishes the value from an untagged node;
-/// the implicit default tags do not.
+/// the Core Schema default tags (which an untagged node resolves to) do not.
 fn tag_vid(tag: Option<&Cow<'_, Tag>>) -> Vid {
     match tag.map(Cow::as_ref) {
-        // `core_schema_suffix`, not granit's handle-only check, so a verbatim core
-        // default tag is recognised as non-distinguishing too (#277).
-        Some(tag)
-            if !matches!(
-                core_schema_suffix(tag),
-                Some(suffix) if DEFAULT_TAG_SUFFIXES.contains(&suffix)
-            ) =>
-        {
-            hash_of(tag)
-        }
+        // `is_yaml_core_schema` matches a Core Schema tag in any spelling
+        // (verbatim, `%TAG` mid-split), so every default tag stays
+        // non-distinguishing; `merge`, removed 1.1 types, and local tags do not.
+        Some(tag) if !tag.is_yaml_core_schema() => hash_of(tag),
         _ => UNKNOWN_VID,
     }
 }

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -19,8 +19,8 @@
 //!   lets a team permit only the handles it actually uses.
 //!
 //! Detection normalises tag spelling, so shorthand (`!!omap`), local
-//! (`!ruby/object:`), and verbatim (`!<tag:yaml.org,2002:omap>`) forms map to
-//! the same identity and cannot be used to evade a check.
+//! (`!ruby/object:`), verbatim (`!<tag:yaml.org,2002:omap>`), and `%TAG`-split
+//! forms map to the same identity and cannot be used to evade a check.
 //!
 //! Sources: YAML 1.2.2 spec (tags); YAML 1.2.2 changes page; `PyYAML` docs; The
 //! YAML Company. There is no safe `--fix`: rewriting or dropping a tag changes
@@ -87,12 +87,14 @@ impl Config {
         }
         let core = core_schema_suffix(tag);
         if self.forbid_unsafe_tags
-            && unsafe_namespace(tag, core).is_some_and(is_unsafe_suffix)
+            && unsafe_namespace(tag, core.as_deref()).is_some_and(is_unsafe_suffix)
         {
             return Some(format!("forbidden unsafe tag \"{}\"", shorthand(tag)));
         }
         if self.forbid_removed_types
-            && core.is_some_and(|suffix| REMOVED_TYPE_SUFFIXES.contains(&suffix))
+            && core
+                .as_deref()
+                .is_some_and(|suffix| REMOVED_TYPE_SUFFIXES.contains(&suffix))
         {
             return Some(format!(
                 "forbidden removed YAML 1.1 type \"{}\"",

--- a/src/yaml_dom/loader.rs
+++ b/src/yaml_dom/loader.rs
@@ -176,7 +176,11 @@ impl Loader {
         // untyped — mirroring the scalar path, which yields `BadValue` for a core
         // tag that does not match the value.
         let node = match tag {
-            Some(tag) if core_schema_suffix(&tag) == Some(default_suffix) => node,
+            Some(tag)
+                if core_schema_suffix(&tag).as_deref() == Some(default_suffix) =>
+            {
+                node
+            }
             Some(tag) => YamlOwned::Tagged(tag, Box::new(node)),
             None => node,
         };

--- a/src/yaml_dom/scalar.rs
+++ b/src/yaml_dom/scalar.rs
@@ -55,7 +55,7 @@ impl<'input> Scalar<'input> {
         // before the non-plain-is-a-string fallback. Matching on the core-schema
         // *suffix* (not the handle) means a verbatim `!<tag:yaml.org,2002:int>`
         // resolves identically to the `!!int` shorthand (issue #277).
-        match tag.map(Cow::as_ref).and_then(core_schema_suffix) {
+        match tag.map(Cow::as_ref).and_then(core_schema_suffix).as_deref() {
             Some("bool") => parse_core_schema_bool(&v).map(Self::Boolean),
             Some("int") => parse_core_schema_int(&v).map(Self::Integer),
             Some("float") => parse_core_schema_fp(&v)

--- a/src/yaml_dom/tag.rs
+++ b/src/yaml_dom/tag.rs
@@ -1,39 +1,42 @@
-//! Spelling-independent inspection of YAML core-schema tags.
-//!
-//! `granit_parser::Tag::is_yaml_core_schema` inspects only the tag *handle*, so a
-//! verbatim core tag — `!<tag:yaml.org,2002:int>`, which granit scans to an empty
-//! handle with the full URI sitting in `suffix` — is not recognised as
-//! core-schema even though `PyYAML` and ruamel.yaml resolve every spelling to the
-//! same type (verified). These helpers collapse all three spellings (shorthand
-//! `!!int`, a `%TAG`-resolved handle, and verbatim) onto one core-schema suffix,
-//! so a rule matches a type regardless of how the author wrote the tag and the
-//! verbatim form cannot be used to evade a check.
-//!
-//! Prefer these over `Tag::is_yaml_core_schema` for any spelling-independent
-//! core-schema decision (issue #277).
+//! Spelling-independent inspection of the `tag:yaml.org,2002:` namespace, wider
+//! than granit's strict Core Schema accessors so `tags`/`key-duplicates` also see
+//! the non-core types (`merge`, the removed YAML 1.1 types). It matches the full
+//! resolved tag URI, so no verbatim or `%TAG`-split spelling can hide a type from
+//! a check.
+
+use std::borrow::Cow;
 
 use granit_parser::Tag;
 
-/// The core-schema tag-handle prefix (`tag:yaml.org,2002:`) that `!!`-shorthand
-/// tags resolve to, and that a verbatim core tag carries inside its suffix.
+/// The `tag:yaml.org,2002:` namespace prefix that every spelling resolves to.
 const CORE_SCHEMA_PREFIX: &str = "tag:yaml.org,2002:";
 
-/// The core-schema type suffix this tag resolves to regardless of spelling
-/// (`!!int`, a `%TAG`-resolved `tag:yaml.org,2002:` handle, and verbatim
-/// `!<tag:yaml.org,2002:int>` all yield `int`), or `None` for any non-core tag.
+/// The `tag:yaml.org,2002:` type suffix this tag resolves to in any spelling, or
+/// `None` outside the namespace. Wider than the Core Schema: also reports `merge`
+/// and the removed YAML 1.1 types.
 #[must_use]
-pub fn core_schema_suffix(tag: &Tag) -> Option<&str> {
-    if tag.handle == CORE_SCHEMA_PREFIX {
-        Some(tag.suffix.as_str())
-    } else if tag.handle.is_empty() {
-        // Verbatim `!<…>` tags carry an empty handle and the full URI in `suffix`.
-        tag.suffix.strip_prefix(CORE_SCHEMA_PREFIX)
-    } else {
-        None
+pub fn core_schema_suffix(tag: &Tag) -> Option<Cow<'_, str>> {
+    // A tag resolves to `handle ++ suffix` (YAML 1.2.2 §6.8.2.2) and a `%TAG`
+    // directive can cut that URI at any point, so strip the namespace prefix
+    // across the seam — otherwise a split spelling could hide a type from a check.
+    if let Some(head) = tag.handle.strip_prefix(CORE_SCHEMA_PREFIX) {
+        // The handle holds the whole prefix; the type is its tail plus the suffix
+        // (only a mid-token `%TAG` split leaves a non-empty tail and must own it).
+        return Some(if head.is_empty() {
+            Cow::Borrowed(tag.suffix.as_str())
+        } else {
+            Cow::Owned(format!("{head}{}", tag.suffix))
+        });
     }
+    // The handle stops inside the prefix (an empty verbatim handle is one case);
+    // the suffix must supply the prefix remainder before the type name.
+    CORE_SCHEMA_PREFIX
+        .strip_prefix(tag.handle.as_str())
+        .and_then(|prefix_tail| tag.suffix.strip_prefix(prefix_tail))
+        .map(Cow::Borrowed)
 }
 
-/// Whether `tag` resolves to a YAML core-schema type under any spelling.
+/// Whether `tag` resolves into the `tag:yaml.org,2002:` namespace in any spelling.
 #[must_use]
 pub fn is_core_schema(tag: &Tag) -> bool {
     core_schema_suffix(tag).is_some()

--- a/tests/cli_tags_rule.rs
+++ b/tests/cli_tags_rule.rs
@@ -151,6 +151,32 @@ fn verbatim_and_javax_tag_spellings_are_normalised_and_detected() {
 }
 
 #[test]
+fn tag_directive_mid_split_uri_is_normalised_and_detected() {
+    // A `%TAG` directive can cut the resolved URI mid-token (handle
+    // `tag:yaml.org,2002:o` + suffix `map` resolves to `omap`); the type must
+    // still be recognised so a split spelling cannot evade a safety check.
+    let (code, output) = lint_with_toml_config(
+        "%TAG !o! tag:yaml.org,2002:o\n---\nx: !o!map [1]\n",
+        "[rules.tags]\nforbid-removed-types = true\n",
+    );
+    assert_eq!(code, 1, "mid-split removed type should fail: {output}");
+    assert!(
+        output.contains("forbidden removed YAML 1.1 type \"!!omap\""),
+        "mid-split core tag should normalise to !!omap: {output}"
+    );
+
+    let (code, output) = lint_with_toml_config(
+        "%TAG !p! tag:yaml.org,2002:p\n---\nx: !p!ython/object:os.system [1]\n",
+        "[rules.tags]\nforbid-unsafe-tags = true\n",
+    );
+    assert_eq!(code, 1, "mid-split unsafe tag should fail: {output}");
+    assert!(
+        output.contains("forbidden unsafe tag \"!!python/object:os.system\""),
+        "mid-split unsafe tag should normalise and be flagged: {output}"
+    );
+}
+
+#[test]
 fn custom_tag_directive_handle_is_not_namespace_matched() {
     let (code, output) = lint_with_toml_config(
         "%TAG !e! tag:example.com,2000:\n---\nx: !e!python/object value\n",


### PR DESCRIPTION
## What

- Update `granit-parser` 0.0.5 -> 0.0.6.
- Lean `key-duplicates` `tag_vid` on granit's now spec-correct
  `is_yaml_core_schema` (recognises verbatim and `%TAG`-split spellings of the
  seven core types); drop the redundant `DEFAULT_TAG_SUFFIXES` constant.
- Rework `yaml_dom::tag::core_schema_suffix` to resolve the full
  `handle ++ suffix` URI across any `%TAG` split point, returning `Cow` (it
  allocates only for a mid-token split).
- Add a CLI regression for the mid-split removed and unsafe spellings.

## Why

`#352` asked to bump granit and remove the tag-handling workarounds. granit
0.0.6's `core_suffix()` / `is_yaml_core_schema()` resolve every spelling
(including a `%TAG` mid-split) but only for the strict 7-type YAML 1.2 Core
Schema. ryl additionally classifies the wider `tag:yaml.org,2002:` namespace
(`merge`, the removed 1.1 types) for the `tags` and `key-duplicates` rules, so
the workaround can be *leaned on granit where it fits* (`tag_vid`) but not fully
deleted.

While reworking the helper, the local Codex review surfaced a **pre-existing**
evasion: a `%TAG` directive that splits a removed/unsafe 2002-namespace tag URI
mid-token (e.g. `%TAG !o! tag:yaml.org,2002:o` then `!o!map` -> `omap`) slipped
past `tags.forbid-removed-types` and `forbid-unsafe-tags`, because the old helper
only matched the two clean splits. Resolving the full URI closes it (verified:
both spellings now flag, shorthand/verbatim/core/local unchanged).

The upstream ask to let granit own the wider-namespace resolution (so the
reassembly can be dropped here and in `merge_key.rs`) is scoped in #355.

## Verification

- `prek run --all-files` clean (stable, no auto-fix churn)
- `cargo clippy --all-targets -- -D warnings` and `--no-default-features` both clean
- Coverage: zero uncovered regions
- `property_check`: 12/12 at ~512x (262k cases each)
- Local Codex adversarial review: approve, no material findings

Closes #352.

https://claude.ai/code/session_01SSQ63fGhQE9AYnfRNJip6s
