### PR TITLE
fix: unblock CI audit and let the refresh bot push again

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -90,6 +90,9 @@ jobs:
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          # The wingetcreate step edits release.yml, and GitHub rejects an App push
+          # touching .github/workflows/ without this.
+          permission-workflows: write
 
       - name: Create PR with updated deps and linters
         if: steps.check_diff.outputs.changed == 'true'

--- a/uv.lock
+++ b/uv.lock
@@ -149,15 +149,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two small fixes that between them get the weekly dependency-refresh pipeline working again. The audit fix has to come first — `uv audit` currently fails on `main`, which blocks every commit and reddens every PR.

### 1. `pymdown-extensions` 10.21.3 → 11.0.1

`uv audit` fails on `main` today. The package arrives transitively via `zensical` (docs) and carries two advisories:

| Advisory | Severity | Issue |
| --- | --- | --- |
| GHSA-gm37-52c6-37mw | High | Exponential-backtracking ReDoS in the `caret`, `tilde`, `betterem` and `magiclink` inline processors |
| GHSA-9xwg-3r6f-jcx2 | Medium | Path traversal in the `b64` extension lets `<img src>` read outside `base_path` |

Both fixed in 11.0.1. Lockfile-only change.

### 2. `permission-workflows: write` on the refresh bot token

The **Update Dependencies and Linters** workflow has failed to push for three consecutive weeks — 2026-07-26, 08-02 and 08-09:

```
! [remote rejected] bot/update-deps-and-linters -> bot/update-deps-and-linters
  (refusing to allow a GitHub App to create or update workflow .github/workflows/...)
```

The `Bump pinned wingetcreate version` step edits `.github/workflows/release.yml`, but the token minted by `actions/create-github-app-token` requested only `permission-contents: write` and `permission-pull-requests: write`. GitHub rejects an App push that touches `.github/workflows/` without `workflows: write`.

That is why #398 has been frozen at its 2026-07-19 state.

> [!IMPORTANT]
> This change alone is not sufficient — the App installation also needs the **Workflows** repository permission granted in its settings. A token can only request permissions the installation already holds.

### Verification

`prek run --all-files` passes (`uv audit` included).