### PR TITLE
docs: dev-skill fixes surfaced by the 0.21.0 release (release + winget repro)

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -65,6 +65,18 @@ description: >-
   - `.github/workflows/release.yml` validates that the pushed tag version
     matches `Cargo.toml`, `pyproject.toml`, and `package.json` versions
     before release jobs run.
+  - **Transient network/download flakes recur (~every 2nd-3rd release), in no fixed
+    step.** Release runs have many download-heavy steps (macOS/Linux build jobs, the
+    cross-compile `cargo install cross`, crates.io fetches); one intermittently dies
+    on a network/SSL blip (e.g. `curl ... OpenSSL SSL_read: unexpected eof`, exit
+    101) — sometimes a macOS build, sometimes the aarch64-linux cross install. It is
+    not a real failure: a failed build/upload job gates and *skips* the
+    publish/finalize jobs, so nothing publishes and the tag stays intact. Re-run the
+    failed jobs with `gh run rerun <run-id> --failed` (also re-runs the skipped
+    downstream publish jobs); repeat if a different step flakes next time. A partial
+    durable fix for the most frequent culprit: pre-install `cross` from a prebuilt
+    binary (`taiki-e/install-action@cross`) so the flaky `cargo install cross` step
+    never runs.
 - After a successful release, `.github/workflows/sync-schemastore.yml` projects
   `ryl.toml.schema.json` into SchemaStore's draft-07 format, updates the user's
   SchemaStore fork, and prints a manual upstream PR handoff for

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -73,10 +73,7 @@ description: >-
     not a real failure: a failed build/upload job gates and *skips* the
     publish/finalize jobs, so nothing publishes and the tag stays intact. Re-run the
     failed jobs with `gh run rerun <run-id> --failed` (also re-runs the skipped
-    downstream publish jobs); repeat if a different step flakes next time. A partial
-    durable fix for the most frequent culprit: pre-install `cross` from a prebuilt
-    binary (`taiki-e/install-action@cross`) so the flaky `cargo install cross` step
-    never runs.
+    downstream publish jobs); repeat if a different step flakes next time.
 - After a successful release, `.github/workflows/sync-schemastore.yml` projects
   `ryl.toml.schema.json` into SchemaStore's draft-07 format, updates the user's
   SchemaStore fork, and prints a manual upstream PR handoff for

--- a/.agents/skills/winget-defender-fp/SKILL.md
+++ b/.agents/skills/winget-defender-fp/SKILL.md
@@ -50,19 +50,31 @@ it is the key datum for the PR reply):
 
 ```powershell
 $u = "https://github.com/owenlamont/ryl/releases/download/vX.Y.Z/ryl-x86_64-pc-windows-msvc.zip"
-try { Invoke-WebRequest $u -OutFile "$env:TEMP\ryl-check.zip" -ErrorAction Stop; "OK" }
-catch { "BLOCKED: $($_.Exception.Message)" }   # a block/quarantine == reproduced
-Start-MpScan -ScanType CustomScan -ScanPath "$env:TEMP\ryl-check.zip"
-Get-MpThreatDetection | Sort-Object InitialDetectionTime -Descending |
-  Select-Object -First 3 InitialDetectionTime, Resources
+$zip = "$env:TEMP\ryl-check.zip"
+Invoke-WebRequest $u -OutFile $zip
+# Invoke-WebRequest does NOT set mark-of-the-web, so the heuristic that flags *downloaded*
+# zips never fires on an IWR file. Tag it Internet-zone (3) with the real source to mimic a
+# browser/winget download — without this the repro tests an unmarked file and proves nothing:
+Set-Content -Path $zip -Stream Zone.Identifier -Value "[ZoneTransfer]`r`nZoneId=3`r`nHostUrl=$u"
+Start-MpScan -ScanType CustomScan -ScanPath $zip   # file-at-rest scan; weaker than on-access
+# THIS run only — Get-MpThreatDetection is cumulative, so a stale hit from a prior version
+# reads as a current-version flag unless filtered by date:
+Get-MpThreatDetection | Where-Object { $_.InitialDetectionTime -ge (Get-Date).Date } |
+  Sort-Object InitialDetectionTime -Descending | Select-Object InitialDetectionTime, Resources
 (Get-MpComputerStatus).AntivirusSignatureVersion
 ```
 
+A clean `Start-MpScan` is reassuring but not conclusive: the `!ml`/`!cl` verdict is a
+cloud/ML call on the real-time on-access/download path, which a file-at-rest custom scan
+may not exercise — VirusTotal's Microsoft engine is the stronger corroboration.
+
 Cross-check **VirusTotal** — its Microsoft engine is the best proxy for the validator.
-Look up by hash first (`https://www.virustotal.com/gui/file/<sha256-lowercase>`);
-upload if absent. Check **all four** artifacts: both zips **and** the unzipped `.exe`s.
-The bare exe usually scans clean; only the MOTW download trips it. (VT's GUI is
-shadow-DOM heavy, so reading a verdict via DOM scraping needs shadow-root traversal.)
+Look up by hash first (`https://www.virustotal.com/gui/file/<sha256-lowercase>`); upload
+if absent (anonymous, no login wall; upload + scan ~30s each). Check **all four** artifacts:
+both zips **and** the unzipped `.exe`s — the bare exe usually scans clean; only the MOTW
+download trips it. VT's GUI is shadow-DOM heavy: walk shadow roots, read the `Microsoft`
+engine row, and rebuild the `n/NN` ratio from its DOM ancestors (no `positives`/`total`
+attribute); let the "analysing" state clear before reading the final ratio.
 
 ## Decide
 


### PR DESCRIPTION
Two dev-skill fixes surfaced while cutting the **v0.21.0** release.

## `release` skill — transient release-run flakes

The release run intermittently fails in a download-heavy step (~every 2nd-3rd release) on a
network/SSL blip (e.g. the `cargo install cross` crates.io fetch, or a macOS build) — never
the same step. Document that it is transient: a failed build/upload job gates and *skips*
the publish/finalize jobs, so nothing publishes and the tag stays intact. The fix is `gh run
rerun <run-id> --failed`. (Durable-fix ideas — retries, pre-installing `cross` — are tracked
separately in #372, not in the skill: skills document the current procedure, not future plans.)

## `winget-defender-fp` skill — local repro fixes

Driving the Windows Claude to vet the v0.21.0 Windows artifacts (all clean: Defender +
VirusTotal Microsoft engine Undetected across both zips and both `.exe`s) surfaced three
holes in the documented local Defender reproduction:

- **No mark-of-the-web.** `Invoke-WebRequest -OutFile` sets no `Zone.Identifier` ADS, so the
  repro tested an *unmarked* file the MOTW heuristic can never flag. Now tags the download
  Internet-zone (`ZoneId=3`) with the real source, mimicking a browser/winget download.
- **Cumulative detection history.** `Get-MpThreatDetection | Select -First N` surfaces stale
  hits from prior versions (easily misread as a current-version flag). Now filters by date.
- **Weak scan vs. real trigger.** A file-at-rest `Start-MpScan` may not exercise the
  on-access/download cloud path that fires the `!ml`/`!cl` verdict, so VirusTotal's Microsoft
  engine is the stronger corroboration. Also tightened the VT shadow-DOM scraping guidance.

Docs-only (`.agents/skills/`); no behaviour or code changes.
