### PR TITLE
chore(deps): bump lsp-server to 0.10.0 and jsonschema to 0.52.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10aec8f7f9393bd6a4f2762be0ceb012d3cbe2478987258cc9960de148561914"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -489,12 +489,12 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
 dependencies = [
- "lazy_static",
  "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -632,21 +632,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -656,7 +647,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -899,7 +890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -986,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.10"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1000,6 +991,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -1009,24 +1001,34 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "strum",
  "unicode-general-category",
  "uuid-simd",
 ]
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.46.10"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "jsonschema-value"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+ "zmij",
+]
 
 [[package]]
 name = "libc"
@@ -1072,9 +1074,9 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lsp-server"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad8be6fe0ca81b8298bfbbe8a77e9fcd8895ad6c84cd7794d5ebadcbb09ae43"
+checksum = "3ee25a31f2e571e426eef2896179450cafc7e2f5be00d8a93b1c2d21c0ff7656"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -1458,14 +1460,14 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.10"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
+checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
 dependencies = [
  "ahash",
  "fluent-uri 0.4.1",
  "getrandom 0.3.4",
- "hashbrown 0.16.1",
+ "hashbrown",
  "itoa",
  "micromap",
  "parking_lot",
@@ -1928,6 +1930,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ pulldown-cmark = { version = "0.13.4", default-features = false }
 quick-xml = { version = "0.41", default-features = false }
 sha2 = "0.11"
 same-file = "1.0.6"
-lsp-server = { version = "0.8.0", optional = true }
+lsp-server = { version = "0.10.0", optional = true }
 lsp-types = { version = "0.97.0", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 
@@ -66,12 +66,12 @@ crossbeam-channel = { version = "0.5", optional = true }
 # A different diff implementation than `similar` (which produces the diff), so the
 # `--diff` round-trip property test validates the output is standard-compliant.
 diffy = { version = "0.5.0", default-features = false }
-jsonschema = "0.46.2"
+jsonschema = "0.52.1"
 proptest = "1.11.0"
 semver = "1"
 tempfile = "3"
 # Non-optional for the `lsp`-feature integration tests; keep versions matching the
 # optional runtime deps above.
-lsp-server = "0.8.0"
+lsp-server = "0.10.0"
 lsp-types = "0.97.0"
 serde_json = "1.0.149"

--- a/tests/lsp_server.rs
+++ b/tests/lsp_server.rs
@@ -74,7 +74,7 @@ fn assert_no_diagnostics_push(notifications: &[Notification]) {
 /// caches result ids, so the report is always full).
 fn pull_items(response: Response) -> Vec<Diagnostic> {
     let report: DocumentDiagnosticReport =
-        serde_json::from_value(response.result.expect("diagnostic result"))
+        serde_json::from_value(response.response_result.expect("diagnostic result"))
             .expect("DocumentDiagnosticReport");
     let DocumentDiagnosticReport::Full(report) = report else {
         panic!("expected a full report");
@@ -188,8 +188,10 @@ impl Client {
         let id = this.request("initialize", params);
         let response = this.response(&id);
         this.notify("initialized", serde_json::json!({}));
-        let init = serde_json::from_value(response.result.expect("initialize result"))
-            .expect("InitializeResult");
+        let init = serde_json::from_value(
+            response.response_result.expect("initialize result"),
+        )
+        .expect("InitializeResult");
         (this, init)
     }
 
@@ -395,7 +397,7 @@ impl Client {
         let response = self.response(&id);
         // lsp-server's `initialize_finish` blocks until the client confirms.
         self.notify("initialized", serde_json::json!({}));
-        serde_json::from_value(response.result.expect("initialize result"))
+        serde_json::from_value(response.response_result.expect("initialize result"))
             .expect("InitializeResult")
     }
 
@@ -458,7 +460,7 @@ impl Client {
         };
         let id = self.request("textDocument/codeAction", params);
         let response = self.response(&id);
-        serde_json::from_value(response.result.expect("code action result"))
+        serde_json::from_value(response.response_result.expect("code action result"))
             .expect("response")
     }
 
@@ -470,7 +472,7 @@ impl Client {
         };
         let id = self.request("textDocument/formatting", params);
         let response = self.response(&id);
-        serde_json::from_value(response.result.expect("formatting result"))
+        serde_json::from_value(response.response_result.expect("formatting result"))
             .expect("response")
     }
 
@@ -492,7 +494,7 @@ impl Client {
         };
         let id = self.request("textDocument/codeAction", params);
         let response = self.response(&id);
-        serde_json::from_value(response.result.expect("code action result"))
+        serde_json::from_value(response.response_result.expect("code action result"))
             .expect("response")
     }
 
@@ -503,7 +505,7 @@ impl Client {
         });
         let id = self.request("textDocument/hover", params);
         let response = self.response(&id);
-        serde_json::from_value(response.result.expect("hover result"))
+        serde_json::from_value(response.response_result.expect("hover result"))
             .expect("Option<Hover>")
     }
 
@@ -519,7 +521,7 @@ impl Client {
         });
         let id = self.request("textDocument/prepareRename", params);
         let response = self.response(&id);
-        serde_json::from_value(response.result.expect("prepareRename result"))
+        serde_json::from_value(response.response_result.expect("prepareRename result"))
             .expect("Option<PrepareRenameResponse>")
     }
 
@@ -544,7 +546,7 @@ impl Client {
         let params = json!({ "textDocument": { "uri": uri } });
         let id = self.request("textDocument/diagnostic", params);
         let response = self.response(&id);
-        serde_json::from_value(response.result.expect("diagnostic result"))
+        serde_json::from_value(response.response_result.expect("diagnostic result"))
             .expect("DocumentDiagnosticReport")
     }
 
@@ -552,8 +554,12 @@ impl Client {
         let params = json!({ "previousResultIds": [] });
         let id = self.request("workspace/diagnostic", params);
         let response = self.response(&id);
-        serde_json::from_value(response.result.expect("workspace diagnostic result"))
-            .expect("WorkspaceDiagnosticReport")
+        serde_json::from_value(
+            response
+                .response_result
+                .expect("workspace diagnostic result"),
+        )
+        .expect("WorkspaceDiagnosticReport")
     }
 
     /// Send an incremental (ranged) change replacing `range` with `text`.
@@ -588,7 +594,7 @@ impl Client {
         let id = self.request(UNHANDLED_METHOD, Value::Null);
         let response = self.response(&id);
         assert!(
-            response.error.is_some(),
+            response.response_result.is_err(),
             "unknown request yields an error response"
         );
     }
@@ -596,7 +602,7 @@ impl Client {
     fn shutdown(&mut self) {
         let id = self.request("shutdown", Value::Null);
         let response = self.response(&id);
-        assert!(response.error.is_none(), "shutdown succeeds");
+        assert!(response.response_result.is_ok(), "shutdown succeeds");
         self.notify("exit", Value::Null);
     }
 }
@@ -763,7 +769,10 @@ fn pull_capable_client_receives_no_clear_on_close() {
     let id = client.request(UNHANDLED_METHOD, Value::Null);
     let (notifications, response) = client.notifications_until_response(&id);
     assert_no_diagnostics_push(&notifications);
-    assert!(response.error.is_some(), "the probe is still answered");
+    assert!(
+        response.response_result.is_err(),
+        "the probe is still answered"
+    );
 }
 
 // A pull client's diagnostics are gated off, so after a config change it must be told to
@@ -779,7 +788,10 @@ fn pull_client_is_asked_to_refresh_after_config_change() {
     // Flush with a probe; any refresh request / stray push arrives before its response.
     let id = client.request(UNHANDLED_METHOD, Value::Null);
     let (messages, response) = client.messages_until_response(&id);
-    assert!(response.error.is_some(), "the probe is still answered");
+    assert!(
+        response.response_result.is_err(),
+        "the probe is still answered"
+    );
     let refreshes = messages
         .iter()
         .filter(|message| {
@@ -811,7 +823,10 @@ fn repeated_config_changes_send_distinct_refresh_request_ids() {
     client.notify("workspace/didChangeWatchedFiles", json!({ "changes": [] }));
     let id = client.request(UNHANDLED_METHOD, Value::Null);
     let (messages, response) = client.messages_until_response(&id);
-    assert!(response.error.is_some(), "the probe is still answered");
+    assert!(
+        response.response_result.is_err(),
+        "the probe is still answered"
+    );
     let refresh_ids: Vec<_> = messages
         .iter()
         .filter_map(|message| match message {
@@ -842,7 +857,10 @@ fn pull_client_without_refresh_support_gets_no_refresh() {
     client.notify("workspace/didChangeWatchedFiles", json!({ "changes": [] }));
     let id = client.request(UNHANDLED_METHOD, Value::Null);
     let (messages, response) = client.messages_until_response(&id);
-    assert!(response.error.is_some(), "the probe is still answered");
+    assert!(
+        response.response_result.is_err(),
+        "the probe is still answered"
+    );
     assert!(
         messages.iter().all(|message| {
             !matches!(message, Message::Request(request)
@@ -1095,7 +1113,7 @@ fn unknown_request_is_method_not_found() {
     let (mut client, _init) = Client::launch(None, None);
     let id = client.request(UNHANDLED_METHOD, Value::Null);
     let response = client.response(&id);
-    let error = response.error.expect("unknown method errors");
+    let error = response.response_result.expect_err("unknown method errors");
     assert_eq!(error.code, lsp_server::ErrorCode::MethodNotFound as i32);
 }
 
@@ -1109,12 +1127,10 @@ fn malformed_request_params_yield_a_null_result() {
         Value::String("not params".to_string()),
     );
     let response = client.response(&id);
-    assert_eq!(
-        response.result,
-        Some(Value::Null),
+    assert!(
+        matches!(response.response_result, Ok(Value::Null)),
         "bad params -> null result"
     );
-    assert!(response.error.is_none());
 }
 
 #[test]
@@ -1195,7 +1211,7 @@ fn serve_rejects_malformed_initialize_params() {
     };
     assert_eq!(response.id, id);
     assert!(
-        response.error.is_some(),
+        response.response_result.is_err(),
         "malformed initialize is rejected with an error"
     );
     drop(client);
@@ -1637,9 +1653,10 @@ fn rename_rewrites_an_anchor_and_its_aliases() {
     };
     assert_eq!(placeholder, "anchor");
     let response = client.rename(&doc, 0, 6, "renamed");
-    let edit: WorkspaceEdit =
-        serde_json::from_value(response.result.expect("rename produces an edit"))
-            .expect("workspace edit");
+    let edit: WorkspaceEdit = serde_json::from_value(
+        response.response_result.expect("rename produces an edit"),
+    )
+    .expect("workspace edit");
     let Some(DocumentChanges::Edits(edits)) = edit.document_changes else {
         panic!("expected versioned document changes");
     };
@@ -1658,7 +1675,10 @@ fn rename_rejects_an_illegal_name() {
     client.did_open(doc.clone(), "a: &anchor 1\n");
     let _ = client.diagnostics();
     let response = client.rename(&doc, 0, 6, "bad name");
-    assert!(response.error.is_some(), "a name with a space is rejected");
+    assert!(
+        response.response_result.is_err(),
+        "a name with a space is rejected"
+    );
 }
 
 #[test]
@@ -1669,8 +1689,10 @@ fn rename_off_an_anchor_is_null() {
     client.did_open(doc.clone(), "a: 1\n");
     let _ = client.diagnostics();
     let response = client.rename(&doc, 0, 0, "x");
-    assert_eq!(response.result, Some(Value::Null), "nothing to rename here");
-    assert!(response.error.is_none());
+    assert!(
+        matches!(response.response_result, Ok(Value::Null)),
+        "nothing to rename here"
+    );
 }
 
 #[test]
@@ -1905,9 +1927,9 @@ fn workspace_diagnostic_can_be_cancelled() {
     // Cancel by id. Depending on the race the worker answers with the report or a
     // RequestCancelled error, but the request is always answered (the loop never hangs).
     client.notify("$/cancelRequest", json!({ "id": client.next_id }));
-    let response = client.response(&id);
-    assert!(
-        response.result.is_some() || response.error.is_some(),
+    assert_eq!(
+        client.response(&id).id,
+        id,
         "a cancelled workspace pull is always answered"
     );
 }
@@ -2062,9 +2084,8 @@ fn malformed_rename_params_yield_a_null_result() {
     let (mut client, _init) = Client::launch(None, None);
     let id = client.request("textDocument/rename", Value::String("bad".to_string()));
     let response = client.response(&id);
-    assert_eq!(
-        response.result,
-        Some(Value::Null),
+    assert!(
+        matches!(response.response_result, Ok(Value::Null)),
         "bad rename params -> null"
     );
 }
@@ -2074,9 +2095,8 @@ fn rename_on_an_unopened_document_is_null() {
     let dir = project(TRAILING);
     let (mut client, _init) = Client::launch(None, None);
     let response = client.rename(&file_uri(dir.path(), "never.yaml"), 0, 0, "x");
-    assert_eq!(
-        response.result,
-        Some(Value::Null),
+    assert!(
+        matches!(response.response_result, Ok(Value::Null)),
         "an unopened document yields no rename edit"
     );
 }
@@ -2091,9 +2111,8 @@ fn rename_on_a_markdown_document_is_null() {
     client.did_open(doc.clone(), "```yaml\na: &anchor 1\n```\n");
     let _ = client.diagnostics();
     let response = client.rename(&doc, 1, 6, "renamed");
-    assert_eq!(
-        response.result,
-        Some(Value::Null),
+    assert!(
+        matches!(response.response_result, Ok(Value::Null)),
         "rename targets YAML documents, not markdown hosts"
     );
 }

--- a/tests/lsp_unit.rs
+++ b/tests/lsp_unit.rs
@@ -814,10 +814,16 @@ fn workspace_scan_returns_none_when_cancelled() {
 #[test]
 fn workspace_response_is_ok_or_cancelled() {
     let ok = workspace_response(RequestId::from(1), Some(Vec::new()));
-    assert!(ok.error.is_none(), "a completed scan is an ok response");
+    assert!(
+        ok.response_result.is_ok(),
+        "a completed scan is an ok response"
+    );
     let cancelled = workspace_response(RequestId::from(2), None);
     assert_eq!(
-        cancelled.error.expect("a cancelled scan is an error").code,
+        cancelled
+            .response_result
+            .expect_err("a cancelled scan is an error")
+            .code,
         ErrorCode::RequestCanceled as i32,
         "cancellation maps to the RequestCancelled code"
     );

--- a/tests/property_lsp_protocol.rs
+++ b/tests/property_lsp_protocol.rs
@@ -454,7 +454,7 @@ proptest! {
                     let Message::Response(response) = driver.await_response(&id) else {
                         unreachable!("await_response returns a response");
                     };
-                    prop_assert!(response.error.is_none(), "code action never errors");
+                    prop_assert!(response.response_result.is_ok(), "code action never errors");
                 }
                 Op::Formatting(index) => {
                     let id = driver
@@ -462,7 +462,7 @@ proptest! {
                     let Message::Response(response) = driver.await_response(&id) else {
                         unreachable!("await_response returns a response");
                     };
-                    prop_assert!(response.error.is_none(), "formatting never errors");
+                    prop_assert!(response.response_result.is_ok(), "formatting never errors");
                 }
                 Op::Hover(index) => {
                     let params = json!({
@@ -473,7 +473,7 @@ proptest! {
                     let Message::Response(response) = driver.await_response(&id) else {
                         unreachable!("await_response returns a response");
                     };
-                    prop_assert!(response.error.is_none(), "hover never errors");
+                    prop_assert!(response.response_result.is_ok(), "hover never errors");
                 }
                 Op::Diagnostic(index) => {
                     let params =
@@ -482,7 +482,7 @@ proptest! {
                     let Message::Response(response) = driver.await_response(&id) else {
                         unreachable!("await_response returns a response");
                     };
-                    prop_assert!(response.error.is_none(), "pull diagnostic never errors");
+                    prop_assert!(response.response_result.is_ok(), "pull diagnostic never errors");
                 }
             }
         }
@@ -617,7 +617,7 @@ proptest! {
                     "a pull-capable client must never receive a publishDiagnostics push"
                 );
                 let report: DocumentDiagnosticReport =
-                    serde_json::from_value(response.result.expect("pull result"))
+                    serde_json::from_value(response.response_result.expect("pull result"))
                         .expect("DocumentDiagnosticReport");
                 let DocumentDiagnosticReport::Full(report) = report else {
                     unreachable!("ryl never caches result ids, so every report is full");


### PR DESCRIPTION
Replaces Dependabot's #418, whose branch is stale and fails to compile against lsp-server 0.10.

## What changed

- `lsp-server` 0.8.0 to 0.10.0 (runtime, behind the `lsp` feature, and dev). 0.10 folds `Response::result` and `Response::error` into one `response_result: Result<Value, ResponseError>` field. Only the three LSP test suites read those fields, so they now read `response_result`; `src/lsp` only builds responses through `Response::new_ok` / `new_err`, which are unchanged.
- `jsonschema` 0.46.2 to 0.52.1 (dev-only). Dependabot targeted 0.49.9, but 0.52.1 is current and the `validator_for` API the tests use is unchanged across 0.47 to 0.52. The one breaking note in that range concerns `default-features = false`, which ryl does not set.

## Why

#418 has been stuck since 21 Aug: its workflow-file hunks now conflict with #420 and its tests no longer compile. A fresh branch off main is simpler than repairing it.

## Risk

Low. No `src/` changes. Full suite passes locally (1749 tests), `prek run --all-files` is clean, both `-D warnings` clippy gates pass, and the coverage script reports no uncovered regions. `cargo audit` is clean on the new lock.

## Where to focus review

`tests/lsp_server.rs` around the former `assert_eq!(response.result, Some(Value::Null))` sites, now `matches!(response.response_result, Ok(Value::Null))`, and the cancelled `workspace/diagnostic` test whose old assertion became vacuous under the new type and now checks the response id instead.

<details><summary>Skills used</summary>

| Skill | Version |
| --- | --- |
| `human-collaboration` | v0.8.0 |

</details>
