### PR TITLE
docs(skills): check issue templates, and bracket a regression repro

### DIFF
--- a/.agents/skills/filing-issues/SKILL.md
+++ b/.agents/skills/filing-issues/SKILL.md
@@ -22,21 +22,29 @@ description: >-
 
 These go out under the maintainer's name, so they are higher-stakes:
 
-1. **Draft locally first** for proof-read; do not open it directly. Ask where drafts
+1. **Check the project's issue templates first** — list
+   `.github/ISSUE_TEMPLATE/` (`gh api repos/<owner>/<repo>/contents/.github/ISSUE_TEMPLATE
+   --jq '.[].name'`) and draft against the matching one's headings, rather than inventing
+   a structure that has to be reshaped by hand at filing time. Its checkboxes are also a
+   checklist of what the maintainers expect verified: working through pandera's
+   "not already reported" box turned up a closely-related open issue that belonged in the
+   report. Tick a box only once the claim is actually true, and leave it unticked (saying
+   so) otherwise.
+2. **Draft locally first** for proof-read; do not open it directly. Ask where drafts
    live (do not hardcode a contributor's local path); the convention is a
    `<repo>-<topic>` Markdown file one directory up from the ryl clone.
-2. **Never report on an assumption.** Verify every behavioural claim by *running the
+3. **Never report on an assumption.** Verify every behavioural claim by *running the
    actual target* at the version in use — never inferred from its lineage, a sibling
    tool, its docs, the spec, or memory. (A granit issue was filed on an unverified
    assumption and had to be fully retracted.) Treat memory notes about third-party
    behaviour as hypotheses to re-verify.
-3. **Ship a one-command reproduction**, pinned to the dependency's **latest** version
+4. **Ship a one-command reproduction**, pinned to the dependency's **latest** version
    (so the report can't be for a bug already fixed upstream), printing
    observed-vs-expected. No repro, no report.
-4. **Include verified, clickable Sources** (a "Sources" section: spec quote /
+5. **Include verified, clickable Sources** (a "Sources" section: spec quote /
    play.yaml.com event stream / upstream issue links) on the *first* pass — not bare
    prose mentions — to avoid a verify-then-re-push cycle on an already-published issue.
-5. **For a code PR, profile the repo and its maintainer(s) before investing.** The onus
+6. **For a code PR, profile the repo and its maintainer(s) before investing.** The onus
    is on us to research what that project is likely to accept — study its recently merged
    PRs *and* its closed-unmerged ones to read the maintainer's preferences: scope and size
    they entertain, review bar, test expectations, and house style (doc-comment density,

--- a/.agents/skills/filing-issues/SKILL.md
+++ b/.agents/skills/filing-issues/SKILL.md
@@ -41,10 +41,19 @@ These go out under the maintainer's name, so they are higher-stakes:
 4. **Ship a one-command reproduction**, pinned to the dependency's **latest** version
    (so the report can't be for a bug already fixed upstream), printing
    observed-vs-expected. No repro, no report.
-5. **Include verified, clickable Sources** (a "Sources" section: spec quote /
+5. **Claiming a regression means the repro must bracket it.** Run the *same* script
+   against the last good version and the bad one, and make its exit code carry the
+   result: `0` on the earlier version, non-zero on the reported one. Proving the
+   boundary with prose while only ever running the broken version is not enough — the
+   maintainer's first move is to flip the pin, so that path has to work. Watch for API
+   introduced *by* the offending change: a diagnostic touching it dies with an
+   `AttributeError` on the older version and reports a misleading exit code, so guard it
+   (`getattr(obj, "attr", None)`) and let the script stay quiet there. A pandera repro
+   shipped with exactly that fault and had to be corrected after filing.
+6. **Include verified, clickable Sources** (a "Sources" section: spec quote /
    play.yaml.com event stream / upstream issue links) on the *first* pass — not bare
    prose mentions — to avoid a verify-then-re-push cycle on an already-published issue.
-6. **For a code PR, profile the repo and its maintainer(s) before investing.** The onus
+7. **For a code PR, profile the repo and its maintainer(s) before investing.** The onus
    is on us to research what that project is likely to accept — study its recently merged
    PRs *and* its closed-unmerged ones to read the maintainer's preferences: scope and size
    they entertain, review bar, test expectations, and house style (doc-comment density,


### PR DESCRIPTION
Two additions to the `filing-issues` skill's "Filing on another project's repo" checklist, both from drafting and filing [unionai-oss/pandera#2444](https://github.com/unionai-oss/pandera/issues/2444).

### 1. Check the project's issue templates first

The skill covered how to *verify* a report and where to draft it, but not that most projects publish a template to draft against. I drafted without checking, invented a structure, and it had to be reshaped once the template turned up — pandera has `bug_report.md`, `feature_request.md`, `documentation-improvement.md` and `submit-question.md`.

The more valuable half: those templates carry checkboxes recording what maintainers expect verified — *not already reported*, *confirmed on the latest version*. Working through pandera's *not already reported* box surfaced [unionai-oss/pandera#2406](https://github.com/unionai-oss/pandera/issues/2406), a closely-related open regression from the same upstream PR, which belonged in the report. The template is a checklist, not just a layout.

### 2. A regression repro must bracket the version boundary

Claiming a regression means running the **same** script against the last good version as well as the bad one, with the exit code carrying the result. Asserting the boundary in prose while only ever running the broken version leaves untested the first thing a maintainer does: flip the pin.

The pandera repro was filed with exactly that fault. Its diagnostic read `PydanticModel.column_names` — an attribute the offending change had *introduced* — so re-pinning to 0.32.0 raised `AttributeError` after the checks had already passed, and exited non-zero, reporting a bug where there was none:

```
alias=,               camelCase input: pass
serialization_alias=, snake_case input: pass
serialization_alias=, camelCase input: pass

coerce() produces columns : ['dash_length']
EXIT: 1          <- AttributeError, not a failure
```

Guarding the access fixed it; exit codes now read `0` on 0.32.0 and `1` on 0.32.1, and the filed issue has been corrected. The rule generalises the trap — API introduced by the offending change can't be touched unguarded in a repro that has to run on both sides of the boundary.

Both entries state the durable principle rather than transcribing the incident, and hardcode no local path, per the skill's own closing section.

### Verification

`prek run --files .agents/skills/filing-issues/SKILL.md` clean (rumdl, ryl markdown, typos, lychee).