### PR TITLE
feat: migrate to granit-parser 1.1.0

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -90,6 +90,9 @@ jobs:
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          # The wingetcreate step edits release.yml, and GitHub rejects an App push
+          # touching .github/workflows/ without this.
+          permission-workflows: write
 
       - name: Create PR with updated deps and linters
         if: steps.check_diff.outputs.changed == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14668345710c92cb04181d9268407067689327d4b055273e3c4179a0777ee6a1"
+checksum = "4ccd1be9ebf2bd5520dbfcfb72b70ef492f654061299a097056f3e73410e38ec"
 dependencies = [
  "arraydeque",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ globset = "0.4.18"
 ignore = "0.4.25"
 rayon = "1.11.0"
 schemars = { version = "1.2.1", features = ["derive"] }
-granit-parser = "0.0.6"
+granit-parser = "1.1.0"
 hashlink = "0.12.0"
 ordered-float = "5"
 dirs-next = "2.0.0"

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -428,13 +428,6 @@ fn syntax_diagnostic(content: &str) -> Option<LintProblem> {
 /// find a malformed-token error the parser cannot reach, having halted on an earlier
 /// (tolerated) undefined alias.
 fn scanner_error(content: &str) -> Option<granit_parser::ScanError> {
-    let mut scanner =
-        granit_parser::Scanner::new(granit_parser::StrInput::new(content));
-    loop {
-        match scanner.next_token() {
-            Ok(Some(_)) => {}
-            Ok(None) => return None,
-            Err(err) => return Some(err),
-        }
-    }
+    granit_parser::Scanner::new(granit_parser::StrInput::new(content))
+        .find_map(Result::err)
 }

--- a/src/lsp/rename.rs
+++ b/src/lsp/rename.rs
@@ -23,8 +23,9 @@ struct Occurrence {
 fn occurrences(text: &str) -> Vec<Occurrence> {
     let mut occurrences = Vec::new();
     let mut document = 0usize;
-    for token in Scanner::new(StrInput::new(text)) {
-        let name = match token.1 {
+    for token in Scanner::new(StrInput::new(text)).map_while(Result::ok) {
+        let (span, token_type) = token.into_parts();
+        let name = match token_type {
             TokenType::DocumentStart | TokenType::DocumentEnd => {
                 document += 1;
                 continue;
@@ -35,7 +36,7 @@ fn occurrences(text: &str) -> Vec<Occurrence> {
         // granit's Anchor/Alias span starts at the `&`/`*` sigil (verified), hence `+ 1`.
         occurrences.push(Occurrence {
             name_len: name.chars().count(),
-            name_start: token.0.start.index() + 1,
+            name_start: span.start.index() + 1,
             name,
             document,
         });

--- a/src/rules/anchors.rs
+++ b/src/rules/anchors.rs
@@ -106,9 +106,9 @@ pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
     let mut doc = DocState::new();
     let mut violations = Vec::new();
 
-    for token in Scanner::new(StrInput::new(buffer)) {
-        let span = token.0;
-        match token.1 {
+    for token in Scanner::new(StrInput::new(buffer)).map_while(Result::ok) {
+        let (span, token_type) = token.into_parts();
+        match token_type {
             TokenType::DocumentStart | TokenType::DocumentEnd => {
                 finish_doc(&doc, *cfg, &mut violations);
                 doc = DocState::new();

--- a/src/rules/block_scalar_chomping.rs
+++ b/src/rules/block_scalar_chomping.rs
@@ -36,8 +36,9 @@ pub fn check(buffer: &str) -> Vec<Violation> {
     let lines = line_contents(buffer);
     let mut violations = Vec::new();
 
-    for token in Scanner::new(StrInput::new(buffer)) {
-        let TokenType::Scalar(style, value) = token.1 else {
+    for token in Scanner::new(StrInput::new(buffer)).map_while(Result::ok) {
+        let (span, token_type) = token.into_parts();
+        let TokenType::Scalar(style, value) = token_type else {
             continue;
         };
         if !matches!(style, ScalarStyle::Literal | ScalarStyle::Folded) {
@@ -46,8 +47,8 @@ pub fn check(buffer: &str) -> Vec<Violation> {
 
         let (header_line, header_text, marker_idx) = header_marker(
             &lines,
-            token.0.start.line(),
-            token.0.start.col(),
+            span.start.line(),
+            span.start.col(),
             value.chars().all(|ch| matches!(ch, '\n' | '\r')),
         );
         // `marker_idx` is the byte offset of the single-byte `|`/`>`; the column counts

--- a/src/rules/document_end.rs
+++ b/src/rules/document_end.rs
@@ -9,22 +9,30 @@ use granit_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
 use crate::rules::support::line_syntax::{buffer_newline, line_contents};
-use crate::rules::support::span_utils::{byte_slice, marker_byte_offset};
+use crate::rules::support::span_utils::{BytePos, marker_byte_offset};
 
 pub const ID: &str = "document-end";
 pub const MISSING_MESSAGE: &str = "missing document end \"...\"";
 pub const FORBIDDEN_MESSAGE: &str = "found forbidden document end \"...\"";
 
-#[must_use]
-pub fn classify_document_end_marker_bytes(bytes: &[u8]) -> Option<&'static str> {
-    let trimmed = trim_ascii(bytes);
-    if trimmed == b"..." {
-        Some("...")
-    } else if trimmed == b"---" {
-        Some("---")
-    } else {
-        None
-    }
+/// The line of the next document's `---` when one opens at `offset`. granit points a
+/// zero-width document end either at the marker or at the break before it, so the skip
+/// is also what makes `line` the marker's rather than the point's. An explicit `...`
+/// always arrives spanned, so only `---` reaches here. Content must be separated from
+/// the marker (YAML 1.2.2 rule 203), so `--- foo` opens a document but `---foo` is a
+/// plain scalar.
+fn next_document_marker_line(
+    source: &str,
+    offset: BytePos,
+    line: usize,
+) -> Option<usize> {
+    let rest = source.get(offset.get()..).unwrap_or_default();
+    let marker = rest.trim_start_matches([' ', '\t', '\r', '\n']);
+    let opens_document = marker.strip_prefix("---").is_some_and(|tail| {
+        tail.is_empty() || tail.starts_with([' ', '\t', '\r', '\n'])
+    });
+    let skipped = rest.len() - marker.len();
+    opens_document.then(|| line + rest[..skipped].matches('\n').count())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -61,7 +69,11 @@ pub struct Violation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Marker {
     ExplicitEnd,
-    DocumentStart,
+    /// Carries the marker's own line, which is not the event's where granit points the
+    /// zero-width end at the break before the marker.
+    DocumentStart {
+        line: usize,
+    },
     Other,
 }
 
@@ -152,10 +164,10 @@ impl<'src, 'cfg> DocumentEndReceiver<'src, 'cfg> {
             Marker::ExplicitEnd => {
                 self.pending_stream_end_violation = false;
             }
-            Marker::DocumentStart => {
+            Marker::DocumentStart { line } => {
                 self.pending_stream_end_violation = false;
                 self.violations.push(Violation {
-                    line: span.start.line(),
+                    line,
                     column: 1,
                     message: MISSING_MESSAGE.to_string(),
                 });
@@ -183,18 +195,13 @@ impl<'src, 'cfg> DocumentEndReceiver<'src, 'cfg> {
 
     fn marker(&self, span: Span) -> Marker {
         let start = marker_byte_offset(span.start);
-        let end = marker_byte_offset(span.end);
-        let slice = if start < end {
-            byte_slice(self.source, start..end).as_bytes()
-        } else {
-            &[]
-        };
-
-        match classify_document_end_marker_bytes(slice) {
-            Some("...") => Marker::ExplicitEnd,
-            Some("---") => Marker::DocumentStart,
-            _ => Marker::Other,
+        // granit spans the explicit `...` and nothing else, reporting an implicit end
+        // as a zero-width point that carries no marker text to inspect.
+        if start < marker_byte_offset(span.end) {
+            return Marker::ExplicitEnd;
         }
+        next_document_marker_line(self.source, start, span.start.line())
+            .map_or(Marker::Other, |line| Marker::DocumentStart { line })
     }
 }
 
@@ -206,18 +213,4 @@ impl SpannedEventReceiver<'_> for DocumentEndReceiver<'_, '_> {
             _ => {}
         }
     }
-}
-
-fn trim_ascii(bytes: &[u8]) -> &[u8] {
-    let mut start = 0usize;
-    let mut end = bytes.len();
-
-    while start < end && bytes[start].is_ascii_whitespace() {
-        start += 1;
-    }
-    while start < end && bytes[end - 1].is_ascii_whitespace() {
-        end -= 1;
-    }
-
-    &bytes[start..end]
 }

--- a/src/rules/document_start.rs
+++ b/src/rules/document_start.rs
@@ -113,7 +113,7 @@ impl<'cfg> DocumentStartReceiver<'cfg> {
 
 impl SpannedEventReceiver<'_> for DocumentStartReceiver<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
-        if let Event::DocumentStart(explicit) = event {
+        if let Event::DocumentStart(explicit, _) = event {
             if self.config.requires_marker() {
                 if !explicit {
                     self.violations.push(Violation {

--- a/src/rules/empty_values.rs
+++ b/src/rules/empty_values.rs
@@ -231,7 +231,7 @@ impl SpannedEventReceiver<'_> for EmptyValuesReceiver<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart
-            | Event::DocumentStart(_)
+            | Event::DocumentStart(..)
             | Event::StreamEnd
             | Event::DocumentEnd => {
                 self.reset();
@@ -254,17 +254,7 @@ impl SpannedEventReceiver<'_> for EmptyValuesReceiver<'_> {
             Event::Alias(_) => {
                 self.begin_node();
             }
-            Event::Comment(_, _) | Event::Nothing => {}
+            _ => {}
         }
     }
-}
-
-#[allow(dead_code)]
-pub fn coverage_touch_nothing_branch() {
-    use granit_parser::{Marker, Span};
-
-    let cfg_struct = crate::config::YamlLintConfig::default();
-    let config = Config::resolve(&cfg_struct);
-    let mut receiver = EmptyValuesReceiver::new(&config);
-    receiver.on_event(Event::Nothing, Span::empty(Marker::default()));
 }

--- a/src/rules/hyphens.rs
+++ b/src/rules/hyphens.rs
@@ -161,21 +161,20 @@ fn collect_dash_on_own_line(buffer: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut dash_line: Option<usize> = None;
 
-    for token in Scanner::new(StrInput::new(buffer)) {
-        match token.1 {
+    for token in Scanner::new(StrInput::new(buffer)).map_while(Result::ok) {
+        let (span, token_type) = token.into_parts();
+        match token_type {
             TokenType::BlockEntry => {
                 let (line, _) =
-                    line_and_column(&line_starts, CharPos::new(token.0.start.index()));
+                    line_and_column(&line_starts, CharPos::new(span.start.index()));
                 dash_line = Some(line);
             }
             // Node properties decorate the entry's value without ending the dash.
             TokenType::Anchor(_) | TokenType::Tag(..) | TokenType::Comment(_) => {}
             TokenType::BlockMappingStart => {
                 if let Some(dash) = dash_line.take() {
-                    let (line, column) = line_and_column(
-                        &line_starts,
-                        CharPos::new(token.0.start.index()),
-                    );
+                    let (line, column) =
+                        line_and_column(&line_starts, CharPos::new(span.start.index()));
                     if line == dash {
                         violations.push(Violation {
                             line,

--- a/src/rules/key_duplicates.rs
+++ b/src/rules/key_duplicates.rs
@@ -283,7 +283,7 @@ impl<'cfg> KeyDuplicatesReceiver<'cfg> {
 impl SpannedEventReceiver<'_> for KeyDuplicatesReceiver<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
-            Event::StreamStart | Event::DocumentStart(_) | Event::DocumentEnd => {
+            Event::StreamStart | Event::DocumentStart(..) | Event::DocumentEnd => {
                 self.state.reset();
             }
             Event::SequenceStart(_, anchor_id, ref tag) => {
@@ -304,7 +304,7 @@ impl SpannedEventReceiver<'_> for KeyDuplicatesReceiver<'_> {
                 );
             }
             Event::Alias(anchor_id) => self.state.handle_alias(anchor_id),
-            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
+            _ => {}
         }
     }
 }

--- a/src/rules/key_ordering.rs
+++ b/src/rules/key_ordering.rs
@@ -150,7 +150,7 @@ impl SpannedEventReceiver<'_> for KeyOrderingReceiver<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart => self.state.reset_stream(),
-            Event::DocumentStart(_) => self.state.document_start(),
+            Event::DocumentStart(..) => self.state.document_start(),
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(_, _, _) => self.state.enter_sequence(),
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
@@ -160,7 +160,7 @@ impl SpannedEventReceiver<'_> for KeyOrderingReceiver<'_> {
                     .handle_scalar(value.as_ref(), span, &mut self.violations);
             }
             Event::Alias(_) => self.state.skip_node(),
-            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
+            _ => {}
         }
     }
 }

--- a/src/rules/line_length.rs
+++ b/src/rules/line_length.rs
@@ -202,15 +202,7 @@ impl SpannedEventReceiver<'_> for InlineMappingDetector<'_> {
             }
             Event::Scalar(_, _, _, _) if self.mappings.is_empty() => {}
             Event::Scalar(_, _, _, _) => self.handle_scalar_event(span),
-            Event::SequenceStart(_, _, _)
-            | Event::SequenceEnd
-            | Event::StreamStart
-            | Event::StreamEnd
-            | Event::DocumentStart(_)
-            | Event::DocumentEnd
-            | Event::Alias(_)
-            | Event::Comment(_, _)
-            | Event::Nothing => {}
+            _ => {}
         }
     }
 }

--- a/src/rules/merge_keys.rs
+++ b/src/rules/merge_keys.rs
@@ -46,7 +46,7 @@ struct MergeKeysReceiver {
 impl SpannedEventReceiver<'_> for MergeKeysReceiver {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
-            Event::StreamStart | Event::DocumentStart(_) | Event::DocumentEnd => {
+            Event::StreamStart | Event::DocumentStart(..) | Event::DocumentEnd => {
                 self.walker.reset();
             }
             Event::MappingStart(..) => self.walker.enter_mapping((), ()),
@@ -66,7 +66,7 @@ impl SpannedEventReceiver<'_> for MergeKeysReceiver {
                 self.walker.finish_node(context);
             }
             Event::Alias(_) => self.walker.skip_node(),
-            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
+            _ => {}
         }
     }
 }

--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -217,7 +217,7 @@ impl SpannedEventReceiver<'_> for QuotedStringsReceiver<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart => self.state.reset_stream(),
-            Event::DocumentStart(_) => self.state.document_start(span),
+            Event::DocumentStart(..) => self.state.document_start(span),
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(style, _, _) => {
                 self.state.enter_sequence(style == StructureStyle::Flow);
@@ -236,7 +236,7 @@ impl SpannedEventReceiver<'_> for QuotedStringsReceiver<'_> {
                 );
             }
             Event::Alias(_) => self.state.skip_node(),
-            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
+            _ => {}
         }
     }
 }
@@ -802,7 +802,7 @@ impl SpannedEventReceiver<'_> for ConsistentQuoteStyleFinder<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart => self.state.reset_stream(),
-            Event::DocumentStart(_) => self.state.document_start(span),
+            Event::DocumentStart(..) => self.state.document_start(span),
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(style, _, _) => {
                 self.state.enter_sequence(style == StructureStyle::Flow);
@@ -820,7 +820,7 @@ impl SpannedEventReceiver<'_> for ConsistentQuoteStyleFinder<'_> {
                 );
             }
             Event::Alias(_) => self.state.skip_node(),
-            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
+            _ => {}
         }
     }
 }
@@ -854,7 +854,7 @@ impl SpannedEventReceiver<'_> for QuotedStringsFixer<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart => self.state.reset_stream(),
-            Event::DocumentStart(_) => self.state.document_start(span),
+            Event::DocumentStart(..) => self.state.document_start(span),
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(style, _, _) => {
                 self.state.enter_sequence(style == StructureStyle::Flow);
@@ -872,7 +872,7 @@ impl SpannedEventReceiver<'_> for QuotedStringsFixer<'_> {
                 }
             }
             Event::Alias(_) => self.state.skip_node(),
-            Event::Comment(_, _) | Event::StreamEnd | Event::Nothing => {}
+            _ => {}
         }
     }
 }

--- a/src/rules/support/comments_scan.rs
+++ b/src/rules/support/comments_scan.rs
@@ -1,4 +1,4 @@
-use granit_parser::{Event, Parser, Placement, Span};
+use granit_parser::{Placement, Scanner, Span, StrInput, TokenType};
 
 /// `text` is granit's raw payload (after the `#`, excluding the break); `span` covers
 /// the whole comment including the `#`; `placement` is `Right` for trailing comments.
@@ -8,31 +8,24 @@ pub(crate) struct CommentInfo {
     pub(crate) placement: Placement,
 }
 
-/// Recovers past parse errors so comments are still reported for documents that fail
-/// to parse cleanly.
+/// Scans rather than parses so comments are still reported for documents that fail to
+/// parse: the parser stops at its first error, but a parse error (an undefined alias,
+/// say) is not a lexical one, so the scanner tokenizes straight past it. Consumers only
+/// test for `Right`, so the scanner reporting an own-line comment as `Free` where the
+/// parser resolved it to `Above` makes no difference.
 pub(crate) fn collect_comments(buffer: &str) -> Vec<CommentInfo> {
-    let mut parser = Parser::new_from_str(buffer);
-    let mut comments = Vec::new();
-    let mut last_err_at: Option<usize> = None;
-    while let Some(res) = parser.next_event() {
-        match res {
-            Ok((Event::Comment(text, placement), span)) => {
-                comments.push(CommentInfo {
+    Scanner::new(StrInput::new(buffer))
+        .map_while(Result::ok)
+        .filter_map(|token| {
+            let (span, token_type) = token.into_parts();
+            match token_type {
+                TokenType::Comment(comment) => Some(CommentInfo {
                     span,
-                    text: text.into_owned(),
-                    placement,
-                });
-                last_err_at = None;
+                    placement: comment.placement(),
+                    text: comment.into_text().into_owned(),
+                }),
+                _ => None,
             }
-            Ok(_) => last_err_at = None,
-            Err(e) => {
-                let pos = e.marker().index();
-                if last_err_at == Some(pos) {
-                    break;
-                }
-                last_err_at = Some(pos);
-            }
-        }
-    }
-    comments
+        })
+        .collect()
 }

--- a/src/rules/support/merge_key.rs
+++ b/src/rules/support/merge_key.rs
@@ -22,8 +22,8 @@ pub(crate) fn is_merge_directive(
         // anywhere (YAML 1.2.2 6.8.2.2), so `!m!erge`, verbatim
         // `!<tag:yaml.org,2002:merge>`, and `!!merge` must all resolve alike.
         Some(tag) => MERGE_TAG
-            .strip_prefix(tag.handle.as_str())
-            .is_some_and(|suffix| suffix == tag.suffix.as_str()),
+            .strip_prefix(tag.handle())
+            .is_some_and(|suffix| suffix == tag.suffix()),
         None => value == "<<" && matches!(style, ScalarStyle::Plain),
     }
 }

--- a/src/rules/support/punctuation.rs
+++ b/src/rules/support/punctuation.rs
@@ -19,8 +19,9 @@ pub(crate) fn collect_scalar_ranges(buffer: &str) -> Vec<Range<CharPos>> {
 /// before an alias mapping key (`*foo : bar`).
 pub(crate) fn collect_alias_ends(buffer: &str) -> Vec<CharPos> {
     Scanner::new(StrInput::new(buffer))
-        .filter(|token| matches!(token.1, TokenType::Alias(_)))
-        .map(|token| CharPos::new(token.0.end.index()))
+        .map_while(Result::ok)
+        .filter(|token| matches!(token.token_type(), TokenType::Alias(_)))
+        .map(|token| CharPos::new(token.span().end.index()))
         .collect()
 }
 

--- a/src/rules/support/span_utils.rs
+++ b/src/rules/support/span_utils.rs
@@ -47,11 +47,6 @@ pub fn marker_byte_offset(marker: Marker) -> BytePos {
     )
 }
 
-#[must_use]
-pub fn byte_slice(buffer: &str, range: Range<BytePos>) -> &str {
-    &buffer[range.start.0..range.end.0]
-}
-
 /// The scalar range containing char index `idx`, if any, advancing `cursor` past
 /// ranges ending at or before it. Flow-rule scanners use this to skip scalar
 /// interiors; `cursor` persists across calls for one left-to-right scan.

--- a/src/rules/support/yaml_version.rs
+++ b/src/rules/support/yaml_version.rs
@@ -5,7 +5,7 @@
 
 use std::sync::LazyLock;
 
-use granit_parser::{Scanner, StrInput, Token, TokenType};
+use granit_parser::{Scanner, StrInput, TokenType};
 use regex::Regex;
 
 use crate::rules::support::span_utils::{BytePos, marker_byte_offset};
@@ -29,7 +29,8 @@ fn collect_directives(buffer: &str) -> Vec<Directive> {
     // The scanner reports a `%YAML` only where it is a real directive (not block-scalar
     // or plain-scalar text that happens to start with `%YAML`); it stops at the first
     // lexical error, after which no further directive can be reached anyway.
-    while let Ok(Some(Token(span, token_type))) = scanner.next_token() {
+    while let Some(Ok(token)) = scanner.next() {
+        let (span, token_type) = token.into_parts();
         if let TokenType::VersionDirective(major, minor) = token_type {
             directives.push(Directive {
                 offset: marker_byte_offset(span.start),

--- a/src/rules/tags.rs
+++ b/src/rules/tags.rs
@@ -70,7 +70,7 @@ impl Config {
         // The non-specific "!" tag carries no safety/portability signal. A `%TAG`
         // directive can resolve a non-empty handle onto it while leaving the suffix
         // "!", so key the exemption on the suffix, not the handle.
-        if tag.suffix == "!" {
+        if tag.suffix() == "!" {
             return None;
         }
         let core = core_schema_suffix(tag);
@@ -153,8 +153,8 @@ fn is_unsafe_suffix(suffix: &str) -> bool {
 fn unsafe_namespace<'a>(tag: &'a Tag, core: Option<&'a str>) -> Option<&'a str> {
     if let Some(core) = core {
         Some(core)
-    } else if tag.handle == "!" || tag.handle.is_empty() {
-        Some(tag.suffix.strip_prefix('!').unwrap_or(&tag.suffix))
+    } else if tag.handle() == "!" || tag.handle().is_empty() {
+        Some(tag.suffix().strip_prefix('!').unwrap_or(tag.suffix()))
     } else {
         None
     }

--- a/src/rules/truthy.rs
+++ b/src/rules/truthy.rs
@@ -276,7 +276,7 @@ impl SpannedEventReceiver<'_> for TruthyReceiver<'_> {
                 self.state.bad_truthy = None;
                 self.state.versions.reset();
             }
-            Event::DocumentStart(_) => self.state.document_start(span),
+            Event::DocumentStart(..) => self.state.document_start(span),
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(_, _, _) => self.state.enter_sequence(),
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
@@ -291,10 +291,7 @@ impl SpannedEventReceiver<'_> for TruthyReceiver<'_> {
                     &mut self.diagnostics,
                 );
             }
-            Event::Comment(_, _)
-            | Event::Alias(_)
-            | Event::StreamEnd
-            | Event::Nothing => {}
+            _ => {}
         }
     }
 }

--- a/src/yaml_dom/loader.rs
+++ b/src/yaml_dom/loader.rs
@@ -68,11 +68,6 @@ struct Loader {
 impl<'input> SpannedEventReceiver<'input> for Loader {
     fn on_event(&mut self, ev: Event<'input>, span: Span) {
         match ev {
-            Event::DocumentStart(_)
-            | Event::Nothing
-            | Event::StreamStart
-            | Event::StreamEnd
-            | Event::Comment(_, _) => {}
             Event::DocumentEnd => {
                 let node = self.root.take().unwrap_or(YamlOwned::BadValue);
                 self.docs.push(node);
@@ -141,6 +136,7 @@ impl<'input> SpannedEventReceiver<'input> for Loader {
                     self.attach(node, size);
                 }
             }
+            _ => {}
         }
     }
 }

--- a/src/yaml_dom/tag.rs
+++ b/src/yaml_dom/tag.rs
@@ -15,19 +15,19 @@ pub fn core_schema_suffix(tag: &Tag) -> Option<Cow<'_, str>> {
     // A tag resolves to `handle ++ suffix` (YAML 1.2.2 6.8.2.2) and a `%TAG` directive
     // can cut the URI at any point, so strip the prefix across the seam; otherwise a
     // split spelling could hide a type.
-    if let Some(head) = tag.handle.strip_prefix(CORE_SCHEMA_PREFIX) {
+    if let Some(head) = tag.handle().strip_prefix(CORE_SCHEMA_PREFIX) {
         // Handle holds the whole prefix; the type is its tail plus the suffix (only a
         // mid-token split leaves a non-empty tail).
         return Some(if head.is_empty() {
-            Cow::Borrowed(tag.suffix.as_str())
+            Cow::Borrowed(tag.suffix())
         } else {
-            Cow::Owned(format!("{head}{}", tag.suffix))
+            Cow::Owned(format!("{head}{}", tag.suffix()))
         });
     }
     // Handle stops inside the prefix; the suffix supplies the remainder.
     CORE_SCHEMA_PREFIX
-        .strip_prefix(tag.handle.as_str())
-        .and_then(|prefix_tail| tag.suffix.strip_prefix(prefix_tail))
+        .strip_prefix(tag.handle())
+        .and_then(|prefix_tail| tag.suffix().strip_prefix(prefix_tail))
         .map(Cow::Borrowed)
 }
 

--- a/tests/rule_document_end.rs
+++ b/tests/rule_document_end.rs
@@ -1,7 +1,4 @@
-use ryl::rules::document_end::{
-    self, Config, FORBIDDEN_MESSAGE, MISSING_MESSAGE,
-    classify_document_end_marker_bytes,
-};
+use ryl::rules::document_end::{self, Config, FORBIDDEN_MESSAGE, MISSING_MESSAGE};
 
 #[test]
 fn detects_end_marker_after_multibyte_comment() {
@@ -114,16 +111,4 @@ fn marker_with_inline_comment_is_allowed() {
         hits.is_empty(),
         "marker followed by comment should satisfy requirement: {hits:?}"
     );
-}
-
-#[test]
-fn classify_marker_bytes_trims_whitespace() {
-    assert_eq!(classify_document_end_marker_bytes(b"  ...   "), Some("..."));
-    assert_eq!(classify_document_end_marker_bytes(b"\t---\r"), Some("---"));
-}
-
-#[test]
-fn classify_marker_bytes_rejects_comments_and_empty() {
-    assert!(classify_document_end_marker_bytes(b"... # done").is_none());
-    assert!(classify_document_end_marker_bytes(b"").is_none());
 }

--- a/tests/rule_empty_values.rs
+++ b/tests/rule_empty_values.rs
@@ -97,11 +97,11 @@ fn handles_alias_nodes() {
 }
 
 #[test]
-fn clamps_tagged_empty_value_at_eof_into_bounds() {
-    // `a: !!str` is a tagged but empty value; granit positions the implicit
-    // scalar on a non-existent next line. Without a trailing newline the report
-    // must clamp onto the only real line, not overshoot to line 2 (found by the
-    // property-check fuzzer once it began synthesizing tags).
+fn reports_tagged_empty_value_at_eof_in_bounds() {
+    // `a: !!str` is a tagged but empty value with no trailing newline, so the report
+    // must land on the only real line (found by the property-check fuzzer once it
+    // began synthesizing tags). The column follows the untagged `a:` convention of
+    // pointing where the value would go, here past the tag.
     let yaml = "a: !!str";
     let cfg = resolve_config("rules:\n  empty-values: enable\n");
     let hits = empty_values::check(yaml, &cfg);
@@ -109,13 +109,8 @@ fn clamps_tagged_empty_value_at_eof_into_bounds() {
         hits,
         vec![Violation {
             line: 1,
-            column: 2,
+            column: 9,
             message: "empty value in block mapping".to_string(),
         }]
     );
-}
-
-#[test]
-fn covers_nothing_event_branch() {
-    empty_values::coverage_touch_nothing_branch();
 }

--- a/uv.lock
+++ b/uv.lock
@@ -149,15 +149,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #409. Dependabot proposed granit-parser **0.0.7**, which is five releases behind — 1.1.0 shipped 2026-08-15 — and whose only relevant change (the `Event::DocumentStart` arity) is a subset of this one. Closing #409 in favour of this is the suggestion.

> [!NOTE]
> Based on #411 because `uv audit` fails on `main` and blocks every commit. GitHub will retarget this to `main` once #411 merges.

## Mechanical API updates

| Change | Handling |
| --- | --- |
| `Event::DocumentStart` gained the `%YAML` version | `(..)`, or `(explicit, _)` where the flag is bound |
| `Event::Nothing` removed | Those no-op arms become the wildcard `Event` now needs as `#[non_exhaustive]` |
| `Tag` fields private | `handle`/`suffix` via accessors |
| `Scanner` is a fallible fused iterator | `.map_while(Result::ok)` preserves stop-at-first-lexical-error; `Token` read via `into_parts()` |
| `Scanner::next_token` private | `scanner_error` collapses to `find_map(Result::err)` |

## Three behaviour changes that needed real fixes

### `collect_comments` — comments after a parse error were silently dropped

The helper recovered past parse errors by continuing to pull events. The parser is now **fused**: it emits its error once and returns `None` for good. Probed directly:

```
0: Ok(StreamStart)   1: Ok(DocumentStart(false, None))   2: Ok(MappingStart)
3: Ok(Scalar("a"))   4: Err(@3)   5: None
```

So no comment after any parse error was reported — caught by `checks_comments_after_undeclared_anchor_alias`.

It now **scans rather than parses**. An undefined alias is a parse error, not a lexical one, so the scanner tokenizes straight past it and reaches the trailing `Comment`. Consumers only ever compare against `Right`, so the scanner reporting an own-line comment as `Free` where the parser resolved `Above` is immaterial (verified: spans and text are byte-identical between the two).

### `document-end` — every implicit end looked unmarked

The rule classified its marker from the text the `DocumentEnd` span covered. granit now spans **only** the explicit `...`; an implicit end is a zero-width point, sitting sometimes on the marker and sometimes on the break before it:

```
"---\na: 1\n---\nb: 2\n"  ->  DocumentEnd 9..9   rest="---\nb: 2"
"---\n---\n"              ->  DocumentEnd 3..3   rest="\n---\n"     <- points at the break
"---\na: 1\n...\n"        ->  DocumentEnd 9..12  (spanned)
```

Every implicit end therefore classified as unmarked, and `---\nfirst\n---\nsecond\n` lost a violation. The zero-width case now reads the source forward, skipping the break — which is also what recovers the marker's own line, fixing an off-by-one on `---\n---\n`.

Verified against **real yamllint** across twelve inputs — two/three documents, explicit end, `--- foo`, empty documents, blank lines between, comment between, CRLF, no trailing newline — **12/12 agree**.

The spanned branch collapses to `ExplicitEnd`, which retires `classify_document_end_marker_bytes`, `trim_ascii` and `byte_slice` as dead (coverage would otherwise fail on their unreachable arms).

### `empty-values` — column moves for a tagged empty value at EOF

`a: !!str` reported column 2. That was the clamp pulling back granit's old out-of-bounds position, not a chosen column; granit now positions the implicit scalar in bounds, giving **column 9**, consistent with the untagged `a:` convention of pointing where the value would go:

```
a:          ->  1:3
a: !!str    ->  1:9
```

yamllint reports nothing at all for this input, so there is no compatibility target either way. Flagging it as the one user-visible diagnostic change in this PR.

## Not done — worth its own issue

`Event::DocumentStart` now carries `Option<YamlVersion>` directly. `truthy` and `quoted_strings` currently get the same information from `DocumentVersions`, which runs a **second** token scan over the whole buffer and correlates directives to documents by byte offset. That machinery could be dropped in favour of the event field. `lint.rs`'s `first_unsupported_major`/`first_higher_minor` would keep the scan, since they need the directive's own position for their diagnostics. Left out as a separate change rather than folded in here.

## Verification

- `prek run --all-files` — exit 0
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --all-targets --no-default-features -- -D warnings` — clean
- `cargo nextest run --all-features` — **1749 passed, 0 skipped**
- `coverage-missing.py` — **no uncovered regions**
- `source_size.py` — **net −72 lines**