### PR TITLE
ci: reduce transient flakiness in the release workflow

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -65,15 +65,14 @@ description: >-
   - `.github/workflows/release.yml` validates that the pushed tag version
     matches `Cargo.toml`, `pyproject.toml`, and `package.json` versions
     before release jobs run.
-  - **Transient network/download flakes recur (~every 2nd-3rd release), in no fixed
-    step.** Release runs have many download-heavy steps (macOS/Linux build jobs, the
-    cross-compile `cargo install cross`, crates.io fetches); one intermittently dies
-    on a network/SSL blip (e.g. `curl ... OpenSSL SSL_read: unexpected eof`, exit
-    101) — sometimes a macOS build, sometimes the aarch64-linux cross install. It is
-    not a real failure: a failed build/upload job gates and *skips* the
-    publish/finalize jobs, so nothing publishes and the tag stays intact. Re-run the
-    failed jobs with `gh run rerun <run-id> --failed` (also re-runs the skipped
-    downstream publish jobs); repeat if a different step flakes next time.
+  - **Transient network/download flakes are now auto-retried in `release.yml`** (#372):
+    `CARGO_NET_RETRY` retries crates.io fetches, `cross` is pre-installed (no
+    `cargo install cross` crates.io hop), the QEMU manylinux/musllinux builds retry
+    once, and the smoke tests loop up to three attempts. A flake that survives all
+    those is rare. When one does, it is not a real failure: a failed build/upload job
+    gates and *skips* the publish/finalize jobs, so nothing publishes and the tag
+    stays intact. Re-run the failed jobs with `gh run rerun <run-id> --failed` (also
+    re-runs the skipped downstream publish jobs); repeat if a different step flakes.
 - After a successful release, `.github/workflows/sync-schemastore.yml` projects
   `ryl.toml.schema.json` into SchemaStore's draft-07 format, updates the user's
   SchemaStore fork, and prints a manual upstream PR handoff for

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
 permissions:
   contents: read
 
+# Retry transient crates.io fetches across the cargo build/publish steps so a
+# network blip does not fail the release run.
+env:
+  CARGO_NET_RETRY: "10"
+
 jobs:
   version-check:
     runs-on: ubuntu-latest
@@ -127,7 +132,18 @@ jobs:
         target: [x86_64, aarch64, armv7, i686, ppc64le, s390x]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      # QEMU-emulated manylinux builds flake transiently; retry once before failing.
       - name: Build manylinux wheels
+        id: build
+        continue-on-error: true
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          manylinux: auto
+          sccache: ${{ github.event_name != 'release' }}
+      - name: Build manylinux wheels (retry)
+        if: steps.build.outcome == 'failure'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
         with:
           target: ${{ matrix.target }}
@@ -161,10 +177,17 @@ jobs:
       - name: Install wheel and run CLI
         run: |-
           set -euxo pipefail
-          uv python install ${{ matrix.python }}
-          uv venv -p ${{ matrix.python }} .venv
-          uv pip install -p .venv --no-index --find-links dist ryl
-          uv run -p .venv ryl --version
+          for attempt in 1 2 3; do
+            if uv python install ${{ matrix.python }} \
+              && uv venv --clear -p ${{ matrix.python }} .venv \
+              && uv pip install -p .venv --no-index --find-links dist ryl \
+              && uv run -p .venv ryl --version; then
+              exit 0
+            fi
+            echo "Smoke attempt ${attempt} failed; retrying" >&2
+            if [ "${attempt}" -lt 3 ]; then sleep 10; fi
+          done
+          exit 1
 
   musllinux:
     needs: [version-check]
@@ -174,7 +197,18 @@ jobs:
         target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      # QEMU-emulated musllinux builds flake transiently; retry once before failing.
       - name: Build musllinux wheels
+        id: build
+        continue-on-error: true
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          manylinux: musllinux_1_2
+          sccache: ${{ github.event_name != 'release' }}
+      - name: Build musllinux wheels (retry)
+        if: steps.build.outcome == 'failure'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
         with:
           target: ${{ matrix.target }}
@@ -204,8 +238,15 @@ jobs:
       - name: Install wheel and run CLI in Alpine
         run: |-
           set -euxo pipefail
-          docker run --rm -v "$PWD/dist":/dist python:${{ matrix.python_image }} \
-            sh -euxc "python --version; python -m pip install --no-index --find-links /dist ryl; ryl --version"
+          for attempt in 1 2 3; do
+            if docker run --rm -v "$PWD/dist":/dist python:${{ matrix.python_image }} \
+              sh -euxc "python --version; python -m pip install --no-index --find-links /dist ryl; ryl --version"; then
+              exit 0
+            fi
+            echo "Smoke attempt ${attempt} failed; retrying" >&2
+            if [ "${attempt}" -lt 3 ]; then sleep 10; fi
+          done
+          exit 1
 
   windows:
     needs: [version-check]
@@ -249,10 +290,17 @@ jobs:
         shell: bash
         run: |-
           set -euxo pipefail
-          uv python install ${{ matrix.python }}
-          uv venv -p ${{ matrix.python }} .venv
-          uv pip install -p .venv --no-index --find-links dist ryl
-          uv run -p .venv ryl --version
+          for attempt in 1 2 3; do
+            if uv python install ${{ matrix.python }} \
+              && uv venv --clear -p ${{ matrix.python }} .venv \
+              && uv pip install -p .venv --no-index --find-links dist ryl \
+              && uv run -p .venv ryl --version; then
+              exit 0
+            fi
+            echo "Smoke attempt ${attempt} failed; retrying" >&2
+            if [ "${attempt}" -lt 3 ]; then sleep 10; fi
+          done
+          exit 1
 
   macos:
     needs: [version-check]
@@ -298,10 +346,17 @@ jobs:
       - name: Install wheel and run CLI
         run: |-
           set -euxo pipefail
-          uv python install ${{ matrix.python }}
-          uv venv -p ${{ matrix.python }} .venv
-          uv pip install -p .venv --no-index --find-links dist ryl
-          uv run -p .venv ryl --version
+          for attempt in 1 2 3; do
+            if uv python install ${{ matrix.python }} \
+              && uv venv --clear -p ${{ matrix.python }} .venv \
+              && uv pip install -p .venv --no-index --find-links dist ryl \
+              && uv run -p .venv ryl --version; then
+              exit 0
+            fi
+            echo "Smoke attempt ${attempt} failed; retrying" >&2
+            if [ "${attempt}" -lt 3 ]; then sleep 10; fi
+          done
+          exit 1
 
   sdist:
     needs: [version-check]
@@ -362,6 +417,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      # Pre-install a prebuilt cross so upload-rust-binary-action reuses it instead of
+      # running `cargo install cross`, whose crates.io fetch is a transient-failure point.
+      - name: Install cross
+        if: startsWith(matrix.runner, 'ubuntu')
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912
+        with:
+          tool: cross
       - name: Build binaries for ${{ matrix.target }}
         uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6
         with:


### PR DESCRIPTION
Closes #372.

Makes `release.yml` resilient to the transient network/runner flakes that have forced a manual rerun on ~6 of the last 30 releases. Native (no new action dependency), scoped to the spread of flake sites:

- **`CARGO_NET_RETRY: "10"`** top-level env — retries every crates.io fetch (`cargo publish`, the upload-rust-binary build, and the in-container maturin builds; maturin-action forwards `CARGO_*` into the QEMU container).
- **Pre-install `cross`** (prebuilt, via the already-pinned `taiki-e/install-action`) in `upload-release-binaries`, Ubuntu legs only — removes the v0.21.0 `cargo install cross` crates.io hop at the root (the action only runs `cargo install cross` when it is not already on PATH).
- **maturin build retry** on the QEMU-emulated `linux`/`musllinux` jobs (`continue-on-error` attempt + a copy gated on `if: steps.build.outcome == 'failure'`). The retry step is fail-fast, so the job still fails iff both attempts fail.
- **bash retry loop** (3 attempts, 10s backoff) in all four smoke jobs — covers the proven Windows-smoke flakes; `uv venv --clear` keeps the venv step idempotent across attempts (a bare `uv venv` exits 2 on an existing `.venv`, which would otherwise defeat the retry).

## Deliberately out of scope

- **SchemaStore sync** — its flake was the already-fixed stale-fork bug, not transient.
- **Native windows/macOS wheel builds** — never flaked at build; `CARGO_NET_RETRY` covers their only transient risk (fetches).
- **The upload-rust-binary build step** isn't separately retried — pre-installed cross + `CARGO_NET_RETRY` remove its one proven failure mode.

The `release` dev skill's rerun note is updated to reflect the auto-retry (manual `gh run rerun --failed` stays the rare-double-flake fallback).

CI resilience only — no ryl behavior change.
