### PR TITLE
feat: add ryl check lint subcommand (#369)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,13 @@ user skills; `.agents/skills/` is in-repo contributor tooling and is never publi
 
 ## CLI Behavior
 
+- `ryl check <inputs>` (the lint subcommand, #369) and bare `ryl <inputs>` lint
+  identically: `LintArgs` (`clap::Args`) is flattened both at the top level and under
+  `Commands::Check`, and the dispatch routes `check` through the subcommand's own
+  `ArgMatches` so the repeatable `--format`/`--output-file` `indices_of` recovery reads
+  the right scope. `check` is the recommended form; bare is being phased out
+  (warn-then-remove, later siblings of the #238 lint/format split). Meta-actions
+  (`--migrate-*`, `--print-*-config-schema`, `--generate-completions`) stay top-level.
 - Accepts one or more inputs: files, directories, or `-` to read from stdin.
 - Directories: recursively scanned, honoring git ignore and git exclude; does not
   follow symlinks. Each file's source kind is resolved from the `[files]` globs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "ryl"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryl"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -29,12 +29,17 @@ ryl enables no rules by default, so it needs a configuration that turns rules on
 for a project, drop a `.ryl.toml` at the root (see
 [Configuration](https://ryl-docs.pages.dev/getting-started/quickstart/)).
 
+`ryl check` is the lint subcommand (a `ryl format` formatter is coming) and the
+recommended form. Bare `ryl <paths>` still lints identically today but is being
+phased out (a future release will deprecate it, then a later one will remove it), so
+prefer `ryl check`.
+
 ```bash
 # Using uv (Python)
-uvx ryl -d 'extends: default' .
+uvx ryl check -d 'extends: default' .
 
 # Using npx (Node.js)
-npx @owenlamont/ryl -d 'extends: default' .
+npx @owenlamont/ryl check -d 'extends: default' .
 ```
 
 For `prek` / `pre-commit` integration, see

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -100,7 +100,7 @@ Syntax errors are always reported; no directive can suppress them.
 ## Interaction with `--fix`
 
 `--fix` honours directives too: a fixer never rewrites a line whose rule is
-disabled. Running `ryl --fix` over the block above leaves `a:   1` and `b:   2`
+disabled. Running `ryl check --fix` over the block above leaves `a:   1` and `b:   2`
 untouched while still fixing `c:   3`.
 
 ## Embedded Markdown

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -27,7 +27,7 @@ hover only explains ryl's own diagnostics.
 The fix-all action and formatting both apply ryl's whole-file safe fixes; ryl has no
 per-occurrence "fix just this one" action, because its fix engine operates per file (the
 per-rule fix-all is the finest grain available, and applies only to YAML, not Markdown). A
-document that does not parse is never modified (the same guarantee as `ryl --fix`).
+document that does not parse is never modified (the same guarantee as `ryl check --fix`).
 
 ## Running it
 
@@ -56,8 +56,8 @@ documents:
 | Setting | Effect |
 | --- | --- |
 | `enable` (bool, default `true`) | `false` turns ryl off: no diagnostics, no actions |
-| `configPath` (string) | Use this config file instead of discovering one (like `ryl -c`) |
-| `configData` (string) | Inline YAML config text, highest precedence (like `ryl -d`) |
+| `configPath` (string) | Use this config file instead of discovering one (like `ryl check -c`) |
+| `configData` (string) | Inline YAML config text, highest precedence (like `ryl check -d`) |
 
 These are the same precedence as the CLI: `configData` > `configPath` > the discovered
 project/user config.

--- a/docs/getting-started/migrating-from-yamllint.md
+++ b/docs/getting-started/migrating-from-yamllint.md
@@ -11,6 +11,13 @@ If you are coming from yamllint you have two paths:
   [`[fix]` table](#optional-configure-auto-fixes) controlling auto-fix
   selection.
 
+On the command line the mapping is mechanical: replace `yamllint` with `ryl
+check`, keeping every flag and path the same. `ryl check` accepts the same lint
+flags as yamllint (`-c`/`-d`/`-f`/`-s`/`--no-warnings`/`--list-files`/`-`), so
+`yamllint -d 'extends: default' .` becomes `ryl check -d 'extends: default' .`.
+Bare `ryl <paths>` also lints today but is being phased out in favour of `ryl
+check`.
+
 ## Automatic migration
 
 ryl ships with a built-in converter. From the root of your project:
@@ -88,7 +95,7 @@ since its rule config cannot be relocated safely. Project migration keeps a
 relative `ignore-from-file` as-is, because the `.ryl.toml` stays in the same
 directory.
 
-After migration, run `ryl .` to confirm diagnostics match what yamllint
+After migration, run `ryl check .` to confirm diagnostics match what yamllint
 produced.
 
 ## What is preserved
@@ -197,9 +204,9 @@ option flags welded colons so you can forbid the construct outright.
 ### De-duplicated inputs
 
 When a single run names the same file more than once &mdash; listed twice, or reached
-by both a directory argument and an explicit path (`ryl . file.yaml`) &mdash; ryl
+by both a directory argument and an explicit path (`ryl check . file.yaml`) &mdash; ryl
 processes it **once**. yamllint handles each occurrence, so it would report that
-file's diagnostics (or, under `ryl --diff`, emit its patch) twice.
+file's diagnostics (or, under `ryl check --diff`, emit its patch) twice.
 
 **Why ryl differs:** duplicate output is never useful, and it is actively harmful for
 `--diff`, whose output is meant to be applied as a patch &mdash; a repeated patch
@@ -230,9 +237,9 @@ faithfully anyway (and whose `new-lines` `type` has no `mac` value). ryl follows
 specification and its [reference parser](https://play.yaml.com), which rank above
 yamllint as the authority.
 
-Two editing-path caveats on such files. First, `ryl --diff` skips a file whose
+Two editing-path caveats on such files. First, `ryl check --diff` skips a file whose
 content *ends* in a bare `\r` (a unified diff is `\n`-terminated by format, so that
-one case has no applicable patch &mdash; use `ryl --fix`, which rewrites bytes
+one case has no applicable patch &mdash; use `ryl check --fix`, which rewrites bytes
 directly); a bare `\r` elsewhere is diffed as line content and applies via
 `git apply`. Second, **Markdown embedding** requires a Markdown file with no bare `\r` anywhere:
 the fenced-block and front-matter parser
@@ -441,7 +448,7 @@ outright, so failing loudly on the always-wrong `.toml` case is well-precedented
 
 ## Optional: configure auto-fixes
 
-TOML configurations can declare which rules are eligible for `ryl --fix`:
+TOML configurations can declare which rules are eligible for `ryl check --fix`:
 
 ```toml
 [fix]

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,15 +1,23 @@
 # Quick start
 
+## The `ryl check` subcommand
+
+ryl's CLI is moving to subcommands: `ryl check` is the lint pass (a dedicated
+`ryl format` formatter is coming). `ryl check <paths>` is the recommended form and
+is used throughout these docs. Bare `ryl <paths>` still lints identically today, but
+it is being phased out — a future release will warn on it and a later one will remove
+it, so adopt `ryl check` now.
+
 ## Run a lint
 
 Point ryl at a file or directory:
 
 ```bash
 # Lint a single file
-ryl path/to/file.yaml
+ryl check path/to/file.yaml
 
 # Lint a project (recursively scans .yml/.yaml, honouring .gitignore)
-ryl .
+ryl check .
 ```
 
 ryl does not enable any rules by default, so these commands report `no
@@ -17,7 +25,7 @@ configuration found` (exit `2`) until a configuration enables at least one rule.
 To lint with yamllint's standard rule set straight away, pass it inline:
 
 ```bash
-ryl -d 'extends: default' .
+ryl check -d 'extends: default' .
 ```
 
 or drop a config in your project (see [Configure for your
@@ -29,11 +37,11 @@ Pass `-` as the input to read YAML from standard input &mdash; useful for
 editor integrations where the buffer is not yet on disk:
 
 ```bash
-cat file.yaml | ryl -
+cat file.yaml | ryl check -
 
 # Provide a filename so diagnostics, config discovery, and
 # yaml-files / per-file-ignores match the right path:
-cat file.yaml | ryl - --stdin-filename path/to/file.yaml
+cat file.yaml | ryl check - --stdin-filename path/to/file.yaml
 ```
 
 Without `--stdin-filename`, diagnostics are labelled `<stdin>`, config
@@ -70,7 +78,7 @@ is found and silently accepts a rule-less config. Give ryl a config containing
 ryl can automatically fix a subset of rules:
 
 ```bash
-ryl --fix .
+ryl check --fix .
 ```
 
 See the [Rules reference](../rules.md) for which rules are fixable.
@@ -88,7 +96,7 @@ prints a unified diff (3 lines of context) of what would change to
 stdout &mdash; modelled on `ruff check --diff`:
 
 ```bash
-ryl --diff .
+ryl check --diff .
 ```
 
 This is handy for CI previews, PR review, and parallel-safe runners such

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ icon: lucide/braces
     ---
 
     Apply safe automatic fixes for spacing, line endings, quoting, and more
-    with `ryl --fix`.
+    with `ryl check --fix`.
 
     [:octicons-arrow-right-24: Configuration](config-presets.md)
 
@@ -64,8 +64,8 @@ pixi global install ryl
 winget install owenlamont.ryl
 
 # Lint a file or directory
-ryl path/to/file.yaml
-ryl .
+ryl check path/to/file.yaml
+ryl check .
 ```
 
 ## YAML version compatibility

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -143,16 +143,24 @@ Source: https://ryl-docs.pages.dev/getting-started/quickstart/
 
 # Quick start
 
+## The `ryl check` subcommand
+
+ryl's CLI is moving to subcommands: `ryl check` is the lint pass (a dedicated
+`ryl format` formatter is coming). `ryl check <paths>` is the recommended form and
+is used throughout these docs. Bare `ryl <paths>` still lints identically today, but
+it is being phased out — a future release will warn on it and a later one will remove
+it, so adopt `ryl check` now.
+
 ## Run a lint
 
 Point ryl at a file or directory:
 
 ```bash
 # Lint a single file
-ryl path/to/file.yaml
+ryl check path/to/file.yaml
 
 # Lint a project (recursively scans .yml/.yaml, honouring .gitignore)
-ryl .
+ryl check .
 ```
 
 ryl does not enable any rules by default, so these commands report `no
@@ -160,7 +168,7 @@ configuration found` (exit `2`) until a configuration enables at least one rule.
 To lint with yamllint's standard rule set straight away, pass it inline:
 
 ```bash
-ryl -d 'extends: default' .
+ryl check -d 'extends: default' .
 ```
 
 or drop a config in your project (see [Configure for your
@@ -172,11 +180,11 @@ Pass `-` as the input to read YAML from standard input &mdash; useful for
 editor integrations where the buffer is not yet on disk:
 
 ```bash
-cat file.yaml | ryl -
+cat file.yaml | ryl check -
 
 # Provide a filename so diagnostics, config discovery, and
 # yaml-files / per-file-ignores match the right path:
-cat file.yaml | ryl - --stdin-filename path/to/file.yaml
+cat file.yaml | ryl check - --stdin-filename path/to/file.yaml
 ```
 
 Without `--stdin-filename`, diagnostics are labelled `<stdin>`, config
@@ -213,7 +221,7 @@ is found and silently accepts a rule-less config. Give ryl a config containing
 ryl can automatically fix a subset of rules:
 
 ```bash
-ryl --fix .
+ryl check --fix .
 ```
 
 See the [Rules reference](https://ryl-docs.pages.dev/rules/) for which rules are fixable.
@@ -231,7 +239,7 @@ prints a unified diff (3 lines of context) of what would change to
 stdout &mdash; modelled on `ruff check --diff`:
 
 ```bash
-ryl --diff .
+ryl check --diff .
 ```
 
 This is handy for CI previews, PR review, and parallel-safe runners such
@@ -394,7 +402,7 @@ it. The skill is the canonical, tightened agent reference; this page only links 
 If a repo has an `AGENTS.md` (or `CLAUDE.md`), a one-line nudge helps agents reach for
 ryl and avoid its main gotcha:
 
-> Lint YAML with `ryl`. It has no default-on rules, so make sure a config (`ryl.toml`
+> Lint YAML with `ryl check`. It has no default-on rules, so make sure a config (`ryl.toml`
 > or a yamllint-style `.yamllint`) enables rules first, or it exits `2`.
 
 ## Feeding the docs to an LLM
@@ -428,6 +436,13 @@ If you are coming from yamllint you have two paths:
   features that have no upstream equivalent &mdash; for example the
   [`[fix]` table](#optional-configure-auto-fixes) controlling auto-fix
   selection.
+
+On the command line the mapping is mechanical: replace `yamllint` with `ryl
+check`, keeping every flag and path the same. `ryl check` accepts the same lint
+flags as yamllint (`-c`/`-d`/`-f`/`-s`/`--no-warnings`/`--list-files`/`-`), so
+`yamllint -d 'extends: default' .` becomes `ryl check -d 'extends: default' .`.
+Bare `ryl <paths>` also lints today but is being phased out in favour of `ryl
+check`.
 
 ## Automatic migration
 
@@ -506,7 +521,7 @@ since its rule config cannot be relocated safely. Project migration keeps a
 relative `ignore-from-file` as-is, because the `.ryl.toml` stays in the same
 directory.
 
-After migration, run `ryl .` to confirm diagnostics match what yamllint
+After migration, run `ryl check .` to confirm diagnostics match what yamllint
 produced.
 
 ## What is preserved
@@ -615,9 +630,9 @@ option flags welded colons so you can forbid the construct outright.
 ### De-duplicated inputs
 
 When a single run names the same file more than once &mdash; listed twice, or reached
-by both a directory argument and an explicit path (`ryl . file.yaml`) &mdash; ryl
+by both a directory argument and an explicit path (`ryl check . file.yaml`) &mdash; ryl
 processes it **once**. yamllint handles each occurrence, so it would report that
-file's diagnostics (or, under `ryl --diff`, emit its patch) twice.
+file's diagnostics (or, under `ryl check --diff`, emit its patch) twice.
 
 **Why ryl differs:** duplicate output is never useful, and it is actively harmful for
 `--diff`, whose output is meant to be applied as a patch &mdash; a repeated patch
@@ -648,9 +663,9 @@ faithfully anyway (and whose `new-lines` `type` has no `mac` value). ryl follows
 specification and its [reference parser](https://play.yaml.com), which rank above
 yamllint as the authority.
 
-Two editing-path caveats on such files. First, `ryl --diff` skips a file whose
+Two editing-path caveats on such files. First, `ryl check --diff` skips a file whose
 content *ends* in a bare `\r` (a unified diff is `\n`-terminated by format, so that
-one case has no applicable patch &mdash; use `ryl --fix`, which rewrites bytes
+one case has no applicable patch &mdash; use `ryl check --fix`, which rewrites bytes
 directly); a bare `\r` elsewhere is diffed as line content and applies via
 `git apply`. Second, **Markdown embedding** requires a Markdown file with no bare `\r` anywhere:
 the fenced-block and front-matter parser
@@ -859,7 +874,7 @@ outright, so failing loudly on the always-wrong `.toml` case is well-precedented
 
 ## Optional: configure auto-fixes
 
-TOML configurations can declare which rules are eligible for `ryl --fix`:
+TOML configurations can declare which rules are eligible for `ryl check --fix`:
 
 ```toml
 [fix]
@@ -991,7 +1006,7 @@ To switch rules off for part of a file with `# ryl disable` /
 The `--fix` flag applies safe fixes for rules marked with :wrench: above:
 
 ```bash
-ryl --fix .
+ryl check --fix .
 ```
 
 Control which rules apply fixes with a `[fix]` table:
@@ -1254,7 +1269,7 @@ Syntax errors are always reported; no directive can suppress them.
 ## Interaction with `--fix`
 
 `--fix` honours directives too: a fixer never rewrites a line whose rule is
-disabled. Running `ryl --fix` over the block above leaves `a:   1` and `b:   2`
+disabled. Running `ryl check --fix` over the block above leaves `a:   1` and `b:   2`
 untouched while still fixing `c:   3`.
 
 ## Embedded Markdown
@@ -1430,9 +1445,9 @@ Or, for a one-off run without editing config, pass `--markdown`, which enables t
 `markdown` kind with those default globs:
 
 ```sh
-ryl --markdown docs/        # scan a tree for *.md/*.markdown/*.qmd/*.Rmd/*.mdx
-ryl --markdown report.qmd   # a single Quarto document
-cat SKILL.md | ryl --markdown -   # from stdin (e.g. an editor / pre-commit)
+ryl check --markdown docs/        # scan a tree for *.md/*.markdown/*.qmd/*.Rmd/*.mdx
+ryl check --markdown report.qmd   # a single Quarto document
+cat SKILL.md | ryl check --markdown -   # from stdin (e.g. an editor / pre-commit)
 ```
 
 This lints the YAML front matter and fenced `yaml`/`yml` blocks in Quarto (`.qmd`),
@@ -1443,7 +1458,7 @@ extracted.
 
 In practice Quarto and RMarkdown keep their YAML almost entirely in **front matter**
 (their code chunks are ` ```{r} `/` ```{python} `, not ` ```yaml `), so linting them
-mostly exercises the front-matter path. For example, `ryl --markdown report.qmd`
+mostly exercises the front-matter path. For example, `ryl check --markdown report.qmd`
 checks the leading block of:
 
 ````qmd
@@ -1459,7 +1474,7 @@ format:
 
 and reports the extra space after `toc:` at its real line and column inside the
 `.qmd` file. The same applies to **agent skill files**: a `SKILL.md` is YAML front
-matter (`name`, `description`) plus prose, so `ryl --markdown SKILL.md` (or a
+matter (`name`, `description`) plus prose, so `ryl check --markdown SKILL.md` (or a
 `markdown = ["**/SKILL.md"]` glob) lints that block.
 
 ## How rules apply
@@ -1500,7 +1515,7 @@ build:
 ```
 ````
 
-With `colons` enabled, `ryl docs.md` reports the extra space after `title:` on
+With `colons` enabled, `ryl check docs.md` reports the extra space after `title:` on
 line 2 and any spacing problems inside the fenced block on its actual line —
 columns include the block's indentation.
 
@@ -1537,7 +1552,7 @@ also be turned on for a single run from the command line:
   globs for an overlapping file (so the flag never aborts a run whose `yaml` globs
   happen to match a Markdown extension). When linting stdin, `--markdown` forces the
   input to be treated as Markdown regardless of `--stdin-filename`.
-- Reading from stdin otherwise honours the source kind: `ryl - --stdin-filename
+- Reading from stdin otherwise honours the source kind: `ryl check - --stdin-filename
   doc.md` lints the piped bytes as Markdown when `doc.md` matches the `markdown`
   globs (front matter and fenced blocks are extracted exactly as for a file on
   disk). Without `--stdin-filename` and without `--markdown`, stdin is linted as
@@ -1549,7 +1564,7 @@ also be turned on for a single run from the command line:
 `ryl` is published as a pre-commit hook at
 [ryl-pre-commit](https://github.com/owenlamont/ryl-pre-commit). The default `ryl`
 hook only sees YAML files. To also lint YAML embedded in Markdown, add the
-dedicated `ryl-markdown` hook — it runs `ryl --markdown`, so it needs **no**
+dedicated `ryl-markdown` hook — it runs `ryl check --markdown`, so it needs **no**
 `[files]` config:
 
 ```yaml
@@ -1609,7 +1624,7 @@ top.
 
 When two tools both rewrite files they can disagree. A setting in one can undo a fix from
 the other, and running them in a loop (for example in a pre-commit hook) makes them fight:
-the formatter changes a byte, `ryl --fix` changes it back, the formatter changes it again.
+the formatter changes a byte, `ryl check --fix` changes it back, the formatter changes it again.
 This page lists the ryl settings that matter for each formatter and gives a verified,
 conflict-free starting config for each.
 
@@ -1631,8 +1646,8 @@ There are exactly two ways the two tools can disagree:
   loop, but ryl warns on every run until you align the setting or turn the rule off.
 
 Everything below is about steering clear of both. The configs were checked by running
-`formatter` then `ryl --fix` repeatedly until the file settled, and confirming the
-settled file passes `ryl` with no findings. They were verified against the latest release
+`formatter` then `ryl check --fix` repeatedly until the file settled, and confirming the
+settled file passes `ryl check` with no findings. They were verified against the latest release
 of each formatter as of 2026-06-20: **yamlfmt 0.21.0**, **Prettier 3.8.4**, and
 **yamlfix 1.19.1**.
 
@@ -1651,10 +1666,10 @@ actually cause a loop or a standing complaint.
 
 !!! note "Check mode vs fix mode"
 
-    A few alignments rely on `ryl --fix` applying a one-time fix that the formatter then
+    A few alignments rely on `ryl check --fix` applying a one-time fix that the formatter then
     keeps (for example ryl adding `---` where the formatter preserves it). If you run ryl
-    in lint-only mode (`ryl` with no `--fix`, common in CI) rather than fix mode, prefer
-    the settings marked as needing no fix below, or run `ryl --fix` once before the check.
+    in lint-only mode (`ryl check` with no `--fix`, common in CI) rather than fix mode, prefer
+    the settings marked as needing no fix below, or run `ryl check --fix` once before the check.
 
 ## google/yamlfmt
 
@@ -1767,7 +1782,7 @@ Notes:
 - `document-start` is left off here. Prettier never adds or removes `---`, and ryl's
   document-start fix can add markers but not strip them, so `present = false` would
   permanently flag any file that already has a `---`. To enforce consistent markers
-  instead, set `present = true` and run `ryl --fix` (ryl adds `---`, Prettier keeps it).
+  instead, set `present = true` and run `ryl check --fix` (ryl adds `---`, Prettier keeps it).
 - The flow-padding split is the key alignment: `braces` must allow one inner space, while
   `brackets` must allow none. Prettier pads a non-empty mapping (`{ a: 1 }`) but keeps an
   empty one tight (`{}`), so the recipe also sets `min-spaces-inside-empty = 0` /
@@ -1787,7 +1802,7 @@ inline comments (the same as ryl's default), does not pad flow collections, inde
 two spaces, and canonicalizes block-style truthy values (`yes` becomes `true`), so the
 `truthy` rule stays clean for ordinary mappings and sequences (with one caveat noted
 below). It removes the `...` document-end marker. On Windows it writes CRLF only on files
-it actually rewrites and leaves unchanged files alone, so with `ryl --fix` it settles back
+it actually rewrites and leaves unchanged files alone, so with `ryl check --fix` it settles back
 to LF rather than fighting it (see
 [Line endings across operating systems](#line-endings-across-operating-systems)). Its
 settings are documented in the
@@ -1860,7 +1875,7 @@ formatter (the recipes above already do):
 | `new-lines` `type` | `unix` † | `unix` | `unix` † |
 
 † On Windows, yamlfmt forces CRLF on every write (pin its `line_ending: lf`), while
-yamlfix emits CRLF only on files it rewrites and settles back to LF under `ryl --fix`; see
+yamlfix emits CRLF only on files it rewrites and settles back to LF under `ryl check --fix`; see
 [Line endings across operating systems](#line-endings-across-operating-systems).
 
 Two of these point in opposite directions across formatters, which is why there is no
@@ -1879,9 +1894,9 @@ the three formatters behave differently:
   [`line_ending: lf`](https://github.com/google/yamlfmt/blob/main/docs/config-file.md#basic-formatter)
   in `.yamlfmt` and the recipe's `type = "unix"` holds on every OS.
 - **yamlfix** writes CRLF only on files it actually rewrites (it reads line endings
-  agnostically and skips unchanged files), so once `ryl --fix` normalizes a file to LF
+  agnostically and skips unchanged files), so once `ryl check --fix` normalizes a file to LF
   yamlfix leaves it alone. The two converge to LF on Windows with no loop, so
-  `type = "unix"` needs no change; just keep `ryl --fix` running after yamlfix. As
+  `type = "unix"` needs no change; just keep `ryl check --fix` running after yamlfix. As
   belt-and-braces you can also pin the committed form with a `.gitattributes` entry such
   as `*.yaml text eol=lf`.
 - **Prettier** writes LF on every OS (its `endOfLine` defaults to `lf`), so no change is
@@ -1987,7 +2002,7 @@ file.
 
 ### Configuring outputs in TOML
 
-The same outputs can be set once in a project's TOML config under `[output]`, so `ryl .`
+The same outputs can be set once in a project's TOML config under `[output]`, so `ryl check .`
 in CI produces the artifacts without repeating the flags. Each format is a sub-table; an
 absent `path` uses that format's default stream, `path = "-"` is stdout, and any other
 value is a file:
@@ -2002,7 +2017,7 @@ path = "gl-code-quality-report.json"
 
 `[output]` is ryl-only and TOML-only (it is rejected in a YAML config). It is read once
 from the configuration governing the run: the `-c`/`-d` config, or the project config
-discovered for the inputs (so a project's `.ryl.toml` applies to `ryl .`). A CLI
+discovered for the inputs (so a project's `.ryl.toml` applies to `ryl check .`). A CLI
 `--format` overrides the entire `[output]` table, so the command line always wins over the
 config. The same unambiguous-output rules above apply to a config that declares several
 targets.
@@ -2115,7 +2130,7 @@ hover only explains ryl's own diagnostics.
 The fix-all action and formatting both apply ryl's whole-file safe fixes; ryl has no
 per-occurrence "fix just this one" action, because its fix engine operates per file (the
 per-rule fix-all is the finest grain available, and applies only to YAML, not Markdown). A
-document that does not parse is never modified (the same guarantee as `ryl --fix`).
+document that does not parse is never modified (the same guarantee as `ryl check --fix`).
 
 ## Running it
 
@@ -2144,8 +2159,8 @@ documents:
 | Setting | Effect |
 | --- | --- |
 | `enable` (bool, default `true`) | `false` turns ryl off: no diagnostics, no actions |
-| `configPath` (string) | Use this config file instead of discovering one (like `ryl -c`) |
-| `configData` (string) | Inline YAML config text, highest precedence (like `ryl -d`) |
+| `configPath` (string) | Use this config file instead of discovering one (like `ryl check -c`) |
+| `configData` (string) | Inline YAML config text, highest precedence (like `ryl check -d`) |
 
 These are the same precedence as the CLI: `configData` > `configPath` > the discovered
 project/user config.
@@ -2654,7 +2669,7 @@ object: {key1: 4, key2: 8}
 
 ## Automatic fixing
 
-`ryl --fix` adjusts whitespace inside braces to satisfy the configured
+`ryl check --fix` adjusts whitespace inside braces to satisfy the configured
 `min-spaces-inside` / `max-spaces-inside` bounds. The `forbid` constraint
 is not auto-fixed because converting flow to block style requires
 re-flowing the surrounding document.
@@ -2726,7 +2741,7 @@ object: [1, 2, abc]
 
 ## Automatic fixing
 
-`ryl --fix` adjusts whitespace inside brackets to satisfy the configured
+`ryl check --fix` adjusts whitespace inside brackets to satisfy the configured
 bounds. The `forbid` constraint is not auto-fixed because converting flow
 sequences to block style requires re-flowing the document.
 
@@ -2871,7 +2886,7 @@ list: [10, 20, 30, {x: 1, y: 2}]
 list: [10, 20 ,30,   {x: 1,   y: 2}]
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 list: [10, 20, 30, {x: 1, y: 2}]
@@ -2879,7 +2894,7 @@ list: [10, 20, 30, {x: 1, y: 2}]
 
 ## Automatic fixing
 
-`ryl --fix` normalises whitespace around commas to satisfy the configured
+`ryl check --fix` normalises whitespace around commas to satisfy the configured
 limits. Disable with:
 
 ```toml
@@ -2961,7 +2976,7 @@ options:
     - more stuff
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 parent:
@@ -2971,7 +2986,7 @@ parent:
 
 ## Automatic fixing
 
-`ryl --fix` reindents standalone comment lines to match the line that
+`ryl check --fix` reindents standalone comment lines to match the line that
 follows them. Disable with:
 
 ```toml
@@ -3039,7 +3054,7 @@ key: value  # inline comment with two spaces of padding
 key: value # only one space before inline comment
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 # missing space after the hash
@@ -3048,7 +3063,7 @@ key: value  # only one space before inline comment
 
 ## Automatic fixing
 
-`ryl --fix` inserts the missing space after `#` and pads inline comments
+`ryl check --fix` inserts the missing space after `#` and pads inline comments
 to the configured `min-spaces-from-content`. Disable with:
 
 ```toml
@@ -3116,7 +3131,7 @@ this: is the only document
 this: is the only document
 ```
 
-### :wrench: After `ryl --fix` (with `present: true`)
+### :wrench: After `ryl check --fix` (with `present: true`)
 
 ```yaml
 ---
@@ -3126,7 +3141,7 @@ this: is the only document
 
 ## Automatic fixing
 
-`ryl --fix` appends a `...` end marker when `present: true` and the
+`ryl check --fix` appends a `...` end marker when `present: true` and the
 document does not already have one. The fix is **partial** by design:
 it only runs when the buffer is a single document. A buffer is treated
 as single-document when, after skipping leading blank lines, comments,
@@ -3207,7 +3222,7 @@ title: example
 title: example
 ```
 
-### :wrench: After `ryl --fix` (with `present: true`)
+### :wrench: After `ryl check --fix` (with `present: true`)
 
 ```yaml
 ---
@@ -3216,7 +3231,7 @@ title: example
 
 ## Automatic fixing
 
-`ryl --fix` prepends a `---` start marker when `present: true` and the
+`ryl check --fix` prepends a `---` start marker when `present: true` and the
 document does not already have one. The fix is **partial** by design:
 it only runs when
 
@@ -3305,7 +3320,7 @@ a: 1
 b: 2
 ```
 
-### :wrench: After `ryl --fix` (defaults)
+### :wrench: After `ryl check --fix` (defaults)
 
 ```yaml
 ---
@@ -3317,7 +3332,7 @@ b: 2
 
 ## Automatic fixing
 
-`ryl --fix` trims runs of empty lines down to `max` (or `max-start`
+`ryl check --fix` trims runs of empty lines down to `max` (or `max-start`
 and `max-end` for the leading and trailing run). The fix is **partial**
 by design: blank lines that fall inside any multi-line scalar — literal
 or folded block scalars (`|`/`>`), multi-line single- or double-quoted
@@ -4090,13 +4105,13 @@ key: value
 A file whose final byte is not a newline character. (Trailing *blank* lines
 are not this rule's concern; see [`empty-lines`](https://ryl-docs.pages.dev/rules/empty-lines/).)
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ryl appends a single newline when the file does not already end with one.
 
 ## Automatic fixing
 
-`ryl --fix` appends a trailing newline when one is missing. Disable with:
+`ryl check --fix` appends a trailing newline when one is missing. Disable with:
 
 ```toml
 [fix]
@@ -4155,9 +4170,9 @@ A file whose every line ends with `\n`.
 
 A file whose lines end with `\r\n`.
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
-`ryl --fix` rewrites the file so every line ends with the configured
+`ryl check --fix` rewrites the file so every line ends with the configured
 character sequence.
 
 ## Bare carriage returns
@@ -4165,7 +4180,7 @@ character sequence.
 A bare `\r` (a carriage return not part of `\r\n`) is a YAML 1.2 line break, so
 ryl treats it as a line ending here too. It is never one of the configurable
 styles (`unix`/`dos`/`platform`), so when the file's first line break is a bare
-`\r` the rule reports it as wrong and `ryl --fix` rewrites it to the configured
+`\r` the rule reports it as wrong and `ryl check --fix` rewrites it to the configured
 ending. This is a deliberate divergence from yamllint, whose line layer cannot
 see a bare `\r` and whose `type` has no `mac` value; on supported LF/CRLF files
 the behaviour is identical. See
@@ -4173,7 +4188,7 @@ the behaviour is identical. See
 
 ## Automatic fixing
 
-`ryl --fix` rewrites all line endings to match `type`. Disable with:
+`ryl check --fix` rewrites all line endings to match `type`. Disable with:
 
 ```toml
 [fix]
@@ -4303,7 +4318,7 @@ name: "plain"   # redundantly quoted: a plain string needs no quotes
 version: '1.0'  # needs quoting, but single-quoted where double is required
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 name: plain
@@ -4336,7 +4351,7 @@ check-keys = false
 
 ## Automatic fixing
 
-`ryl --fix` rewrites string scalars to use the configured `quote-type` and
+`ryl check --fix` rewrites string scalars to use the configured `quote-type` and
 adds or removes quotes to satisfy `required`. The fix is conservative: it
 only changes scalars where the corrected form parses to the same value as
 the original.
@@ -4532,7 +4547,7 @@ key: value···
 
 (Where `···` represents trailing whitespace characters.)
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 ---
@@ -4541,7 +4556,7 @@ key: value
 
 ## Automatic fixing
 
-`ryl --fix` strips trailing spaces and tabs from each line. The fix is
+`ryl check --fix` strips trailing spaces and tabs from each line. The fix is
 **partial** by design: lines inside literal/folded block scalars
 (`|`/`>`) and inside multi-line double-quoted scalars are left untouched,
 because in those contexts trailing whitespace can be part of the parsed

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@
 
 - [Installation](https://ryl-docs.pages.dev/getting-started/installation/): ryl ships as a single binary. Pick the install method that matches your toolchain.
 - [Shell completions](https://ryl-docs.pages.dev/getting-started/shell-completions/): ryl can generate tab-completion scripts for its flags. `ryl --generate-completions <SHELL>` prints the script for one shell to stdout, where `<SHELL>` is one of `bash`, `zsh`, `fish`, `powershell`, or `elvish`:
-- [Quick Start](https://ryl-docs.pages.dev/getting-started/quickstart/): Point ryl at a file or directory:
+- [Quick Start](https://ryl-docs.pages.dev/getting-started/quickstart/): ryl's CLI is moving to subcommands: `ryl check` is the lint pass (a dedicated `ryl format` formatter is coming). `ryl check <paths>` is the recommended form and is used throughout these docs. Bare `ryl <paths>` still lints identically today, but it is being phased out — a future release will warn on it and a later one will remove it, so adopt `ryl check` now.
 - [Using ryl with AI agents](https://ryl-docs.pages.dev/using-ryl-with-ai-agents/): ryl is built for programmatic use (stable exit codes, machine-readable output, `--fix`/`--diff`, stdin), so AI coding agents can drive it directly. This page points to the agent-facing resources; the rest of these docs (start with Quick start) cover the CLI itself.
 - [Migrating from yamllint](https://ryl-docs.pages.dev/getting-started/migrating-from-yamllint/): ryl is designed as a drop-in replacement for yamllint's existing rule set. If you are coming from yamllint you have two paths:
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -71,9 +71,9 @@ Or, for a one-off run without editing config, pass `--markdown`, which enables t
 `markdown` kind with those default globs:
 
 ```sh
-ryl --markdown docs/        # scan a tree for *.md/*.markdown/*.qmd/*.Rmd/*.mdx
-ryl --markdown report.qmd   # a single Quarto document
-cat SKILL.md | ryl --markdown -   # from stdin (e.g. an editor / pre-commit)
+ryl check --markdown docs/        # scan a tree for *.md/*.markdown/*.qmd/*.Rmd/*.mdx
+ryl check --markdown report.qmd   # a single Quarto document
+cat SKILL.md | ryl check --markdown -   # from stdin (e.g. an editor / pre-commit)
 ```
 
 This lints the YAML front matter and fenced `yaml`/`yml` blocks in Quarto (`.qmd`),
@@ -84,7 +84,7 @@ extracted.
 
 In practice Quarto and RMarkdown keep their YAML almost entirely in **front matter**
 (their code chunks are ` ```{r} `/` ```{python} `, not ` ```yaml `), so linting them
-mostly exercises the front-matter path. For example, `ryl --markdown report.qmd`
+mostly exercises the front-matter path. For example, `ryl check --markdown report.qmd`
 checks the leading block of:
 
 ````qmd
@@ -100,7 +100,7 @@ format:
 
 and reports the extra space after `toc:` at its real line and column inside the
 `.qmd` file. The same applies to **agent skill files**: a `SKILL.md` is YAML front
-matter (`name`, `description`) plus prose, so `ryl --markdown SKILL.md` (or a
+matter (`name`, `description`) plus prose, so `ryl check --markdown SKILL.md` (or a
 `markdown = ["**/SKILL.md"]` glob) lints that block.
 
 ## How rules apply
@@ -141,7 +141,7 @@ build:
 ```
 ````
 
-With `colons` enabled, `ryl docs.md` reports the extra space after `title:` on
+With `colons` enabled, `ryl check docs.md` reports the extra space after `title:` on
 line 2 and any spacing problems inside the fenced block on its actual line —
 columns include the block's indentation.
 
@@ -178,7 +178,7 @@ also be turned on for a single run from the command line:
   globs for an overlapping file (so the flag never aborts a run whose `yaml` globs
   happen to match a Markdown extension). When linting stdin, `--markdown` forces the
   input to be treated as Markdown regardless of `--stdin-filename`.
-- Reading from stdin otherwise honours the source kind: `ryl - --stdin-filename
+- Reading from stdin otherwise honours the source kind: `ryl check - --stdin-filename
   doc.md` lints the piped bytes as Markdown when `doc.md` matches the `markdown`
   globs (front matter and fenced blocks are extracted exactly as for a file on
   disk). Without `--stdin-filename` and without `--markdown`, stdin is linted as
@@ -190,7 +190,7 @@ also be turned on for a single run from the command line:
 `ryl` is published as a pre-commit hook at
 [ryl-pre-commit](https://github.com/owenlamont/ryl-pre-commit). The default `ryl`
 hook only sees YAML files. To also lint YAML embedded in Markdown, add the
-dedicated `ryl-markdown` hook — it runs `ryl --markdown`, so it needs **no**
+dedicated `ryl-markdown` hook — it runs `ryl check --markdown`, so it needs **no**
 `[files]` config:
 
 ```yaml

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -65,7 +65,7 @@ file.
 
 ### Configuring outputs in TOML
 
-The same outputs can be set once in a project's TOML config under `[output]`, so `ryl .`
+The same outputs can be set once in a project's TOML config under `[output]`, so `ryl check .`
 in CI produces the artifacts without repeating the flags. Each format is a sub-table; an
 absent `path` uses that format's default stream, `path = "-"` is stdout, and any other
 value is a file:
@@ -80,7 +80,7 @@ path = "gl-code-quality-report.json"
 
 `[output]` is ryl-only and TOML-only (it is rejected in a YAML config). It is read once
 from the configuration governing the run: the `-c`/`-d` config, or the project config
-discovered for the inputs (so a project's `.ryl.toml` applies to `ryl .`). A CLI
+discovered for the inputs (so a project's `.ryl.toml` applies to `ryl check .`). A CLI
 `--format` overrides the entire `[output]` table, so the command line always wins over the
 config. The same unambiguous-output rules above apply to a config that declares several
 targets.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -108,7 +108,7 @@ To switch rules off for part of a file with `# ryl disable` /
 The `--fix` flag applies safe fixes for rules marked with :wrench: above:
 
 ```bash
-ryl --fix .
+ryl check --fix .
 ```
 
 Control which rules apply fixes with a `[fix]` table:

--- a/docs/rules/braces.md
+++ b/docs/rules/braces.md
@@ -55,7 +55,7 @@ object: {key1: 4, key2: 8}
 
 ## Automatic fixing
 
-`ryl --fix` adjusts whitespace inside braces to satisfy the configured
+`ryl check --fix` adjusts whitespace inside braces to satisfy the configured
 `min-spaces-inside` / `max-spaces-inside` bounds. The `forbid` constraint
 is not auto-fixed because converting flow to block style requires
 re-flowing the surrounding document.

--- a/docs/rules/brackets.md
+++ b/docs/rules/brackets.md
@@ -54,7 +54,7 @@ object: [1, 2, abc]
 
 ## Automatic fixing
 
-`ryl --fix` adjusts whitespace inside brackets to satisfy the configured
+`ryl check --fix` adjusts whitespace inside brackets to satisfy the configured
 bounds. The `forbid` constraint is not auto-fixed because converting flow
 sequences to block style requires re-flowing the document.
 

--- a/docs/rules/commas.md
+++ b/docs/rules/commas.md
@@ -41,7 +41,7 @@ list: [10, 20, 30, {x: 1, y: 2}]
 list: [10, 20 ,30,   {x: 1,   y: 2}]
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 list: [10, 20, 30, {x: 1, y: 2}]
@@ -49,7 +49,7 @@ list: [10, 20, 30, {x: 1, y: 2}]
 
 ## Automatic fixing
 
-`ryl --fix` normalises whitespace around commas to satisfy the configured
+`ryl check --fix` normalises whitespace around commas to satisfy the configured
 limits. Disable with:
 
 ```toml

--- a/docs/rules/comments-indentation.md
+++ b/docs/rules/comments-indentation.md
@@ -61,7 +61,7 @@ options:
     - more stuff
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 parent:
@@ -71,7 +71,7 @@ parent:
 
 ## Automatic fixing
 
-`ryl --fix` reindents standalone comment lines to match the line that
+`ryl check --fix` reindents standalone comment lines to match the line that
 follows them. Disable with:
 
 ```toml

--- a/docs/rules/comments.md
+++ b/docs/rules/comments.md
@@ -46,7 +46,7 @@ key: value  # inline comment with two spaces of padding
 key: value # only one space before inline comment
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 # missing space after the hash
@@ -55,7 +55,7 @@ key: value  # only one space before inline comment
 
 ## Automatic fixing
 
-`ryl --fix` inserts the missing space after `#` and pads inline comments
+`ryl check --fix` inserts the missing space after `#` and pads inline comments
 to the configured `min-spaces-from-content`. Disable with:
 
 ```toml

--- a/docs/rules/document-end.md
+++ b/docs/rules/document-end.md
@@ -48,7 +48,7 @@ this: is the only document
 this: is the only document
 ```
 
-### :wrench: After `ryl --fix` (with `present: true`)
+### :wrench: After `ryl check --fix` (with `present: true`)
 
 ```yaml
 ---
@@ -58,7 +58,7 @@ this: is the only document
 
 ## Automatic fixing
 
-`ryl --fix` appends a `...` end marker when `present: true` and the
+`ryl check --fix` appends a `...` end marker when `present: true` and the
 document does not already have one. The fix is **partial** by design:
 it only runs when the buffer is a single document. A buffer is treated
 as single-document when, after skipping leading blank lines, comments,

--- a/docs/rules/document-start.md
+++ b/docs/rules/document-start.md
@@ -45,7 +45,7 @@ title: example
 title: example
 ```
 
-### :wrench: After `ryl --fix` (with `present: true`)
+### :wrench: After `ryl check --fix` (with `present: true`)
 
 ```yaml
 ---
@@ -54,7 +54,7 @@ title: example
 
 ## Automatic fixing
 
-`ryl --fix` prepends a `---` start marker when `present: true` and the
+`ryl check --fix` prepends a `---` start marker when `present: true` and the
 document does not already have one. The fix is **partial** by design:
 it only runs when
 

--- a/docs/rules/empty-lines.md
+++ b/docs/rules/empty-lines.md
@@ -53,7 +53,7 @@ a: 1
 b: 2
 ```
 
-### :wrench: After `ryl --fix` (defaults)
+### :wrench: After `ryl check --fix` (defaults)
 
 ```yaml
 ---
@@ -65,7 +65,7 @@ b: 2
 
 ## Automatic fixing
 
-`ryl --fix` trims runs of empty lines down to `max` (or `max-start`
+`ryl check --fix` trims runs of empty lines down to `max` (or `max-start`
 and `max-end` for the leading and trailing run). The fix is **partial**
 by design: blank lines that fall inside any multi-line scalar — literal
 or folded block scalars (`|`/`>`), multi-line single- or double-quoted

--- a/docs/rules/new-line-at-end-of-file.md
+++ b/docs/rules/new-line-at-end-of-file.md
@@ -38,13 +38,13 @@ key: value
 A file whose final byte is not a newline character. (Trailing *blank* lines
 are not this rule's concern; see [`empty-lines`](empty-lines.md).)
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ryl appends a single newline when the file does not already end with one.
 
 ## Automatic fixing
 
-`ryl --fix` appends a trailing newline when one is missing. Disable with:
+`ryl check --fix` appends a trailing newline when one is missing. Disable with:
 
 ```toml
 [fix]

--- a/docs/rules/new-lines.md
+++ b/docs/rules/new-lines.md
@@ -38,9 +38,9 @@ A file whose every line ends with `\n`.
 
 A file whose lines end with `\r\n`.
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
-`ryl --fix` rewrites the file so every line ends with the configured
+`ryl check --fix` rewrites the file so every line ends with the configured
 character sequence.
 
 ## Bare carriage returns
@@ -48,7 +48,7 @@ character sequence.
 A bare `\r` (a carriage return not part of `\r\n`) is a YAML 1.2 line break, so
 ryl treats it as a line ending here too. It is never one of the configurable
 styles (`unix`/`dos`/`platform`), so when the file's first line break is a bare
-`\r` the rule reports it as wrong and `ryl --fix` rewrites it to the configured
+`\r` the rule reports it as wrong and `ryl check --fix` rewrites it to the configured
 ending. This is a deliberate divergence from yamllint, whose line layer cannot
 see a bare `\r` and whose `type` has no `mac` value; on supported LF/CRLF files
 the behaviour is identical. See
@@ -56,7 +56,7 @@ the behaviour is identical. See
 
 ## Automatic fixing
 
-`ryl --fix` rewrites all line endings to match `type`. Disable with:
+`ryl check --fix` rewrites all line endings to match `type`. Disable with:
 
 ```toml
 [fix]

--- a/docs/rules/quoted-strings.md
+++ b/docs/rules/quoted-strings.md
@@ -43,7 +43,7 @@ name: "plain"   # redundantly quoted: a plain string needs no quotes
 version: '1.0'  # needs quoting, but single-quoted where double is required
 ```
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 name: plain
@@ -76,7 +76,7 @@ check-keys = false
 
 ## Automatic fixing
 
-`ryl --fix` rewrites string scalars to use the configured `quote-type` and
+`ryl check --fix` rewrites string scalars to use the configured `quote-type` and
 adds or removes quotes to satisfy `required`. The fix is conservative: it
 only changes scalars where the corrected form parses to the same value as
 the original.

--- a/docs/rules/trailing-spaces.md
+++ b/docs/rules/trailing-spaces.md
@@ -41,7 +41,7 @@ key: value···
 
 (Where `···` represents trailing whitespace characters.)
 
-### :wrench: After `ryl --fix`
+### :wrench: After `ryl check --fix`
 
 ```yaml
 ---
@@ -50,7 +50,7 @@ key: value
 
 ## Automatic fixing
 
-`ryl --fix` strips trailing spaces and tabs from each line. The fix is
+`ryl check --fix` strips trailing spaces and tabs from each line. The fix is
 **partial** by design: lines inside literal/folded block scalars
 (`|`/`>`) and inside multi-line double-quoted scalars are left untouched,
 because in those contexts trailing whitespace can be part of the parsed

--- a/docs/using-ryl-with-ai-agents.md
+++ b/docs/using-ryl-with-ai-agents.md
@@ -23,7 +23,7 @@ it. The skill is the canonical, tightened agent reference; this page only links 
 If a repo has an `AGENTS.md` (or `CLAUDE.md`), a one-line nudge helps agents reach for
 ryl and avoid its main gotcha:
 
-> Lint YAML with `ryl`. It has no default-on rules, so make sure a config (`ryl.toml`
+> Lint YAML with `ryl check`. It has no default-on rules, so make sure a config (`ryl.toml`
 > or a yamllint-style `.yamllint`) enables rules first, or it exits `2`.
 
 ## Feeding the docs to an LLM

--- a/docs/using-with-formatters.md
+++ b/docs/using-with-formatters.md
@@ -12,7 +12,7 @@ top.
 
 When two tools both rewrite files they can disagree. A setting in one can undo a fix from
 the other, and running them in a loop (for example in a pre-commit hook) makes them fight:
-the formatter changes a byte, `ryl --fix` changes it back, the formatter changes it again.
+the formatter changes a byte, `ryl check --fix` changes it back, the formatter changes it again.
 This page lists the ryl settings that matter for each formatter and gives a verified,
 conflict-free starting config for each.
 
@@ -34,8 +34,8 @@ There are exactly two ways the two tools can disagree:
   loop, but ryl warns on every run until you align the setting or turn the rule off.
 
 Everything below is about steering clear of both. The configs were checked by running
-`formatter` then `ryl --fix` repeatedly until the file settled, and confirming the
-settled file passes `ryl` with no findings. They were verified against the latest release
+`formatter` then `ryl check --fix` repeatedly until the file settled, and confirming the
+settled file passes `ryl check` with no findings. They were verified against the latest release
 of each formatter as of 2026-06-20: **yamlfmt 0.21.0**, **Prettier 3.8.4**, and
 **yamlfix 1.19.1**.
 
@@ -54,10 +54,10 @@ actually cause a loop or a standing complaint.
 
 !!! note "Check mode vs fix mode"
 
-    A few alignments rely on `ryl --fix` applying a one-time fix that the formatter then
+    A few alignments rely on `ryl check --fix` applying a one-time fix that the formatter then
     keeps (for example ryl adding `---` where the formatter preserves it). If you run ryl
-    in lint-only mode (`ryl` with no `--fix`, common in CI) rather than fix mode, prefer
-    the settings marked as needing no fix below, or run `ryl --fix` once before the check.
+    in lint-only mode (`ryl check` with no `--fix`, common in CI) rather than fix mode, prefer
+    the settings marked as needing no fix below, or run `ryl check --fix` once before the check.
 
 ## google/yamlfmt
 
@@ -170,7 +170,7 @@ Notes:
 - `document-start` is left off here. Prettier never adds or removes `---`, and ryl's
   document-start fix can add markers but not strip them, so `present = false` would
   permanently flag any file that already has a `---`. To enforce consistent markers
-  instead, set `present = true` and run `ryl --fix` (ryl adds `---`, Prettier keeps it).
+  instead, set `present = true` and run `ryl check --fix` (ryl adds `---`, Prettier keeps it).
 - The flow-padding split is the key alignment: `braces` must allow one inner space, while
   `brackets` must allow none. Prettier pads a non-empty mapping (`{ a: 1 }`) but keeps an
   empty one tight (`{}`), so the recipe also sets `min-spaces-inside-empty = 0` /
@@ -190,7 +190,7 @@ inline comments (the same as ryl's default), does not pad flow collections, inde
 two spaces, and canonicalizes block-style truthy values (`yes` becomes `true`), so the
 `truthy` rule stays clean for ordinary mappings and sequences (with one caveat noted
 below). It removes the `...` document-end marker. On Windows it writes CRLF only on files
-it actually rewrites and leaves unchanged files alone, so with `ryl --fix` it settles back
+it actually rewrites and leaves unchanged files alone, so with `ryl check --fix` it settles back
 to LF rather than fighting it (see
 [Line endings across operating systems](#line-endings-across-operating-systems)). Its
 settings are documented in the
@@ -263,7 +263,7 @@ formatter (the recipes above already do):
 | `new-lines` `type` | `unix` † | `unix` | `unix` † |
 
 † On Windows, yamlfmt forces CRLF on every write (pin its `line_ending: lf`), while
-yamlfix emits CRLF only on files it rewrites and settles back to LF under `ryl --fix`; see
+yamlfix emits CRLF only on files it rewrites and settles back to LF under `ryl check --fix`; see
 [Line endings across operating systems](#line-endings-across-operating-systems).
 
 Two of these point in opposite directions across formatters, which is why there is no
@@ -282,9 +282,9 @@ the three formatters behave differently:
   [`line_ending: lf`](https://github.com/google/yamlfmt/blob/main/docs/config-file.md#basic-formatter)
   in `.yamlfmt` and the recipe's `type = "unix"` holds on every OS.
 - **yamlfix** writes CRLF only on files it actually rewrites (it reads line endings
-  agnostically and skips unchanged files), so once `ryl --fix` normalizes a file to LF
+  agnostically and skips unchanged files), so once `ryl check --fix` normalizes a file to LF
   yamlfix leaves it alone. The two converge to LF on Windows with no loop, so
-  `type = "unix"` needs no change; just keep `ryl --fix` running after yamlfix. As
+  `type = "unix"` needs no change; just keep `ryl check --fix` running after yamlfix. As
   belt-and-braces you can also pin the committed form with a `.gitattributes` entry such
   as `*.yaml text eol=lf`.
 - **Prettier** writes LF on every OS (its `endOfLine` defaults to `lf`), so no change is

--- a/img/benchmark-5x5-5runs.svg
+++ b/img/benchmark-5x5-5runs.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-21T22:15:46.944410</dc:date>
+    <dc:date>2026-06-22T15:47:10.551098</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 63.600722 358.930469
 L 63.600722 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
@@ -107,7 +107,7 @@ z
      <g id="line2d_3">
       <path d="M 117.251843 358.930469
 L 117.251843 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
@@ -156,7 +156,7 @@ z
      <g id="line2d_5">
       <path d="M 170.902963 358.930469
 L 170.902963 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
@@ -196,7 +196,7 @@ z
      <g id="line2d_7">
       <path d="M 224.554084 358.930469
 L 224.554084 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
@@ -237,7 +237,7 @@ z
      <g id="line2d_9">
       <path d="M 278.205205 358.930469
 L 278.205205 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
@@ -282,7 +282,7 @@ z
      <g id="line2d_11">
       <path d="M 331.856326 358.930469
 L 331.856326 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
@@ -312,7 +312,7 @@ z
      <g id="line2d_13">
       <path d="M 385.507447 358.930469
 L 385.507447 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
@@ -368,7 +368,7 @@ z
      <g id="line2d_15">
       <path d="M 439.158568 358.930469
 L 439.158568 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_8">
@@ -415,7 +415,7 @@ z
      <g id="line2d_17">
       <path d="M 492.809688 358.930469
 L 492.809688 48.680684
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_18"/>
      <g id="text_9">
@@ -782,14 +782,14 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 42.140273 345.461631
-L 514.270137 345.461631
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 42.140273 345.495885
+L 514.270137 345.495885
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_20"/>
      <g id="text_11">
       <!-- 0.0 -->
-      <g style="fill: #262626" transform="translate(24.740273 349.101768) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.740273 349.136022) scale(0.1 -0.1)">
        <defs>
         <path id="LiberationSans-11" d="M 584 0
 L 584 684
@@ -807,14 +807,14 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 42.140273 283.799831
-L 514.270137 283.799831
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 42.140273 282.823746
+L 514.270137 282.823746
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_22"/>
      <g id="text_12">
       <!-- 0.5 -->
-      <g style="fill: #262626" transform="translate(24.740273 287.439968) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.740273 286.463883) scale(0.1 -0.1)">
        <use xlink:href="#LiberationSans-13"/>
        <use xlink:href="#LiberationSans-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#LiberationSans-18" transform="translate(83.390625 0)"/>
@@ -823,14 +823,14 @@ L 514.270137 283.799831
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 42.140273 222.138031
-L 514.270137 222.138031
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 42.140273 220.151607
+L 514.270137 220.151607
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_24"/>
      <g id="text_13">
       <!-- 1.0 -->
-      <g style="fill: #262626" transform="translate(24.740273 225.778168) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.740273 223.791744) scale(0.1 -0.1)">
        <use xlink:href="#LiberationSans-14"/>
        <use xlink:href="#LiberationSans-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#LiberationSans-13" transform="translate(83.390625 0)"/>
@@ -839,14 +839,14 @@ L 514.270137 222.138031
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 42.140273 160.476231
-L 514.270137 160.476231
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 42.140273 157.479468
+L 514.270137 157.479468
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_26"/>
      <g id="text_14">
       <!-- 1.5 -->
-      <g style="fill: #262626" transform="translate(24.740273 164.116368) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.740273 161.119605) scale(0.1 -0.1)">
        <use xlink:href="#LiberationSans-14"/>
        <use xlink:href="#LiberationSans-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#LiberationSans-18" transform="translate(83.390625 0)"/>
@@ -855,14 +855,14 @@ L 514.270137 160.476231
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 42.140273 98.814431
-L 514.270137 98.814431
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 42.140273 94.807329
+L 514.270137 94.807329
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_28"/>
      <g id="text_15">
       <!-- 2.0 -->
-      <g style="fill: #262626" transform="translate(24.740273 102.454568) scale(0.1 -0.1)">
+      <g style="fill: #262626" transform="translate(24.740273 98.447465) scale(0.1 -0.1)">
        <use xlink:href="#LiberationSans-15"/>
        <use xlink:href="#LiberationSans-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#LiberationSans-13" transform="translate(83.390625 0)"/>
@@ -1064,118 +1064,118 @@ z
    </g>
    <g id="FillBetweenPolyCollection_1">
     <defs>
-     <path id="m0d618eccf4" d="M 63.600722 -51.212564
+     <path id="m38670d2c9b" d="M 63.600722 -51.227212
 L 63.600722 -51.171794
-L 170.902963 -51.276998
-L 278.205205 -51.453862
-L 385.507447 -51.603023
-L 492.809688 -51.662697
-L 492.809688 -51.870528
-L 492.809688 -51.870528
-L 385.507447 -51.703522
-L 278.205205 -51.513252
-L 170.902963 -51.415888
-L 63.600722 -51.212564
+L 170.902963 -51.352905
+L 278.205205 -51.434007
+L 385.507447 -51.640047
+L 492.809688 -51.70908
+L 492.809688 -51.850904
+L 492.809688 -51.850904
+L 385.507447 -51.685187
+L 278.205205 -51.465584
+L 170.902963 -51.390479
+L 63.600722 -51.227212
 z
 " style="stroke: #a6cee4; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#m0d618eccf4" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#m38670d2c9b" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_2">
     <defs>
-     <path id="mbf1d9f2820" d="M 63.600722 -51.42504
-L 63.600722 -51.300671
-L 170.902963 -51.590324
-L 278.205205 -51.727707
-L 385.507447 -52.022097
-L 492.809688 -52.250636
-L 492.809688 -52.566123
-L 492.809688 -52.566123
-L 385.507447 -52.226087
-L 278.205205 -51.884576
-L 170.902963 -51.736901
-L 63.600722 -51.42504
+     <path id="mb00fd88096" d="M 63.600722 -51.350628
+L 63.600722 -51.314853
+L 170.902963 -51.574513
+L 278.205205 -51.825878
+L 385.507447 -52.018275
+L 492.809688 -52.221803
+L 492.809688 -52.238556
+L 492.809688 -52.238556
+L 385.507447 -52.07993
+L 278.205205 -51.880853
+L 170.902963 -51.660171
+L 63.600722 -51.350628
 z
 " style="stroke: #6aaed6; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#mbf1d9f2820" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#mb00fd88096" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_3">
     <defs>
-     <path id="m71035be16b" d="M 63.600722 -51.56289
-L 63.600722 -51.448408
-L 170.902963 -51.760358
-L 278.205205 -52.000692
-L 385.507447 -52.350747
-L 492.809688 -52.759436
-L 492.809688 -52.9141
-L 492.809688 -52.9141
-L 385.507447 -52.479883
-L 278.205205 -52.593293
-L 170.902963 -51.851912
-L 63.600722 -51.56289
+     <path id="m6e07ab3fe7" d="M 63.600722 -51.591528
+L 63.600722 -51.485965
+L 170.902963 -51.841
+L 278.205205 -52.102953
+L 385.507447 -52.3993
+L 492.809688 -52.748439
+L 492.809688 -52.818725
+L 492.809688 -52.818725
+L 385.507447 -52.506174
+L 278.205205 -52.207183
+L 170.902963 -51.885609
+L 63.600722 -51.591528
 z
 " style="stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#m71035be16b" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#m6e07ab3fe7" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_4">
     <defs>
-     <path id="mf88d6f8c38" d="M 63.600722 -51.691262
-L 63.600722 -51.560839
-L 170.902963 -52.005268
-L 278.205205 -52.392968
-L 385.507447 -52.822486
-L 492.809688 -53.305249
-L 492.809688 -53.460938
-L 492.809688 -53.460938
-L 385.507447 -53.151367
-L 278.205205 -52.415344
-L 170.902963 -52.088738
-L 63.600722 -51.691262
+     <path id="m3d20015ee0" d="M 63.600722 -51.726424
+L 63.600722 -51.639838
+L 170.902963 -52.038277
+L 278.205205 -52.51634
+L 385.507447 -52.608167
+L 492.809688 -53.305449
+L 492.809688 -53.427293
+L 492.809688 -53.427293
+L 385.507447 -53.466069
+L 278.205205 -52.677693
+L 170.902963 -52.085361
+L 63.600722 -51.726424
 z
 " style="stroke: #1764ab; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#mf88d6f8c38" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#m3d20015ee0" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_5">
     <defs>
-     <path id="mc6ef03a2f3" d="M 63.600722 -51.746707
-L 63.600722 -51.655348
-L 170.902963 -52.259022
-L 278.205205 -52.974577
-L 385.507447 -53.45835
-L 492.809688 -53.818076
-L 492.809688 -54.090767
-L 492.809688 -54.090767
-L 385.507447 -53.768818
-L 278.205205 -53.393142
-L 170.902963 -52.382129
-L 63.600722 -51.746707
+     <path id="m90efe5d622" d="M 63.600722 -51.855849
+L 63.600722 -51.647532
+L 170.902963 -52.287329
+L 278.205205 -52.728365
+L 385.507447 -53.253527
+L 492.809688 -53.774758
+L 492.809688 -53.877018
+L 492.809688 -53.877018
+L 385.507447 -53.430079
+L 278.205205 -52.822136
+L 170.902963 -52.320557
+L 63.600722 -51.855849
 z
 " style="stroke: #083c7d; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#mc6ef03a2f3" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#m90efe5d622" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="line2d_29">
-    <path d="M 63.600722 344.807821
-L 170.902963 344.653557
-L 278.205205 344.516443
-L 385.507447 344.346728
-L 492.809688 344.233387
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 63.600722 344.800497
+L 170.902963 344.628308
+L 278.205205 344.550204
+L 385.507447 344.337383
+L 492.809688 344.220008
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m4803c2e0b2" d="M 0 3
+     <path id="m0173464b87" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1187,23 +1187,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #a6cee4"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#m4803c2e0b2" x="63.600722" y="344.807821" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="170.902963" y="344.653557" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="278.205205" y="344.516443" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="385.507447" y="344.346728" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="492.809688" y="344.233387" style="fill: #a6cee4; stroke: #a6cee4"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#m0173464b87" x="63.600722" y="344.800497" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="170.902963" y="344.628308" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="278.205205" y="344.550204" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="385.507447" y="344.337383" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="492.809688" y="344.220008" style="fill: #a6cee4; stroke: #a6cee4"/>
     </g>
    </g>
    <g id="line2d_30">
-    <path d="M 63.600722 344.637145
-L 170.902963 344.336388
-L 278.205205 344.193858
-L 385.507447 343.875908
-L 492.809688 343.59162
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 63.600722 344.667259
+L 170.902963 344.382658
+L 278.205205 344.146635
+L 385.507447 343.950897
+L 492.809688 343.769821
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="mcf2226921e" d="M 0 3
+     <path id="mf48c2e31fc" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1215,23 +1215,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #6aaed6"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#mcf2226921e" x="63.600722" y="344.637145" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="170.902963" y="344.336388" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="278.205205" y="344.193858" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="385.507447" y="343.875908" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="492.809688" y="343.59162" style="fill: #6aaed6; stroke: #6aaed6"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#mf48c2e31fc" x="63.600722" y="344.667259" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="170.902963" y="344.382658" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="278.205205" y="344.146635" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="385.507447" y="343.950897" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="492.809688" y="343.769821" style="fill: #6aaed6; stroke: #6aaed6"/>
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 63.600722 344.494351
-L 170.902963 344.193865
-L 278.205205 343.703007
-L 385.507447 343.584685
-L 492.809688 343.163232
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 63.600722 344.461253
+L 170.902963 344.136696
+L 278.205205 343.844932
+L 385.507447 343.547263
+L 492.809688 343.216418
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m9fdc4eb408" d="M 0 3
+     <path id="m3ba52f3c2a" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1243,23 +1243,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #3b8bc2"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#m9fdc4eb408" x="63.600722" y="344.494351" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="170.902963" y="344.193865" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="278.205205" y="343.703007" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="385.507447" y="343.584685" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="492.809688" y="343.163232" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#m3ba52f3c2a" x="63.600722" y="344.461253" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="170.902963" y="344.136696" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="278.205205" y="343.844932" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="385.507447" y="343.547263" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="492.809688" y="343.216418" style="fill: #3b8bc2; stroke: #3b8bc2"/>
     </g>
    </g>
    <g id="line2d_32">
-    <path d="M 63.600722 344.373949
-L 170.902963 343.952997
-L 278.205205 343.595844
-L 385.507447 343.013074
-L 492.809688 342.616906
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 63.600722 344.316869
+L 170.902963 343.938181
+L 278.205205 343.402984
+L 385.507447 342.962882
+L 492.809688 342.633629
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m93031f03eb" d="M 0 3
+     <path id="m30966c6613" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1271,23 +1271,23 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1764ab"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#m93031f03eb" x="63.600722" y="344.373949" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="170.902963" y="343.952997" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="278.205205" y="343.595844" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="385.507447" y="343.013074" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="492.809688" y="342.616906" style="fill: #1764ab; stroke: #1764ab"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#m30966c6613" x="63.600722" y="344.316869" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="170.902963" y="343.938181" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="278.205205" y="343.402984" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="385.507447" y="342.962882" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="492.809688" y="342.633629" style="fill: #1764ab; stroke: #1764ab"/>
     </g>
    </g>
    <g id="line2d_33">
-    <path d="M 63.600722 344.298972
-L 170.902963 343.679425
-L 278.205205 342.816141
-L 385.507447 342.386416
-L 492.809688 342.045579
-" clip-path="url(#p0a91b32804)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
+    <path d="M 63.600722 344.24831
+L 170.902963 343.696057
+L 278.205205 343.22475
+L 385.507447 342.658197
+L 492.809688 342.174112
+" clip-path="url(#p22d10de942)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m6473a55f58" d="M 0 3
+     <path id="meb2dc0b576" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1299,12 +1299,12 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #083c7d"/>
     </defs>
-    <g clip-path="url(#p0a91b32804)">
-     <use xlink:href="#m6473a55f58" x="63.600722" y="344.298972" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="170.902963" y="343.679425" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="278.205205" y="342.816141" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="385.507447" y="342.386416" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="492.809688" y="342.045579" style="fill: #083c7d; stroke: #083c7d"/>
+    <g clip-path="url(#p22d10de942)">
+     <use xlink:href="#meb2dc0b576" x="63.600722" y="344.24831" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="170.902963" y="343.696057" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="278.205205" y="343.22475" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="385.507447" y="342.658197" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="492.809688" y="342.174112" style="fill: #083c7d; stroke: #083c7d"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1328,7 +1328,7 @@ L 514.270137 48.680684
 " style="fill: none; stroke: #cccccc; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_17">
-    <!-- ryl 0.20.0 -->
+    <!-- ryl 0.21.0 -->
     <g style="fill: #262626" transform="translate(253.527393 42.680684) scale(0.12 -0.12)">
      <defs>
       <path id="LiberationSans-5c" d="M 597 -1328
@@ -1360,7 +1360,7 @@ z
      <use xlink:href="#LiberationSans-13" transform="translate(133.296875 0)"/>
      <use xlink:href="#LiberationSans-11" transform="translate(188.90625 0)"/>
      <use xlink:href="#LiberationSans-15" transform="translate(216.6875 0)"/>
-     <use xlink:href="#LiberationSans-13" transform="translate(272.296875 0)"/>
+     <use xlink:href="#LiberationSans-14" transform="translate(272.296875 0)"/>
      <use xlink:href="#LiberationSans-11" transform="translate(327.90625 0)"/>
      <use xlink:href="#LiberationSans-13" transform="translate(355.6875 0)"/>
     </g>
@@ -1380,7 +1380,7 @@ z
      <g id="line2d_34">
       <path d="M 546.530585 358.930469
 L 546.530585 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_35"/>
      <g id="text_18">
@@ -1395,7 +1395,7 @@ L 546.530585 48.680684
      <g id="line2d_36">
       <path d="M 600.181706 358.930469
 L 600.181706 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_37"/>
      <g id="text_19">
@@ -1410,7 +1410,7 @@ L 600.181706 48.680684
      <g id="line2d_38">
       <path d="M 653.832827 358.930469
 L 653.832827 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_39"/>
      <g id="text_20">
@@ -1425,7 +1425,7 @@ L 653.832827 48.680684
      <g id="line2d_40">
       <path d="M 707.483948 358.930469
 L 707.483948 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_41"/>
      <g id="text_21">
@@ -1440,7 +1440,7 @@ L 707.483948 48.680684
      <g id="line2d_42">
       <path d="M 761.135068 358.930469
 L 761.135068 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_43"/>
      <g id="text_22">
@@ -1455,7 +1455,7 @@ L 761.135068 48.680684
      <g id="line2d_44">
       <path d="M 814.786189 358.930469
 L 814.786189 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_45"/>
      <g id="text_23">
@@ -1470,7 +1470,7 @@ L 814.786189 48.680684
      <g id="line2d_46">
       <path d="M 868.43731 358.930469
 L 868.43731 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_47"/>
      <g id="text_24">
@@ -1485,7 +1485,7 @@ L 868.43731 48.680684
      <g id="line2d_48">
       <path d="M 922.088431 358.930469
 L 922.088431 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_49"/>
      <g id="text_25">
@@ -1500,7 +1500,7 @@ L 922.088431 48.680684
      <g id="line2d_50">
       <path d="M 975.739552 358.930469
 L 975.739552 48.680684
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_51"/>
      <g id="text_26">
@@ -1541,223 +1541,223 @@ L 975.739552 48.680684
    <g id="matplotlib.axis_4">
     <g id="ytick_6">
      <g id="line2d_52">
-      <path d="M 525.070137 345.461631
-L 997.2 345.461631
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 525.070137 345.495885
+L 997.2 345.495885
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_53"/>
     </g>
     <g id="ytick_7">
      <g id="line2d_54">
-      <path d="M 525.070137 283.799831
-L 997.2 283.799831
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 525.070137 282.823746
+L 997.2 282.823746
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_55"/>
     </g>
     <g id="ytick_8">
      <g id="line2d_56">
-      <path d="M 525.070137 222.138031
-L 997.2 222.138031
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 525.070137 220.151607
+L 997.2 220.151607
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_57"/>
     </g>
     <g id="ytick_9">
      <g id="line2d_58">
-      <path d="M 525.070137 160.476231
-L 997.2 160.476231
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 525.070137 157.479468
+L 997.2 157.479468
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_59"/>
     </g>
     <g id="ytick_10">
      <g id="line2d_60">
-      <path d="M 525.070137 98.814431
-L 997.2 98.814431
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
+      <path d="M 525.070137 94.807329
+L 997.2 94.807329
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #cccccc; stroke-width: 0.8; stroke-linecap: round"/>
      </g>
      <g id="line2d_61"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_6">
     <defs>
-     <path id="m5699dafcca" d="M 546.530585 -66.860132
-L 546.530585 -66.349222
-L 653.832827 -73.048904
-L 761.135068 -79.67624
-L 868.43731 -86.327851
-L 975.739552 -92.822762
-L 975.739552 -94.171843
-L 975.739552 -94.171843
-L 868.43731 -87.285152
-L 761.135068 -81.005939
-L 653.832827 -73.737509
-L 546.530585 -66.860132
+     <path id="mba0ea23d8b" d="M 546.530585 -67.426132
+L 546.530585 -66.732136
+L 653.832827 -73.183181
+L 761.135068 -80.109683
+L 868.43731 -86.700931
+L 975.739552 -93.444298
+L 975.739552 -94.837605
+L 975.739552 -94.837605
+L 868.43731 -87.16768
+L 761.135068 -81.629461
+L 653.832827 -74.142524
+L 546.530585 -67.426132
 z
 " style="stroke: #a6cee4; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m5699dafcca" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#mba0ea23d8b" x="0" y="396" style="fill: #a6cee4; fill-opacity: 0.16; stroke: #a6cee4; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_7">
     <defs>
-     <path id="m1c9505b1cb" d="M 546.530585 -79.165086
-L 546.530585 -78.34073
-L 653.832827 -96.897787
-L 761.135068 -114.478176
-L 868.43731 -133.893337
-L 975.739552 -152.112729
-L 975.739552 -153.509994
-L 975.739552 -153.509994
-L 868.43731 -134.723975
-L 761.135068 -121.022281
-L 653.832827 -97.297041
-L 546.530585 -79.165086
+     <path id="m8d02a2a450" d="M 546.530585 -79.744277
+L 546.530585 -78.857749
+L 653.832827 -97.090786
+L 761.135068 -115.527537
+L 868.43731 -133.973302
+L 975.739552 -153.131258
+L 975.739552 -154.804602
+L 975.739552 -154.804602
+L 868.43731 -137.898376
+L 761.135068 -118.034518
+L 653.832827 -98.499127
+L 546.530585 -79.744277
 z
 " style="stroke: #6aaed6; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m1c9505b1cb" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#m8d02a2a450" x="0" y="396" style="fill: #6aaed6; fill-opacity: 0.16; stroke: #6aaed6; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_8">
     <defs>
-     <path id="m9fb3d050fd" d="M 546.530585 -91.194495
-L 546.530585 -89.478015
-L 653.832827 -119.380787
-L 761.135068 -149.559392
-L 868.43731 -180.676613
-L 975.739552 -209.681629
-L 975.739552 -213.340984
-L 975.739552 -213.340984
-L 868.43731 -182.35623
-L 761.135068 -151.490068
-L 653.832827 -120.365179
-L 546.530585 -91.194495
+     <path id="m7d7af62d82" d="M 546.530585 -90.603159
+L 546.530585 -89.807333
+L 653.832827 -119.77466
+L 761.135068 -150.568884
+L 868.43731 -180.429168
+L 975.739552 -211.835423
+L 975.739552 -213.295751
+L 975.739552 -213.295751
+L 868.43731 -182.810154
+L 761.135068 -152.53887
+L 653.832827 -121.560908
+L 546.530585 -90.603159
 z
 " style="stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m9fb3d050fd" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#m7d7af62d82" x="0" y="396" style="fill: #3b8bc2; fill-opacity: 0.16; stroke: #3b8bc2; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_9">
     <defs>
-     <path id="m9b0fc1f2a9" d="M 546.530585 -103.15152
-L 546.530585 -101.936999
-L 653.832827 -143.883852
-L 761.135068 -186.101915
-L 868.43731 -227.870083
-L 975.739552 -270.06251
-L 975.739552 -273.163403
-L 975.739552 -273.163403
-L 868.43731 -230.876822
-L 761.135068 -188.363399
-L 653.832827 -145.823471
-L 546.530585 -103.15152
+     <path id="m3495ee9317" d="M 546.530585 -103.202887
+L 546.530585 -101.935009
+L 653.832827 -145.914892
+L 761.135068 -187.55473
+L 868.43731 -227.399365
+L 975.739552 -271.298274
+L 975.739552 -274.969443
+L 975.739552 -274.969443
+L 868.43731 -233.008093
+L 761.135068 -191.744447
+L 653.832827 -148.153702
+L 546.530585 -103.202887
 z
 " style="stroke: #1764ab; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m9b0fc1f2a9" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#m3495ee9317" x="0" y="396" style="fill: #1764ab; fill-opacity: 0.16; stroke: #1764ab; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_10">
     <defs>
-     <path id="m7879267f83" d="M 546.530585 -114.568996
-L 546.530585 -113.837203
-L 653.832827 -168.160193
-L 761.135068 -221.416365
-L 868.43731 -277.955415
-L 975.739552 -329.005124
+     <path id="m35d86e3e7c" d="M 546.530585 -115.367739
+L 546.530585 -114.490614
+L 653.832827 -167.531463
+L 761.135068 -221.581361
+L 868.43731 -275.063029
+L 975.739552 -330.158636
 L 975.739552 -333.217053
 L 975.739552 -333.217053
-L 868.43731 -280.293698
-L 761.135068 -228.93773
-L 653.832827 -173.53282
-L 546.530585 -114.568996
+L 868.43731 -283.617471
+L 761.135068 -227.160914
+L 653.832827 -170.770934
+L 546.530585 -115.367739
 z
 " style="stroke: #083c7d; stroke-opacity: 0.16"/>
     </defs>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m7879267f83" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#m35d86e3e7c" x="0" y="396" style="fill: #083c7d; fill-opacity: 0.16; stroke: #083c7d; stroke-opacity: 0.16"/>
     </g>
    </g>
    <g id="line2d_62">
-    <path d="M 546.530585 329.395323
-L 653.832827 322.606794
-L 761.135068 315.65891
-L 868.43731 309.193498
-L 975.739552 302.502698
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m4803c2e0b2" x="546.530585" y="329.395323" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="653.832827" y="322.606794" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="761.135068" y="315.65891" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="868.43731" y="309.193498" style="fill: #a6cee4; stroke: #a6cee4"/>
-     <use xlink:href="#m4803c2e0b2" x="975.739552" y="302.502698" style="fill: #a6cee4; stroke: #a6cee4"/>
+    <path d="M 546.530585 328.920866
+L 653.832827 322.337148
+L 761.135068 315.130428
+L 868.43731 309.065694
+L 975.739552 301.859049
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#m0173464b87" x="546.530585" y="328.920866" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="653.832827" y="322.337148" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="761.135068" y="315.130428" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="868.43731" y="309.065694" style="fill: #a6cee4; stroke: #a6cee4"/>
+     <use xlink:href="#m0173464b87" x="975.739552" y="301.859049" style="fill: #a6cee4; stroke: #a6cee4"/>
     </g>
    </g>
    <g id="line2d_63">
-    <path d="M 546.530585 317.247092
-L 653.832827 298.902586
-L 761.135068 278.249772
-L 868.43731 261.691344
-L 975.739552 243.188638
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#mcf2226921e" x="546.530585" y="317.247092" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="653.832827" y="298.902586" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="761.135068" y="278.249772" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="868.43731" y="261.691344" style="fill: #6aaed6; stroke: #6aaed6"/>
-     <use xlink:href="#mcf2226921e" x="975.739552" y="243.188638" style="fill: #6aaed6; stroke: #6aaed6"/>
+    <path d="M 546.530585 316.698987
+L 653.832827 298.205044
+L 761.135068 279.218973
+L 868.43731 260.064161
+L 975.739552 242.03207
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#mf48c2e31fc" x="546.530585" y="316.698987" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="653.832827" y="298.205044" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="761.135068" y="279.218973" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="868.43731" y="260.064161" style="fill: #6aaed6; stroke: #6aaed6"/>
+     <use xlink:href="#mf48c2e31fc" x="975.739552" y="242.03207" style="fill: #6aaed6; stroke: #6aaed6"/>
     </g>
    </g>
    <g id="line2d_64">
-    <path d="M 546.530585 305.663745
-L 653.832827 276.127017
-L 761.135068 245.47527
-L 868.43731 214.483579
-L 975.739552 184.488694
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m9fdc4eb408" x="546.530585" y="305.663745" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="653.832827" y="276.127017" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="761.135068" y="245.47527" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="868.43731" y="214.483579" style="fill: #3b8bc2; stroke: #3b8bc2"/>
-     <use xlink:href="#m9fdc4eb408" x="975.739552" y="184.488694" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+    <path d="M 546.530585 305.794754
+L 653.832827 275.332216
+L 761.135068 244.446123
+L 868.43731 214.380339
+L 975.739552 183.434413
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#m3ba52f3c2a" x="546.530585" y="305.794754" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="653.832827" y="275.332216" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="761.135068" y="244.446123" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="868.43731" y="214.380339" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+     <use xlink:href="#m3ba52f3c2a" x="975.739552" y="183.434413" style="fill: #3b8bc2; stroke: #3b8bc2"/>
     </g>
    </g>
    <g id="line2d_65">
-    <path d="M 546.530585 293.455741
-L 653.832827 251.146338
-L 761.135068 208.767343
-L 868.43731 166.626548
-L 975.739552 124.387043
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m93031f03eb" x="546.530585" y="293.455741" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="653.832827" y="251.146338" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="761.135068" y="208.767343" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="868.43731" y="166.626548" style="fill: #1764ab; stroke: #1764ab"/>
-     <use xlink:href="#m93031f03eb" x="975.739552" y="124.387043" style="fill: #1764ab; stroke: #1764ab"/>
+    <path d="M 546.530585 293.431052
+L 653.832827 248.965703
+L 761.135068 206.350411
+L 868.43731 165.796271
+L 975.739552 122.866141
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#m30966c6613" x="546.530585" y="293.431052" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="653.832827" y="248.965703" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="761.135068" y="206.350411" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="868.43731" y="165.796271" style="fill: #1764ab; stroke: #1764ab"/>
+     <use xlink:href="#m30966c6613" x="975.739552" y="122.866141" style="fill: #1764ab; stroke: #1764ab"/>
     </g>
    </g>
    <g id="line2d_66">
-    <path d="M 546.530585 281.796901
-L 653.832827 225.153494
-L 761.135068 170.822953
-L 868.43731 116.875444
-L 975.739552 64.888911
-" clip-path="url(#p1e89d684a9)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
-    <g clip-path="url(#p1e89d684a9)">
-     <use xlink:href="#m6473a55f58" x="546.530585" y="281.796901" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="653.832827" y="225.153494" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="761.135068" y="170.822953" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="868.43731" y="116.875444" style="fill: #083c7d; stroke: #083c7d"/>
-     <use xlink:href="#m6473a55f58" x="975.739552" y="64.888911" style="fill: #083c7d; stroke: #083c7d"/>
+    <path d="M 546.530585 281.070823
+L 653.832827 226.848802
+L 761.135068 171.628862
+L 868.43731 116.65975
+L 975.739552 64.312155
+" clip-path="url(#pc713ed25b8)" style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
+    <g clip-path="url(#pc713ed25b8)">
+     <use xlink:href="#meb2dc0b576" x="546.530585" y="281.070823" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="653.832827" y="226.848802" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="761.135068" y="171.628862" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="868.43731" y="116.65975" style="fill: #083c7d; stroke: #083c7d"/>
+     <use xlink:href="#meb2dc0b576" x="975.739552" y="64.312155" style="fill: #083c7d; stroke: #083c7d"/>
     </g>
    </g>
    <g id="patch_8">
@@ -1849,7 +1849,7 @@ L 544.070137 75.845723
 L 554.070137 75.845723
 " style="fill: none; stroke: #a6cee4; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m4803c2e0b2" x="544.070137" y="75.845723" style="fill: #a6cee4; stroke: #a6cee4"/>
+      <use xlink:href="#m0173464b87" x="544.070137" y="75.845723" style="fill: #a6cee4; stroke: #a6cee4"/>
      </g>
     </g>
     <g id="text_30">
@@ -1915,7 +1915,7 @@ L 544.070137 90.230488
 L 554.070137 90.230488
 " style="fill: none; stroke: #6aaed6; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#mcf2226921e" x="544.070137" y="90.230488" style="fill: #6aaed6; stroke: #6aaed6"/>
+      <use xlink:href="#mf48c2e31fc" x="544.070137" y="90.230488" style="fill: #6aaed6; stroke: #6aaed6"/>
      </g>
     </g>
     <g id="text_31">
@@ -1934,7 +1934,7 @@ L 544.070137 104.615254
 L 554.070137 104.615254
 " style="fill: none; stroke: #3b8bc2; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m9fdc4eb408" x="544.070137" y="104.615254" style="fill: #3b8bc2; stroke: #3b8bc2"/>
+      <use xlink:href="#m3ba52f3c2a" x="544.070137" y="104.615254" style="fill: #3b8bc2; stroke: #3b8bc2"/>
      </g>
     </g>
     <g id="text_32">
@@ -1953,7 +1953,7 @@ L 544.070137 119.00002
 L 554.070137 119.00002
 " style="fill: none; stroke: #1764ab; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m93031f03eb" x="544.070137" y="119.00002" style="fill: #1764ab; stroke: #1764ab"/>
+      <use xlink:href="#m30966c6613" x="544.070137" y="119.00002" style="fill: #1764ab; stroke: #1764ab"/>
      </g>
     </g>
     <g id="text_33">
@@ -1972,7 +1972,7 @@ L 544.070137 133.384785
 L 554.070137 133.384785
 " style="fill: none; stroke: #083c7d; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m6473a55f58" x="544.070137" y="133.384785" style="fill: #083c7d; stroke: #083c7d"/>
+      <use xlink:href="#meb2dc0b576" x="544.070137" y="133.384785" style="fill: #083c7d; stroke: #083c7d"/>
      </g>
     </g>
     <g id="text_34">
@@ -2119,10 +2119,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p0a91b32804">
+  <clipPath id="p22d10de942">
    <rect x="42.140273" y="48.680684" width="472.129863" height="310.249785"/>
   </clipPath>
-  <clipPath id="p1e89d684a9">
+  <clipPath id="pc713ed25b8">
    <rect x="525.070137" y="48.680684" width="472.129863" height="310.249785"/>
   </clipPath>
  </defs>

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   },
   "sideEffects": false,
   "type": "commonjs",
-  "version": "0.20.0"
+  "version": "0.21.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ryl"
-version = "0.20.0"
+version = "0.21.0"
 description = "Fast YAML linter inspired by yamllint"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/skills/ryl/SKILL.md
+++ b/skills/ryl/SKILL.md
@@ -27,7 +27,7 @@ fully-ignored input set still exits `0`). This is stricter than yamllint. Always
 a config first:
 
 ```bash
-ryl -d 'extends: default' .          # quick: yamllint's standard rule set
+ryl check -d 'extends: default' .          # quick: yamllint's standard rule set
 ```
 
 Or commit a `ryl.toml` / `.ryl.toml` (in `pyproject.toml`, prefix the tables with
@@ -43,8 +43,8 @@ new-line-at-end-of-file = "enable"
 ## Run and branch on exit codes
 
 ```bash
-ryl <path|file ...>     # files and/or directories; `ryl .` recurses, honouring .gitignore
-ryl --list-files .      # preview which files would be linted, then exit
+ryl check <path|file ...>    # files and/or directories; `ryl check .` recurses, honouring .gitignore
+ryl check --list-files .      # preview which files would be linted, then exit
 ```
 
 Exit codes from a plain lint run (`--fix`/`--diff` differ, see below):
@@ -73,7 +73,7 @@ Add `--strict` to make warnings fail (exit `2`); `--no-warnings` reports only er
 produced together:
 
 ```bash
-ryl --format github --format gitlab -o code-quality.json .
+ryl check --format github --format gitlab -o code-quality.json .
 ```
 
 ## Configuration: YAML vs TOML

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,10 +87,10 @@ fn gather_inputs(inputs: &[PathBuf]) -> (Vec<PathBuf>, Vec<PathBuf>) {
     (candidates, explicit_files)
 }
 
-fn cli_overrides(cli: &Cli) -> Overrides {
+fn cli_overrides(args: &LintArgs) -> Overrides {
     Overrides {
-        config_file: cli.config_file.clone(),
-        config_data: cli.config_data.as_ref().map(|raw| {
+        config_file: args.config_file.clone(),
+        config_data: args.config_data.as_ref().map(|raw| {
             if !raw.is_empty() && !raw.contains(':') {
                 format!("extends: {raw}")
             } else {
@@ -102,13 +102,13 @@ fn cli_overrides(cli: &Cli) -> Overrides {
 
 fn build_global_cfg(
     inputs: &[PathBuf],
-    cli: &Cli,
+    args: &LintArgs,
 ) -> Result<Option<ConfigContext>, String> {
-    if cli.config_data.is_some()
-        || cli.config_file.is_some()
+    if args.config_data.is_some()
+        || args.config_file.is_some()
         || std::env::var("YAMLLINT_CONFIG_FILE").is_ok()
     {
-        discover_config(inputs, &cli_overrides(cli)).map(Some)
+        discover_config(inputs, &cli_overrides(args)).map(Some)
     } else {
         Ok(None)
     }
@@ -126,12 +126,12 @@ fn build_global_cfg(
 fn run_output_config(
     global_cfg: Option<&ConfigContext>,
     inputs: &[PathBuf],
-    cli: &Cli,
+    args: &LintArgs,
 ) -> Result<Option<OutputTable>, String> {
     if let Some(ctx) = global_cfg {
         return Ok(ctx.config.output().cloned());
     }
-    Ok(discover_config(inputs, &cli_overrides(cli))?
+    Ok(discover_config(inputs, &cli_overrides(args))?
         .config
         .output()
         .cloned())
@@ -239,44 +239,14 @@ enum CliFormat {
         .args(["migrate_configs", "migrate_user_config"])
         .multiple(true))
 )]
-// `server` is the only subcommand; bare `ryl <paths>` still lints, so lint args and the
-// subcommand are mutually exclusive.
-#[cfg_attr(feature = "lsp", command(args_conflicts_with_subcommands = true))]
+// `check` and (with `lsp`) `server` are subcommands; bare `ryl <paths>` still lints via the
+// flattened top-level lint args, so those are mutually exclusive with any subcommand.
+#[command(args_conflicts_with_subcommands = true)]
 // These are independent toggles, not state better modeled as an enum.
 #[allow(clippy::struct_excessive_bools)]
 struct Cli {
-    /// One or more paths: files and/or directories, or `-` to read from stdin
-    #[arg(value_name = "PATH_OR_FILE")]
-    inputs: Vec<PathBuf>,
-
-    /// Filename used for diagnostics, config discovery, and yaml-files matching when reading stdin
-    #[arg(long = "stdin-filename", value_name = "FILE")]
-    stdin_filename: Option<PathBuf>,
-
-    /// Path to configuration file (YAML or TOML)
-    #[arg(short = 'c', long = "config-file", value_name = "FILE")]
-    config_file: Option<PathBuf>,
-
-    /// Inline configuration data (yaml)
-    #[arg(short = 'd', long = "config-data", value_name = "YAML")]
-    config_data: Option<String>,
-
-    /// Output format (auto, standard, colored, github, parsable, junit, gitlab). Repeatable:
-    /// each `--format` may be followed by an `--output-file` to send that format to a file,
-    /// so console and report artifacts can be produced together.
-    #[arg(short = 'f', long = "format", value_enum)]
-    format: Vec<CliFormat>,
-
-    /// Destination for the preceding `--format` (a path, or `-` for stdout). Repeatable;
-    /// each binds to the most recent `--format`. Default stream otherwise: stderr for the
-    /// console formats, stdout for junit/gitlab.
-    #[arg(
-        short = 'o',
-        long = "output-file",
-        value_name = "FILE",
-        conflicts_with = "diff"
-    )]
-    output_file: Vec<PathBuf>,
+    #[command(flatten)]
+    lint_args: LintArgs,
 
     // These print-and-exit meta-actions are `exclusive` so combining them with a lint/fix
     // request is a usage error. `--migrate-configs` is not exclusive: it combines with its
@@ -315,23 +285,62 @@ struct Cli {
     generate_completions: Option<clap_complete::Shell>,
 
     #[command(flatten)]
-    lint: LintFlags,
-
-    #[command(flatten)]
     migrate: MigrateFlags,
 
-    #[cfg(feature = "lsp")]
     #[command(subcommand)]
     command: Option<Commands>,
 }
 
-/// Subcommands; none (bare `ryl <paths>`) lints. The bare token `server` resolves to this
-/// subcommand, so lint a path of that name as `ryl ./server` or `ryl server/`.
-#[cfg(feature = "lsp")]
+/// Subcommands; none (bare `ryl <paths>`) lints, like `check`. The bare token `check`/`server`
+/// resolves to the subcommand, so lint a path of that name as `ryl ./check` or `ryl check/`.
 #[derive(clap::Subcommand, Debug)]
 enum Commands {
+    /// Lint YAML inputs (the explicit form of bare `ryl <paths>`)
+    Check(LintArgs),
     /// Run the language server (LSP) over stdio for editor integration
+    #[cfg(feature = "lsp")]
     Server,
+}
+
+/// The lint pass arguments, flattened both at the top level (bare `ryl <paths>`) and under
+/// `ryl check`, so the two forms are byte-for-byte equivalent.
+#[derive(clap::Args, Debug, Default)]
+struct LintArgs {
+    /// One or more paths: files and/or directories, or `-` to read from stdin
+    #[arg(value_name = "PATH_OR_FILE")]
+    inputs: Vec<PathBuf>,
+
+    /// Filename used for diagnostics, config discovery, and yaml-files matching when reading stdin
+    #[arg(long = "stdin-filename", value_name = "FILE")]
+    stdin_filename: Option<PathBuf>,
+
+    /// Path to configuration file (YAML or TOML)
+    #[arg(short = 'c', long = "config-file", value_name = "FILE")]
+    config_file: Option<PathBuf>,
+
+    /// Inline configuration data (yaml)
+    #[arg(short = 'd', long = "config-data", value_name = "YAML")]
+    config_data: Option<String>,
+
+    /// Output format (auto, standard, colored, github, parsable, junit, gitlab). Repeatable:
+    /// each `--format` may be followed by an `--output-file` to send that format to a file,
+    /// so console and report artifacts can be produced together.
+    #[arg(short = 'f', long = "format", value_enum)]
+    format: Vec<CliFormat>,
+
+    /// Destination for the preceding `--format` (a path, or `-` for stdout). Repeatable;
+    /// each binds to the most recent `--format`. Default stream otherwise: stderr for the
+    /// console formats, stdout for junit/gitlab.
+    #[arg(
+        short = 'o',
+        long = "output-file",
+        value_name = "FILE",
+        conflicts_with = "diff"
+    )]
+    output_file: Vec<PathBuf>,
+
+    #[command(flatten)]
+    lint: LintFlags,
 }
 
 #[derive(clap::Args, Debug, Default)]
@@ -470,7 +479,7 @@ fn default_destination(format: OutputFormat) -> Destination {
 /// the same `--format`.
 fn resolve_cli_targets(
     matches: &ArgMatches,
-    cli: &Cli,
+    args: &LintArgs,
 ) -> Result<Vec<OutputTarget>, String> {
     enum Occurrence {
         Format(OutputFormat),
@@ -478,13 +487,13 @@ fn resolve_cli_targets(
     }
     let mut occurrences: Vec<(usize, Occurrence)> = Vec::new();
     if let Some(indices) = matches.indices_of("format") {
-        for (index, format) in indices.zip(&cli.format) {
+        for (index, format) in indices.zip(&args.format) {
             occurrences
                 .push((index, Occurrence::Format(detect_output_format(*format))));
         }
     }
     if let Some(indices) = matches.indices_of("output_file") {
-        for (index, path) in indices.zip(&cli.output_file) {
+        for (index, path) in indices.zip(&args.output_file) {
             occurrences.push((index, Occurrence::Output(path.clone())));
         }
     }
@@ -530,10 +539,10 @@ fn resolve_cli_targets(
 /// Propagates a `--format`/`--output-file` pairing error from [`resolve_cli_targets`].
 fn resolve_targets(
     matches: &ArgMatches,
-    cli: &Cli,
+    args: &LintArgs,
     config_output: Option<&OutputTable>,
 ) -> Result<Vec<OutputTarget>, String> {
-    let cli_targets = resolve_cli_targets(matches, cli)?;
+    let cli_targets = resolve_cli_targets(matches, args)?;
     if !cli_targets.is_empty() {
         return Ok(cli_targets);
     }
@@ -960,9 +969,18 @@ fn main() -> ExitCode {
 }
 
 fn run_cli(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
-    #[cfg(feature = "lsp")]
-    if matches!(cli.command, Some(Commands::Server)) {
-        return Ok(ryl::lsp::run());
+    match &cli.command {
+        #[cfg(feature = "lsp")]
+        Some(Commands::Server) => return Ok(ryl::lsp::run()),
+        // `ryl check`: lint via the subcommand's own args/matches (the `--format`/`--output-file`
+        // indices `resolve_cli_targets` reads live in this nested `ArgMatches`, not the root's).
+        Some(Commands::Check(args)) => {
+            let sub = matches
+                .subcommand_matches("check")
+                .expect("check subcommand matches present");
+            return run_lint(args, sub);
+        }
+        None => {}
     }
 
     // A meta-action that ignores every other input/flag, like the schema-print flags below.
@@ -992,42 +1010,42 @@ fn run_cli(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
 
     // Output targets are resolved inside `run_lint`/`run_stdin_lint`, where the run's config
     // (and thus a TOML `[output]` fallback) is known; `matches` carries the arg indices.
-    run_lint(cli, matches)
+    run_lint(&cli.lint_args, matches)
 }
 
-fn run_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
+fn run_lint(args: &LintArgs, matches: &ArgMatches) -> Result<ExitCode, String> {
     let stdin_input = Path::new("-");
-    let has_stdin = cli.inputs.iter().any(|p| p.as_path() == stdin_input);
+    let has_stdin = args.inputs.iter().any(|p| p.as_path() == stdin_input);
     if has_stdin {
-        if cli.inputs.len() > 1 {
+        if args.inputs.len() > 1 {
             return Err(
                 "error: `-` (stdin) cannot be combined with other inputs".to_string()
             );
         }
-        if cli.lint.fix.fix {
+        if args.lint.fix.fix {
             return Err(
                 "error: `--fix` is not supported when reading from stdin".to_string()
             );
         }
-        return run_stdin_lint(cli, matches);
+        return run_stdin_lint(args, matches);
     }
 
-    if cli.stdin_filename.is_some() {
+    if args.stdin_filename.is_some() {
         return Err(
             "error: `--stdin-filename` only applies when reading from stdin (`-`)"
                 .to_string(),
         );
     }
 
-    if cli.inputs.is_empty() {
+    if args.inputs.is_empty() {
         return Err(
             "error: expected one or more paths (files and/or directories), or `-` for stdin"
                 .to_string(),
         );
     }
 
-    let mut global_cfg = build_global_cfg(&cli.inputs, cli)?;
-    if cli.lint.markdown
+    let mut global_cfg = build_global_cfg(&args.inputs, args)?;
+    if args.lint.markdown
         && let Some(ctx) = global_cfg.as_mut()
     {
         // Enable markdown once here so per-file clones inherit the built matcher.
@@ -1038,7 +1056,7 @@ fn run_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
             eprintln!("{}", sanitize_control(notice));
         }
     }
-    let inputs = &cli.inputs;
+    let inputs = &args.inputs;
 
     let (candidates, explicit_files) = gather_inputs(inputs);
 
@@ -1049,13 +1067,13 @@ fn run_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
         &candidates,
         &explicit_files,
         global_cfg.as_ref(),
-        cli.lint.markdown,
+        args.lint.markdown,
         &mut cache,
         &mut emitted_notices,
         &mut files,
     )?;
 
-    if cli.lint.compatibility.list_files {
+    if args.lint.compatibility.list_files {
         for (path, ..) in &files {
             println!("{}", sanitize_control(&path.display().to_string()));
         }
@@ -1065,13 +1083,13 @@ fn run_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
     // `--diff` has its own unified-diff output, so skip config `[output]`: a config report
     // target must not block it. An explicit CLI `--format junit|gitlab` still conflicts via
     // the CLI-derived targets `validate_targets` reads regardless.
-    let output_config = if cli.lint.fix.diff {
+    let output_config = if args.lint.fix.diff {
         None
     } else {
-        run_output_config(global_cfg.as_ref(), &cli.inputs, cli)?
+        run_output_config(global_cfg.as_ref(), &args.inputs, args)?
     };
-    let targets = resolve_targets(matches, cli, output_config.as_ref())?;
-    validate_targets(&targets, cli.lint.fix.diff)?;
+    let targets = resolve_targets(matches, args, output_config.as_ref())?;
+    validate_targets(&targets, args.lint.fix.diff)?;
     let targets = &targets;
 
     reject_input_collisions(targets, files.iter().map(|(path, ..)| path.as_path()))?;
@@ -1087,11 +1105,11 @@ fn run_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
         return Err(no_rules_error(config_found));
     }
 
-    if cli.lint.fix.diff {
+    if args.lint.fix.diff {
         return Ok(emit_diff(&diff_safe_fixes_for_files(&files)?));
     }
 
-    lint_and_exit(&files, cli, targets)
+    lint_and_exit(&files, args, targets)
 }
 
 /// Open destinations before `--fix` mutates anything (so an unopenable `--output-file` fails
@@ -1102,23 +1120,23 @@ fn run_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
 /// Returns an error if a file cannot be read/written or an output destination fails.
 fn lint_and_exit(
     files: &[(PathBuf, PathBuf, YamlLintConfig, SourceKind)],
-    cli: &Cli,
+    args: &LintArgs,
     targets: &[OutputTarget],
 ) -> Result<ExitCode, String> {
     let mut sinks = open_targets(targets)?;
 
-    let initial_problem_count = if cli.lint.fix.fix {
-        apply_fixes_reporting_skips(files, cli.lint.compatibility.no_warnings)?
+    let initial_problem_count = if args.lint.fix.fix {
+        apply_fixes_reporting_skips(files, args.lint.compatibility.no_warnings)?
     } else {
         0
     };
 
     let results = lint_files(files);
     let (summary, records) =
-        collect_records(files, results, cli.lint.compatibility.no_warnings);
+        collect_records(files, results, args.lint.compatibility.no_warnings);
     write_targets(targets, &mut sinks, &records)?;
 
-    if cli.lint.fix.fix && initial_problem_count > 0 {
+    if args.lint.fix.fix && initial_problem_count > 0 {
         eprintln!(
             "Found {} {} ({} fixed, {} remaining).",
             initial_problem_count,
@@ -1128,7 +1146,7 @@ fn lint_and_exit(
         );
     }
 
-    Ok(summary_to_exit(&summary, cli.lint.compatibility.strict))
+    Ok(summary_to_exit(&summary, args.lint.compatibility.strict))
 }
 
 /// Apply safe fixes in place and report any files skipped (they do not parse), returning the
@@ -1172,22 +1190,24 @@ fn eprint_skip_notice(path: &Path, problem: &LintProblem, action: &str) {
     );
 }
 
-fn run_stdin_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
-    let (path, base_dir, cfg, apply_yaml_files, config_found) = resolve_stdin_ctx(cli)?;
+fn run_stdin_lint(args: &LintArgs, matches: &ArgMatches) -> Result<ExitCode, String> {
+    let (path, base_dir, cfg, apply_yaml_files, config_found) =
+        resolve_stdin_ctx(args)?;
 
     // As in `run_lint`, `--diff` skips config `[output]` so a config report can't block it.
-    let config_output = if cli.lint.fix.diff {
+    let config_output = if args.lint.fix.diff {
         None
     } else {
         cfg.output()
     };
-    let targets = resolve_targets(matches, cli, config_output)?;
-    validate_targets(&targets, cli.lint.fix.diff)?;
+    let targets = resolve_targets(matches, args, config_output)?;
+    validate_targets(&targets, args.lint.fix.diff)?;
     let targets = &targets;
 
     reject_input_collisions(targets, std::iter::once(path.as_path()))?;
 
-    let Some(kind) = resolve_stdin_kind(cli, &cfg, &path, &base_dir, apply_yaml_files)?
+    let Some(kind) =
+        resolve_stdin_kind(args, &cfg, &path, &base_dir, apply_yaml_files)?
     else {
         // An ignored stdin filename is an empty input set: still emit a valid empty
         // report per target so CI artifact ingestion does not see a missing file.
@@ -1195,7 +1215,7 @@ fn run_stdin_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
         return Ok(ExitCode::SUCCESS);
     };
 
-    if cli.lint.compatibility.list_files {
+    if args.lint.compatibility.list_files {
         println!("{}", sanitize_control(&path.display().to_string()));
         return Ok(ExitCode::SUCCESS);
     }
@@ -1204,7 +1224,7 @@ fn run_stdin_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
         return Err(no_rules_error(config_found));
     }
 
-    if cli.lint.fix.diff {
+    if args.lint.fix.diff {
         return run_stdin_diff(&path, &base_dir, &cfg, kind);
     }
 
@@ -1215,16 +1235,16 @@ fn run_stdin_lint(cli: &Cli, matches: &ArgMatches) -> Result<ExitCode, String> {
 
     let mut sinks = open_targets(targets)?;
     let (summary, records) =
-        collect_records(&files, results, cli.lint.compatibility.no_warnings);
+        collect_records(&files, results, args.lint.compatibility.no_warnings);
     write_targets(targets, &mut sinks, &records)?;
-    Ok(summary_to_exit(&summary, cli.lint.compatibility.strict))
+    Ok(summary_to_exit(&summary, args.lint.compatibility.strict))
 }
 
 /// Resolve the source kind for stdin, or `None` to skip an ignored `--stdin-filename`.
 /// `--markdown` forces Markdown; with `--stdin-filename` the kind comes from `[files]` globs
 /// (no match is an error); without one the input is YAML.
 fn resolve_stdin_kind(
-    cli: &Cli,
+    args: &LintArgs,
     cfg: &YamlLintConfig,
     path: &Path,
     base_dir: &Path,
@@ -1233,7 +1253,7 @@ fn resolve_stdin_kind(
     if apply_yaml_files && cfg.is_file_ignored(path, base_dir) {
         return Ok(None);
     }
-    if cli.lint.markdown {
+    if args.lint.markdown {
         return Ok(Some(SourceKind::Markdown));
     }
     if !apply_yaml_files {
@@ -1317,9 +1337,9 @@ fn emit_diff(stats: &DiffStats) -> ExitCode {
 }
 
 fn resolve_stdin_ctx(
-    cli: &Cli,
+    args: &LintArgs,
 ) -> Result<(PathBuf, PathBuf, YamlLintConfig, bool, bool), String> {
-    let (path, apply_yaml_files) = match cli.stdin_filename.clone() {
+    let (path, apply_yaml_files) = match args.stdin_filename.clone() {
         Some(name) => (name, true),
         None => (PathBuf::from(STDIN_LABEL), false),
     };
@@ -1328,12 +1348,12 @@ fn resolve_stdin_ctx(
     } else {
         PathBuf::from(".")
     };
-    let ctx = discover_config(std::slice::from_ref(&anchor), &cli_overrides(cli))?;
+    let ctx = discover_config(std::slice::from_ref(&anchor), &cli_overrides(args))?;
     for notice in &ctx.notices {
         eprintln!("{}", sanitize_control(notice.as_str()));
     }
     let mut cfg = ctx.config;
-    if cli.lint.markdown {
+    if args.lint.markdown {
         cfg.enable_default_markdown(&ctx.base_dir);
     }
     if !apply_yaml_files {

--- a/tests/cli_check_subcommand.rs
+++ b/tests/cli_check_subcommand.rs
@@ -1,5 +1,5 @@
-//! `ryl check <paths>` must be byte-for-byte equivalent to the bare `ryl <paths>` lint form
-//! (#369): same diagnostics, exit codes, `--fix`/`--diff`/`--list-files`/stdin behaviour, and
+//! `ryl check <paths>` must be byte-for-byte equivalent to the bare `ryl <paths>` lint form:
+//! same diagnostics, exit codes, `--fix`/`--diff`/`--list-files`/stdin behaviour, and
 //! `--format`/`--output-file` handling. The bare form keeps working with no deprecation warning
 //! this slice. Parity tests run the same args both ways and assert identical output.
 

--- a/tests/cli_check_subcommand.rs
+++ b/tests/cli_check_subcommand.rs
@@ -1,0 +1,253 @@
+//! `ryl check <paths>` must be byte-for-byte equivalent to the bare `ryl <paths>` lint form
+//! (#369): same diagnostics, exit codes, `--fix`/`--diff`/`--list-files`/stdin behaviour, and
+//! `--format`/`--output-file` handling. The bare form keeps working with no deprecation warning
+//! this slice. Parity tests run the same args both ways and assert identical output.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tempfile::tempdir;
+
+mod common;
+use common::cli::{command_output, run, ryl};
+
+/// A yamllint-compatible YAML config (carried via `-d`, so config discovery is bypassed and the
+/// tests need no `HOME` isolation) enabling one deterministic error-level rule.
+const CFG: &str = "rules: {trailing-spaces: enable}";
+
+fn exe() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ryl"))
+}
+
+/// Run identical lint args bare and under `check`, asserting both yield the same
+/// `(exit code, stdout, stderr)`. Returns the shared result for further assertions.
+fn assert_parity(home: &Path, args: &[&str]) -> (i32, String, String) {
+    let bare = run(ryl(home).args(args));
+    let mut checked_args = vec!["check"];
+    checked_args.extend_from_slice(args);
+    let checked = run(ryl(home).args(&checked_args));
+    assert_eq!(
+        bare, checked,
+        "`ryl {args:?}` and `ryl check {args:?}` must be identical"
+    );
+    bare
+}
+
+fn run_with_stdin(cmd: &mut Command, input: &[u8]) -> (i32, String, String) {
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ryl");
+    if let Err(error) = child.stdin.as_mut().expect("stdin").write_all(input) {
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe, "{error}");
+    }
+    let out = child.wait_with_output().expect("wait");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+#[test]
+fn check_matches_bare_on_clean_file() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ok.yaml");
+    fs::write(&file, "a: 1\n").unwrap();
+    let (code, stdout, stderr) =
+        assert_parity(dir.path(), &["-d", CFG, file.to_str().unwrap()]);
+    assert_eq!(code, 0, "clean file should pass");
+    assert!(stdout.is_empty() && stderr.is_empty(), "no diagnostics");
+}
+
+#[test]
+fn check_matches_bare_on_violations() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("bad.yaml");
+    fs::write(&file, "a: 1 \n").unwrap();
+    let (code, stdout, stderr) =
+        assert_parity(dir.path(), &["-d", CFG, file.to_str().unwrap()]);
+    assert_eq!(code, 1, "trailing space is an error");
+    let out = command_output(&stdout, &stderr);
+    assert!(out.contains("1:5"), "expected line:col 1:5: {out}");
+    assert!(out.contains("trailing-spaces"), "expected rule id: {out}");
+}
+
+#[test]
+fn check_matches_bare_on_list_files() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ok.yaml");
+    fs::write(&file, "a: 1\n").unwrap();
+    let (code, stdout, _) = assert_parity(
+        dir.path(),
+        &["-d", CFG, "--list-files", file.to_str().unwrap()],
+    );
+    assert_eq!(code, 0);
+    assert!(stdout.contains("ok.yaml"), "listed file: {stdout}");
+}
+
+#[test]
+fn check_matches_bare_on_diff_without_mutating() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("bad.yaml");
+    fs::write(&file, "a: 1 \n").unwrap();
+    let (code, stdout, _) =
+        assert_parity(dir.path(), &["-d", CFG, "--diff", file.to_str().unwrap()]);
+    assert_eq!(code, 1, "a file would change");
+    assert!(
+        stdout.contains("-a: 1 ") && stdout.contains("+a: 1"),
+        "unified diff body: {stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "a: 1 \n",
+        "--diff must not write"
+    );
+}
+
+/// The load-bearing case: `--format`/`--output-file` order is recovered from clap arg indices,
+/// which under `check` live in the subcommand's `ArgMatches`, not the root's. A console + a
+/// gitlab report file in one run must come out identical for both invocation forms.
+#[test]
+fn check_matches_bare_on_multi_format_outputs() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("bad.yaml");
+    fs::write(&file, "a: 1 \n").unwrap();
+    let bare_report = dir.path().join("bare.json");
+    let check_report = dir.path().join("check.json");
+
+    let bare = run(ryl(dir.path()).args([
+        "-d",
+        CFG,
+        "--format",
+        "auto",
+        "--format",
+        "gitlab",
+        "-o",
+        bare_report.to_str().unwrap(),
+        file.to_str().unwrap(),
+    ]));
+    let checked = run(ryl(dir.path()).args([
+        "check",
+        "-d",
+        CFG,
+        "--format",
+        "auto",
+        "--format",
+        "gitlab",
+        "-o",
+        check_report.to_str().unwrap(),
+        file.to_str().unwrap(),
+    ]));
+    assert_eq!(bare, checked, "console output must match");
+    assert_eq!(
+        fs::read_to_string(&bare_report).unwrap(),
+        fs::read_to_string(&check_report).unwrap(),
+        "gitlab report must match"
+    );
+}
+
+#[test]
+fn check_fix_matches_bare_fix() {
+    let dir = tempdir().unwrap();
+    let bare_file = dir.path().join("bare.yaml");
+    let check_file = dir.path().join("check.yaml");
+    fs::write(&bare_file, "a: 1 \n").unwrap();
+    fs::write(&check_file, "a: 1 \n").unwrap();
+
+    let (bare_code, _bo, bare_err) =
+        run(ryl(dir.path()).args(["-d", CFG, "--fix", bare_file.to_str().unwrap()]));
+    let (check_code, _co, check_err) = run(ryl(dir.path()).args([
+        "check",
+        "-d",
+        CFG,
+        "--fix",
+        check_file.to_str().unwrap(),
+    ]));
+
+    assert_eq!(bare_code, check_code, "fix exit codes match");
+    assert_eq!(bare_err, check_err, "fix summary matches");
+    assert_eq!(
+        fs::read_to_string(&check_file).unwrap(),
+        "a: 1\n",
+        "check --fix removed the trailing space"
+    );
+    assert_eq!(
+        fs::read_to_string(&bare_file).unwrap(),
+        fs::read_to_string(&check_file).unwrap(),
+        "both forms wrote identical content"
+    );
+}
+
+#[test]
+fn check_matches_bare_on_stdin() {
+    let bare = run_with_stdin(exe().arg("-").args(["-d", CFG]), b"a: 1 \n");
+    let checked =
+        run_with_stdin(exe().arg("check").arg("-").args(["-d", CFG]), b"a: 1 \n");
+    assert_eq!(bare, checked, "stdin lint parity");
+}
+
+#[test]
+fn check_matches_bare_on_stdin_filename() {
+    let stdin_args = ["--stdin-filename", "embedded.yaml", "-d", CFG];
+    let bare = run_with_stdin(exe().arg("-").args(stdin_args), b"a: 1 \n");
+    let checked =
+        run_with_stdin(exe().arg("check").arg("-").args(stdin_args), b"a: 1 \n");
+    assert_eq!(bare, checked, "stdin-filename parity");
+    let (_, stdout, stderr) = bare;
+    assert!(
+        command_output(&stdout, &stderr).contains("embedded.yaml"),
+        "label uses the stdin filename"
+    );
+}
+
+#[test]
+fn check_help_lists_every_lint_flag() {
+    let (code, stdout, stderr) = run(exe().args(["check", "--help"]));
+    assert_eq!(code, 0, "check --help should succeed: {stderr}");
+    for flag in [
+        "--fix",
+        "--diff",
+        "--list-files",
+        "--markdown",
+        "--strict",
+        "--no-warnings",
+        "--stdin-filename",
+        "--config-file",
+        "--config-data",
+        "--format",
+        "--output-file",
+    ] {
+        assert!(
+            stdout.contains(flag),
+            "check --help missing {flag}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn completions_include_check_subcommand() {
+    let (code, stdout, stderr) = run(exe().args(["--generate-completions", "bash"]));
+    assert_eq!(code, 0, "completions should succeed: {stderr}");
+    assert!(
+        stdout.contains("check"),
+        "completion script should mention the check subcommand: {stdout}"
+    );
+}
+
+#[test]
+fn bare_lint_emits_no_deprecation_warning() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("ok.yaml");
+    fs::write(&file, "a: 1\n").unwrap();
+    let (code, _stdout, stderr) =
+        run(ryl(dir.path()).args(["-d", CFG, file.to_str().unwrap()]));
+    assert_eq!(code, 0);
+    assert!(
+        stderr.is_empty(),
+        "bare ryl must stay silent this slice: {stderr}"
+    );
+}

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "ryl"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Introduce `ryl check` lint subcommand (additive, zero-break first step of #238)

Closes #369. **Releases 0.21.0** (minor bump: additive feature) so the
`ryl-pre-commit` companion (owenlamont/ryl-pre-commit#20) can pin a ryl that has
`ryl check`. Includes the lockstep version bump (Cargo.toml/pyproject/package.json +
Cargo.lock + uv.lock) and the refreshed benchmark image.

First concrete slice of the lint/format split (#238): land `ryl check` as the lint pass, **additively with no behaviour change and no warning**. Bare `ryl <paths>` keeps linting exactly as before (same flags, exit codes, output). Steering toward the new form is done through docs and release notes only; the deprecation warning and eventual removal are later siblings.

### Implementation
- Extract the lint CLI args into a `clap::Args` struct `LintArgs`, flattened both at the top level of `Cli` (bare-`ryl <paths>` compat) and into a new `Commands::Check(LintArgs)` variant.
- `Commands` is now always present (`Server` stays `lsp`-gated); `args_conflicts_with_subcommands` is unconditional.
- Dispatch routes `ryl check` through the **subcommand's** `ArgMatches`, so the repeatable `--format`/`--output-file` order recovery (`indices_of`) reads the correct scope. Bare and `check` feed the same `run_lint`, so behaviour is byte-for-byte identical.
- Meta-flags (`--migrate-*`, `--print-*-config-schema`, `--generate-completions`) stay top-level; shell completions include `check` automatically.

### Docs
- Flip the recommended lint form to `ryl check` everywhere (README, quickstart, migrating-from-yamllint, rule pages, `docs/` examples, agent skill), regenerate `llms*.txt`.
- Orientation notes in quickstart + README (CLI is moving to subcommands; bare still works but is being phased out → `ryl check`).
- Explicit `yamllint X → ryl check X` mapping note on the migrating page.

### Tests
- New `tests/cli_check_subcommand.rs`: parity across lint / `--fix` / `--diff` / `--list-files` / stdin (`-`/`--stdin-filename`) / multi-`--format`, plus `check --help` flag listing, completions include `check`, and bare emits no warning. Format-agnostic, discovery-isolated.

### Verification
- `prek run --all-files` green (stable)
- Full test suite + 11 new parity tests
- Both clippy `-D warnings` gates (default + `--no-default-features`)
- Coverage: zero uncovered regions

### Out of scope (deferred siblings under #238)
`ryl format`, `[lint]`/`[format]` config nesting, the deprecation warning on bare, and bare removal. The `ryl-pre-commit` companion is tracked at owenlamont/ryl-pre-commit#20.
