### PR TITLE
refactor: take the document's %YAML version from the DocumentStart event

### DIFF
--- a/src/rules/quoted_strings.rs
+++ b/src/rules/quoted_strings.rs
@@ -14,7 +14,7 @@ use crate::rules::support::span_utils::{
     BytePos, apply_replacements, marker_byte_offset,
 };
 use crate::rules::support::yaml_version::{
-    DocumentVersions, Version, keeps_quotes_under_yaml_1_1,
+    Version, event_version, keeps_quotes_under_yaml_1_1,
 };
 use crate::yaml_dom::{Scalar, is_core_schema};
 
@@ -217,7 +217,9 @@ impl SpannedEventReceiver<'_> for QuotedStringsReceiver<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart => self.state.reset_stream(),
-            Event::DocumentStart(..) => self.state.document_start(span),
+            Event::DocumentStart(_, version) => {
+                self.state.document_start(version.map(event_version));
+            }
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(style, _, _) => {
                 self.state.enter_sequence(style == StructureStyle::Flow);
@@ -246,7 +248,6 @@ struct QuotedStringsState<'cfg> {
     buffer: &'cfg str,
     walker: Walker<(), bool>,
     consistent_quote_style: Option<QuoteStyle>,
-    versions: DocumentVersions,
     current_version: Option<Version>,
 }
 
@@ -257,7 +258,6 @@ impl<'cfg> QuotedStringsState<'cfg> {
             buffer,
             walker: Walker::new(),
             consistent_quote_style: None,
-            versions: DocumentVersions::parse(buffer),
             current_version: None,
         }
     }
@@ -265,14 +265,12 @@ impl<'cfg> QuotedStringsState<'cfg> {
     fn reset_stream(&mut self) {
         self.walker.reset();
         self.consistent_quote_style = None;
-        self.versions.reset();
         self.current_version = None;
     }
 
-    fn document_start(&mut self, span: Span) {
+    fn document_start(&mut self, version: Option<Version>) {
         self.walker.reset();
-        self.current_version =
-            self.versions.next_document(marker_byte_offset(span.start));
+        self.current_version = version;
     }
 
     fn document_end(&mut self) {
@@ -802,7 +800,9 @@ impl SpannedEventReceiver<'_> for ConsistentQuoteStyleFinder<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart => self.state.reset_stream(),
-            Event::DocumentStart(..) => self.state.document_start(span),
+            Event::DocumentStart(_, version) => {
+                self.state.document_start(version.map(event_version));
+            }
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(style, _, _) => {
                 self.state.enter_sequence(style == StructureStyle::Flow);
@@ -854,7 +854,9 @@ impl SpannedEventReceiver<'_> for QuotedStringsFixer<'_> {
     fn on_event(&mut self, event: Event<'_>, span: Span) {
         match event {
             Event::StreamStart => self.state.reset_stream(),
-            Event::DocumentStart(..) => self.state.document_start(span),
+            Event::DocumentStart(_, version) => {
+                self.state.document_start(version.map(event_version));
+            }
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(style, _, _) => {
                 self.state.enter_sequence(style == StructureStyle::Flow);
@@ -883,7 +885,6 @@ struct FixState<'cfg> {
     walker: Walker<(), bool>,
     seeded_consistent_quote_style: Option<QuoteStyle>,
     consistent_quote_style: Option<QuoteStyle>,
-    versions: DocumentVersions,
     current_version: Option<Version>,
 }
 
@@ -903,7 +904,6 @@ impl<'cfg> FixState<'cfg> {
             walker: Walker::new(),
             seeded_consistent_quote_style: consistent_quote_style,
             consistent_quote_style,
-            versions: DocumentVersions::parse(buffer),
             current_version: None,
         }
     }
@@ -911,14 +911,12 @@ impl<'cfg> FixState<'cfg> {
     fn reset_stream(&mut self) {
         self.walker.reset();
         self.consistent_quote_style = self.seeded_consistent_quote_style;
-        self.versions.reset();
         self.current_version = None;
     }
 
-    fn document_start(&mut self, span: Span) {
+    fn document_start(&mut self, version: Option<Version>) {
         self.walker.reset();
-        self.current_version =
-            self.versions.next_document(marker_byte_offset(span.start));
+        self.current_version = version;
     }
 
     fn document_end(&mut self) {

--- a/src/rules/support/yaml_version.rs
+++ b/src/rules/support/yaml_version.rs
@@ -5,16 +5,20 @@
 
 use std::sync::LazyLock;
 
-use granit_parser::{Scanner, StrInput, TokenType};
+use granit_parser::{Scanner, StrInput, TokenType, YamlVersion};
 use regex::Regex;
-
-use crate::rules::support::span_utils::{BytePos, marker_byte_offset};
 
 pub type Version = (u32, u32);
 
+/// The `%YAML` version granit reports on `Event::DocumentStart`, which already resolves
+/// the directive to its document, so rules take it from the event rather than rescanning.
+#[must_use]
+pub const fn event_version(version: YamlVersion) -> Version {
+    (version.major, version.minor)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Directive {
-    pub offset: BytePos,
     pub line: usize,
     pub column: usize,
     pub version: Version,
@@ -33,7 +37,6 @@ fn collect_directives(buffer: &str) -> Vec<Directive> {
         let (span, token_type) = token.into_parts();
         if let TokenType::VersionDirective(major, minor) = token_type {
             directives.push(Directive {
-                offset: marker_byte_offset(span.start),
                 line: span.start.line(),
                 column: span.start.col() + 1,
                 version: (major, minor),
@@ -41,38 +44,6 @@ fn collect_directives(buffer: &str) -> Vec<Directive> {
         }
     }
     directives
-}
-
-/// The directive version in effect for each document, consumed in document order.
-#[derive(Debug)]
-pub struct DocumentVersions {
-    directives: Vec<Directive>,
-    index: usize,
-}
-
-impl DocumentVersions {
-    #[must_use]
-    pub fn parse(buffer: &str) -> Self {
-        Self {
-            directives: collect_directives(buffer),
-            index: 0,
-        }
-    }
-
-    pub const fn reset(&mut self) {
-        self.index = 0;
-    }
-
-    pub fn next_document(&mut self, doc_start: BytePos) -> Option<Version> {
-        let mut version = None;
-        while self.index < self.directives.len()
-            && self.directives[self.index].offset.get() < doc_start.get()
-        {
-            version = Some(self.directives[self.index].version);
-            self.index += 1;
-        }
-        version
-    }
 }
 
 /// Whether a scalar's quotes must be kept under the document's resolved version: only

--- a/src/rules/truthy.rs
+++ b/src/rules/truthy.rs
@@ -8,8 +8,7 @@ use std::collections::HashSet;
 use granit_parser::{Event, Parser, ScalarStyle, Span, SpannedEventReceiver};
 
 use crate::config::YamlLintConfig;
-use crate::rules::support::span_utils::marker_byte_offset;
-use crate::rules::support::yaml_version::DocumentVersions;
+use crate::rules::support::yaml_version::{Version, event_version};
 
 pub const ID: &str = "truthy";
 
@@ -105,28 +104,23 @@ struct TruthyState<'cfg> {
     config: &'cfg Config,
     containers: Vec<ContainerState>,
     key_depth: usize,
-    current_version: (u32, u32),
+    current_version: Version,
     bad_truthy: Option<HashSet<String>>,
-    versions: DocumentVersions,
 }
 
 impl<'cfg> TruthyState<'cfg> {
-    const fn new(config: &'cfg Config, versions: DocumentVersions) -> Self {
+    const fn new(config: &'cfg Config) -> Self {
         Self {
             config,
             containers: Vec::new(),
             key_depth: 0,
             current_version: (1, 1),
             bad_truthy: None,
-            versions,
         }
     }
 
-    fn document_start(&mut self, span: Span) {
-        self.current_version = self
-            .versions
-            .next_document(marker_byte_offset(span.start))
-            .unwrap_or((1, 1));
+    fn document_start(&mut self, version: Option<Version>) {
+        self.current_version = version.unwrap_or((1, 1));
         self.bad_truthy = None;
         self.key_depth = 0;
         self.containers.clear();
@@ -260,9 +254,9 @@ struct TruthyReceiver<'cfg> {
 
 #[allow(clippy::missing_const_for_fn)]
 impl<'cfg> TruthyReceiver<'cfg> {
-    fn new(cfg: &'cfg Config, versions: DocumentVersions) -> Self {
+    fn new(cfg: &'cfg Config) -> Self {
         Self {
-            state: TruthyState::new(cfg, versions),
+            state: TruthyState::new(cfg),
             diagnostics: Vec::new(),
         }
     }
@@ -274,9 +268,10 @@ impl SpannedEventReceiver<'_> for TruthyReceiver<'_> {
             Event::StreamStart => {
                 self.state.current_version = (1, 1);
                 self.state.bad_truthy = None;
-                self.state.versions.reset();
             }
-            Event::DocumentStart(..) => self.state.document_start(span),
+            Event::DocumentStart(_, version) => {
+                self.state.document_start(version.map(event_version));
+            }
             Event::DocumentEnd => self.state.document_end(),
             Event::SequenceStart(_, _, _) => self.state.enter_sequence(),
             Event::SequenceEnd | Event::MappingEnd => self.state.exit_container(),
@@ -298,9 +293,8 @@ impl SpannedEventReceiver<'_> for TruthyReceiver<'_> {
 
 #[must_use]
 pub fn check(buffer: &str, cfg: &Config) -> Vec<Violation> {
-    let versions = DocumentVersions::parse(buffer);
     let mut parser = Parser::new_from_str(buffer);
-    let mut receiver = TruthyReceiver::new(cfg, versions);
+    let mut receiver = TruthyReceiver::new(cfg);
     let _ = parser.load(&mut receiver, true);
     receiver.diagnostics
 }


### PR DESCRIPTION
The follow-up flagged in #413. granit 1.1.0 reports the `%YAML` version on `Event::DocumentStart`, already resolved to its document — which is exactly the fact `DocumentVersions` was reconstructing the hard way.

## What it replaces

`DocumentVersions` did a **second full token scan** of the buffer to collect every `%YAML` directive, then replayed them against each document's byte offset to decide which applied where:

```rust
pub fn next_document(&mut self, doc_start: BytePos) -> Option<Version> {
    let mut version = None;
    while self.index < self.directives.len()
        && self.directives[self.index].offset.get() < doc_start.get()
    { version = Some(self.directives[self.index].version); self.index += 1; }
    version
}
```

`truthy` and `quoted_strings` now read the version straight off the event, so the scan, the offset correlation and the replay cursor all go — along with the stream-reset bookkeeping, since there is no cursor left to rewind.

`collect_directives` **stays**: `first_unsupported_major` and `first_higher_minor` need each directive's own line and column to point a diagnostic at it, and the event does not carry that. `Directive::offset` goes with the correlation that used it.

## Behaviour is unchanged, and checked rather than asserted

I captured ryl's own output across ten version-sensitive inputs before the change and diffed it after — **byte-identical**:

| Case | Covers |
| --- | --- |
| no directive | the 1.1 default |
| `%YAML 1.0` / `1.1` / `1.2` | each resolved version |
| directive on the first of two documents | the version must **not** leak into document 2 |
| a directive on each document | independent per-document versions |
| three documents, middle one bare | the cursor-advance case |
| implicit document, directive-only, reset between | edge shapes |

The discriminating cases are the multi-document ones: `"on"` keeps its quotes under 1.1 but is flagged redundant under 1.2, so a version leaking across a document boundary would show up immediately. It doesn't.

## Verification

- `prek run --all-files` — exit 0
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --all-targets --no-default-features -- -D warnings` — clean
- `cargo nextest run --all-features` — **1749 passed, 0 skipped**
- `coverage-missing.py` — **no uncovered regions**
- Net **-37 lines**