### PR TITLE
docs: add winget-defender-fp dev skill for winget Defender FP triage

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -88,7 +88,9 @@ description: >-
   winget-pkgs from the one-time `wingetcreate new` bootstrap; `update` preserves the
   nested-portable config and `Microsoft.VCRedist.2015+` dependencies, swapping only
   version, URLs, and SHA256. Re-running a published version would attempt a duplicate
-  winget PR (no existence guard, unlike the crates/PyPI/NPM steps).
+  winget PR (no existence guard, unlike the crates/PyPI/NPM steps). If that winget PR is
+  blocked by a Microsoft Defender false positive (`Validation-Defender-Error` / "Installer
+  failed security check"), see the `winget-defender-fp` skill.
 - Social posts are optional — skip them for a routine correctness/packaging release; draft
   them only for a notable feature. When drafting, write the `.txt` files one directory up
   from the ryl clone (where drafts live) but run any post-length/status check from **inside

--- a/.agents/skills/winget-defender-fp/SKILL.md
+++ b/.agents/skills/winget-defender-fp/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: winget-defender-fp
+description: >-
+  Use when a ryl winget-pkgs validation PR is blocked by a Microsoft Defender
+  false positive (`Validation-Defender-Error` / "Installer failed security
+  check"). Covers the transient-vs-reproducible decision, local Defender +
+  VirusTotal reproduction, the WDSI false-positive submission, and the log
+  noise to ignore.
+---
+
+# Winget Defender False-Positive Triage
+
+ryl ships **unsigned** Windows binaries (`InstallerType: zip` + `NestedInstallerType:
+portable`). Microsoft Defender's cloud/ML heuristics intermittently flag the *downloaded*
+ZIP (mark-of-the-web) as a trojan, failing the winget-pkgs validation. The packaging is
+correct — this is a false positive, not a ryl bug. Code signing is the durable fix but is
+deferred (#342); this loop is the interim process.
+
+## Recognise it
+
+- Labels: **`Validation-Defender-Error`** is the root cause; `Validation-Installation-Error`
+  and `Validation-Executable-Error` are downstream cascades of the same block;
+  `Needs-Author-Feedback` means the PR is waiting on you (reply, or it can be auto-closed).
+- The moderator's "… Validation ended with" comment names the **detection** and the
+  **artifact** (usually the x64 zip), e.g. `[FAIL] Installer failed security check. Url:
+  …/ryl-x86_64-pc-windows-msvc.zip … Detection: Trojan:Win32/Sprisky.U!cl`.
+- The signature name **varies per release** (`Wacatac.H!ml`, `Sprisky.U!cl`, …); the
+  `!ml`/`!cl` suffix means heuristic/cloud, not a content-signature match.
+- Error codes: `0x8A15002D` = `APPINSTALLER_CLI_ERROR_INSTALLER_SECURITY_CHECK_FAILED`;
+  `0x80004005` = `E_FAIL`.
+- **Log noise to ignore** (always present, never the cause): the validator's WMI
+  `wminet_utils.dll` `TypeInitializationException`, and `ryl.exe returned exit code: 2`
+  (ryl's by-design no-args usage exit).
+
+## Diagnose
+
+The Azure validation pipeline is **public/anonymous**. From the wingetbot "Validation
+Pipeline Run" link grab the `buildId`, then (project GUID
+`8b78618a-7973-49d8-9174-4360829d979b`) read the timeline and the failed task's log (look
+for the `Installation Validation` task):
+
+```sh
+base="https://dev.azure.com/shine-oss/8b78618a-7973-49d8-9174-4360829d979b/_apis/build/builds"
+curl -s "$base/<buildId>/timeline?api-version=7.1"
+curl -s "$base/<buildId>/logs/<logId>?api-version=7.1"
+```
+
+Reproduce locally (Windows, real-time protection ON — always record the signature build,
+it is the key datum for the PR reply):
+
+```powershell
+$u = "https://github.com/owenlamont/ryl/releases/download/vX.Y.Z/ryl-x86_64-pc-windows-msvc.zip"
+try { Invoke-WebRequest $u -OutFile "$env:TEMP\ryl-check.zip" -ErrorAction Stop; "OK" }
+catch { "BLOCKED: $($_.Exception.Message)" }   # a block/quarantine == reproduced
+Start-MpScan -ScanType CustomScan -ScanPath "$env:TEMP\ryl-check.zip"
+Get-MpThreatDetection | Sort-Object InitialDetectionTime -Descending |
+  Select-Object -First 3 InitialDetectionTime, Resources
+(Get-MpComputerStatus).AntivirusSignatureVersion
+```
+
+Cross-check **VirusTotal** — its Microsoft engine is the best proxy for the validator.
+Look up by hash first (`https://www.virustotal.com/gui/file/<sha256-lowercase>`);
+upload if absent. Check **all four** artifacts: both zips **and** the unzipped `.exe`s.
+The bare exe usually scans clean; only the MOTW download trips it. (VT's GUI is
+shadow-DOM heavy, so reading a verdict via DOM scraping needs shadow-root traversal.)
+
+## Decide
+
+- **Both VT (Microsoft = Undetected) and local Defender clean** → the verdict has aged out
+  / is environment-specific. **Do not file a WDSI submission** (Microsoft would likely
+  reject it as "not detected"). Reply to `Needs-Author-Feedback` with the evidence —
+  the Defender **signature build** tested, VT links, "Microsoft: Undetected" — and
+  request a re-run (`@wingetbot run`, or ask the assigned moderator; the bot also
+  auto-retries ~every 18h).
+  *(0.20.0 / `microsoft/winget-pkgs#391230`.)*
+- **Still reproducibly flagged** (local Defender and/or VT's Microsoft engine) → file a
+  WDSI false-positive submission, then wait for propagation + re-run.
+  *(0.19.1 / `microsoft/winget-pkgs#390120`.)*
+
+## WDSI submission (only when reproducible)
+
+<https://www.microsoft.com/en-us/wdsi/filesubmission> → **Software developer** persona →
+requires a Microsoft account sign-in **and a CAPTCHA** (human steps; not automatable).
+
+- Submit the **flagged ZIP**. Defender blocks *copying* a quarantined file, so obtain an
+  uploadable copy via a temporary exclusion: `Add-MpPreference -ExclusionPath <folder>`
+  (admin), re-download into it, submit, then `Remove-MpPreference -ExclusionPath <folder>`.
+- Fields: detection name, definition version, "Incorrectly detected as malware",
+  company = your own name (ryl is a personal project, not an employer), notes cite the
+  VT link.
+- **"Accepted" ≠ propagated.** The per-submission details page can transiently error
+  ("Unable to access your submission details") — that is not a failure; verify via the
+  **submission history** list. After Microsoft clears it, propagation to the validator takes
+  ~1–3 days; then re-run.
+
+## Gotchas
+
+- Cross-repo refs: always `microsoft/winget-pkgs#NNN`; a bare `#NNN` links to ryl (see the
+  `filing-issues` skill).
+- Never put a local home path or machine specifics in a public PR comment — use `$env:TEMP`
+  or placeholders.
+- **Delegating to a headless/WSL agent:** launch it with `cwd` = the ryl repo (so it loads
+  this skill) and hand it the **full** step list (local Defender repro + VT for zips *and*
+  exes + tie back to the PR). A prompt scoped to "scan the zips on VT" misses the
+  reproduction and PR-triage half.
+
+## History
+
+- `microsoft/winget-pkgs#387703` (0.17.0, merged), `#390120` (0.19.1, `Wacatac.H!ml` —
+  needed a WDSI submission + propagation), `#391230` (0.20.0, `Sprisky.U!cl` — transient;
+  re-run requested, outcome pending as of writing).
+- Durable fix: code signing (#342). Microsoft label reference:
+  <https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md>.

--- a/.agents/skills/winget-defender-fp/SKILL.md
+++ b/.agents/skills/winget-defender-fp/SKILL.md
@@ -69,9 +69,10 @@ shadow-DOM heavy, so reading a verdict via DOM scraping needs shadow-root traver
 - **Both VT (Microsoft = Undetected) and local Defender clean** → the verdict has aged out
   / is environment-specific. **Do not file a WDSI submission** (Microsoft would likely
   reject it as "not detected"). Reply to `Needs-Author-Feedback` with the evidence —
-  the Defender **signature build** tested, VT links, "Microsoft: Undetected" — and
-  request a re-run (`@wingetbot run`, or ask the assigned moderator; the bot also
-  auto-retries ~every 18h).
+  the Defender **signature build** tested, VT links, "Microsoft: Undetected" — and ask
+  the assigned/active moderator to re-run validation (`@wingetbot run` is
+  moderator-triggered — an author/maintainer comment does not reliably start a run; the
+  bot also auto-retries ~every 18h).
   *(0.20.0 / `microsoft/winget-pkgs#391230`.)*
 - **Still reproducibly flagged** (local Defender and/or VT's Microsoft engine) → file a
   WDSI false-positive submission, then wait for propagation + re-run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,10 @@ skills also carry a `uv`-runnable helper script.
   the CI gate, the `coverage-missing.py` workflow, and coverage-friendly Rust idioms.
 - **`release`** (`.agents/skills/release/SKILL.md`) — the lockstep version bump,
   tag/push gate, and post-release SchemaStore + publishing flow.
+- **`winget-defender-fp`** (`.agents/skills/winget-defender-fp/SKILL.md`) — triage a
+  winget-pkgs PR blocked by a Microsoft Defender false positive
+  (`Validation-Defender-Error`): the transient-vs-reproducible decision, local
+  Defender + VirusTotal reproduction, and the WDSI false-positive submission.
 - **`codex-review`** (`.agents/skills/codex-review/SKILL.md`) — drive a Codex CI review
   on a PR end to end: trigger, monitor and classify the verdict, and handle the resulting
   comments (thumbs-up/down, resolve, reply).


### PR DESCRIPTION
## What

Adds a `winget-defender-fp` dev skill capturing the recurring Microsoft Defender
false-positive triage for ryl's winget-pkgs validation PRs, so the next occurrence is a
checklist rather than a re-investigation.

- New `.agents/skills/winget-defender-fp/SKILL.md`: recognise it (labels, error-code
  decodes, log noise to ignore), diagnose (the public Azure pipeline API + a local
  Defender repro + VirusTotal across all four artifacts), the
  transient-vs-reproducible decision tree, the WDSI false-positive submission mechanics,
  gotchas, and the per-release history.
- Lists it in the **Dev Skills** section of `AGENTS.md`.
- Cross-links it from the `release` skill's `publish-winget` step.

## Notes

- Docs-only (no Rust changes). `prek` is green (rumdl / lychee / typos / zizmor).
- The durable fix remains code signing (#342), which is deferred — this skill documents
  the interim triage loop.

Closes #366.

https://claude.ai/code/session_01Lgy15c2eJd5zhvFnN5ud3k
