### PR TITLE
chore: bump the Rust toolchain to 1.98.1 and trim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,16 +52,8 @@ ryl is a CLI tool for linting yaml files
   documentation often - it's much cheaper to have the linters and formatters auto fix
   issues than correcting them yourself. Only correct what the linters and formatters
   can't automatically fix.
-- No unsafe Rust code. Do not introduce `unsafe` in application code or tests. If a
-  change appears to require `unsafe`, propose an alternative design that keeps code
-  safe. The crate is built with `#![forbid(unsafe_code)]` and tests should follow the
-  same principle.
 - Remember the linter/formatter prek won't scan any new modules until they are added to
   git so don't forget to git add any new modules you create before running prek.
-- Use the most modern Rust idioms and syntax allowed by the Rust version (currently this
-  is Rust 1.97.1).
-- Keep `clippy.toml` `msrv` in sync with `rust-toolchain.toml` whenever the Rust
-  toolchain channel is changed.
 - Don't rely on your memory of libraries and APIs. All external dependencies evolve fast
   so ensure current documentation and/or repo is consulted when working with third party
   dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ryl"
 version = "0.22.0"
 edition = "2024"
+rust-version = "1.98.1"
 description = "Fast YAML linter inspired by yamllint"
 readme = "README.md"
 license = "MIT"
@@ -24,6 +25,9 @@ include = [
   "/src/**",
   "/tests/**",
 ]
+
+[lints.rust]
+unsafe_code = "forbid"
 
 [[bin]]
 name = "ryl"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ pixi global install ryl             # conda-forge
 winget install owenlamont.ryl       # winget (Windows)
 ```
 
+Building from source (`cargo install`, or a `pip` sdist) needs Rust 1.98.1 or
+newer. The prebuilt wheels, npm, conda-forge and winget packages do not.
+
 ## Status and scope
 
 - All 23 yamllint rules are implemented, plus four ryl-only rules with no

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,3 @@
-msrv = "1.97.1"
 # lsp-types pins bitflags 1.x and pulldown-cmark uses 2.x; no published lsp-types avoids
 # 1.x, so this duplicate is unavoidable under the `lsp` feature. synstructure 0.13 pins
 # syn 2.x and reaches the graph only through the `jsonschema` dev-dependency

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.1"
 components = ["llvm-tools-preview"]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -293,10 +293,10 @@ fn decode_utf16(
         ));
     }
     let mut units: Vec<u16> = Vec::with_capacity(data.len() / 2);
-    for chunk in data.chunks_exact(2) {
+    for &chunk in data.as_chunks::<2>().0 {
         let value = match endian {
-            Endian::Big => u16::from_be_bytes([chunk[0], chunk[1]]),
-            Endian::Little => u16::from_le_bytes([chunk[0], chunk[1]]),
+            Endian::Big => u16::from_be_bytes(chunk),
+            Endian::Little => u16::from_le_bytes(chunk),
         };
         units.push(value);
     }
@@ -324,12 +324,10 @@ fn decode_utf32(
         ));
     }
     let mut out = String::with_capacity(data.len() / 4);
-    for chunk in data.chunks_exact(4) {
+    for &chunk in data.as_chunks::<4>().0 {
         let raw = match endian {
-            Endian::Big => u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]),
-            Endian::Little => {
-                u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]])
-            }
+            Endian::Big => u32::from_be_bytes(chunk),
+            Endian::Little => u32::from_le_bytes(chunk),
         };
         match char::from_u32(raw) {
             Some(ch) => out.push(ch),

--- a/src/rules/key_duplicates.rs
+++ b/src/rules/key_duplicates.rs
@@ -238,8 +238,10 @@ impl MapData {
     fn vid(&self) -> Vid {
         let mut entries: Vec<Vid> = self
             .vid_children
-            .chunks_exact(2)
-            .map(|pair| hash_of(&(pair[0], pair[1])))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|&[key, value]| hash_of(&(key, value)))
             .collect();
         entries.sort_unstable();
         hash_of(&(2u8, self.node_tag, entries))


### PR DESCRIPTION
## What changed

- `rust-toolchain.toml` to 1.98.1; the MSRV moves to `Cargo.toml`'s `rust-version`, so
  `clippy.toml`'s `msrv` goes.
- 1.98's `clippy::chunks_exact_to_as_chunks` fires at three sites; `as_chunks::<N>()`
  replaces them, dropping the byte-by-byte rebuilds.
- `AGENTS.md` loses the three Rust bullets; `[lints.rust] unsafe_code = "forbid"` replaces
  the deleted no-unsafe prose and reaches the test targets too.

## Departures from the issues

- `rust-version` is cargo-enforced, not just a Clippy hint: `cargo +1.97.1 check` now
  hard-fails. Kept at 1.98.1 to match the pin, with the README stating it.
- [#427](https://github.com/owenlamont/ryl/issues/427) asked for the three skills to be
  named here. Dropped: this repo is public, the skills repo is not.

## Notes for the reviewer

Nothing in [#426](https://github.com/owenlamont/ryl/issues/426)'s feature delta was worth
adopting: `substr_range` has no site here, and ~~`from_utf16le/be` changes error text the
`decoder` tests assert~~ — corrected in #432: the tests assert only the `invalid utf-16`
prefix, which survives; only the detail text changes. The `as_chunks` rewrite was checked differentially against the
pre-change binary over 99 encoding fixtures, not by reading.

<details><summary>Skills used</summary>

| Skill | Version |
| --- | --- |
| `pr-review` | v0.13.0 |
| `rust-code-style` | v0.13.0 |
| `docs` | v0.12.4 |
| `software-engineering` | v0.13.0 |

</details>

Closes #426, closes #427

— Claude

