### PR TITLE
ci: notify ryl-vscode of a release so it bumps its pin

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -85,6 +85,10 @@ description: >-
     `permission-workflows: write` (added in PR #265) and that the GitHub App installation
     actually grants Workflows: Read and write. The fork's `master` state is *not*
     involved (the branch never derives from it).
+- After a successful release, `release.yml`'s `notify-ryl-vscode` job dispatches a
+  `ryl_release` event to `owenlamont/ryl-vscode`, whose `bump-ryl` workflow opens a PR
+  moving its bundled-binary pin to this release. That repo also polls weekly, so a
+  failed dispatch delays the bump rather than losing it; nothing here needs re-running.
 - Publishing uses Trusted Publishing on all registries (crates.io via GitHub OIDC, PyPI
   via `pypa/gh-action-pypi-publish`, NPM via `actions/setup-node` OIDC). GitHub release
   creation is deferred until after crates.io/PyPI/NPM publishing succeeds, kept as a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1041,3 +1041,39 @@ jobs:
             -H "Authorization: Bearer ${APP_TOKEN}" \
             https://api.github.com/repos/owenlamont/ryl-pre-commit/dispatches \
             -d "{\"event_type\":\"pypi_release\",\"client_payload\":{\"version\":\"${version}\"}}"
+
+  notify-ryl-vscode:
+    name: Notify ryl-vscode
+    runs-on: ubuntu-latest
+    environment: automation
+    needs:
+      - finalize-github-release
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') &&
+      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
+    permissions:
+      contents: read
+    steps:
+      - name: Generate token for cross-repository dispatch
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ secrets.AUTH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+          owner: owenlamont
+          repositories: ryl-vscode
+          permission-contents: write
+
+      # ryl-vscode's weekly schedule is the fallback, so a failure here only delays its bump.
+      - name: Dispatch ryl_release event to ryl-vscode
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |-
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          curl --fail -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${APP_TOKEN}" \
+            https://api.github.com/repos/owenlamont/ryl-vscode/dispatches \
+            -d "{\"event_type\":\"ryl_release\",\"client_payload\":{\"version\":\"${version}\"}}"


### PR DESCRIPTION
`ryl-vscode` bundles a pinned ryl binary and had no signal that a release happened, so it
sat on 0.18.1 while ryl reached 0.21.0 (owenlamont/ryl-vscode#30).

## What changed

- `notify-ryl-vscode`: a `ryl_release` dispatch after `finalize-github-release`, mirroring
  `notify-ryl-pre-commit`.
- One line in the `release` skill, so the post-release checklist names the new downstream
  effect and nobody re-runs the job by hand.

## Where to focus review

- owenlamont/ryl-vscode#32 adds the `bump-ryl` workflow that consumes the event. Order
  does not matter: a dispatch to a repo with no matching trigger is a no-op, and
  `bump-ryl` also runs weekly.

<details><summary>Skills used</summary>

| Skill | Version |
| --- | --- |
| `docs` | v0.9.1 |

</details>

— Claude

https://claude.ai/code/session_012MpR5SKipZeoPRAavuUD2Z

