### PR TITLE
ci: sync the winget-pkgs fork before submitting

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -94,6 +94,11 @@ description: >-
   creation is deferred until after crates.io/PyPI/NPM publishing succeeds, kept as a
   draft until assets upload, with auto-generated notes; reruns skip publish steps for a
   version that already exists.
+- The `publish-winget` job syncs the winget-pkgs fork with upstream before submitting,
+  because `wingetcreate` cannot fast-forward it and `--submit` fails with "The forked
+  repository could not be synced with the upstream commits" once it falls behind. If that
+  error appears anyway, sync by hand
+  (`gh api repos/<owner>/winget-pkgs/merge-upstream -f branch=master`) and re-run the job.
 - After the release is un-drafted, the `publish-winget` job submits a winget-pkgs PR via
   `wingetcreate update owenlamont.ryl` (token: the classic `public_repo` `WINGET_PAT`
   secret in the `automation` environment). It requires the package to already exist in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -978,6 +978,24 @@ jobs:
           if ($actual -ne ${env:WINGETCREATE_SHA256}) {
             throw "wingetcreate.exe SHA256 mismatch: expected ${env:WINGETCREATE_SHA256}, got $actual"
           }
+      # wingetcreate cannot fast-forward the fork itself: once it falls behind upstream,
+      # which it does between releases, --submit fails with "The forked repository could
+      # not be synced with the upstream commits". Non-fatal, since the submit below
+      # reports a sync it could not fix with a clearer error.
+      - name: Sync the winget-pkgs fork with upstream
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_FORK: ${{ github.repository_owner }}/winget-pkgs
+        run: |-
+          $output = gh api "repos/${env:WINGET_FORK}/merge-upstream" -f branch=master 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::Could not sync ${env:WINGET_FORK}: $output"
+          } else {
+            Write-Host $output
+          }
+          exit 0
+
       - name: Submit ryl to winget-pkgs
         shell: pwsh
         env:


### PR DESCRIPTION
## What changed

The `publish-winget` job now fast-forwards the fork through the API before
`wingetcreate --submit`. `wingetcreate` cannot do it itself, so once the fork falls behind
upstream the submit fails with "The forked repository could not be synced with the
upstream commits". The `release` skill records the manual command for when it still fails.

## Notes for the reviewer

Deliberately non-fatal (`::warning::` then `exit 0`): a failed sync should not block a
release whose submit might still succeed.

Checked first — the fork's default branch is `master`, it is public so the classic
`public_repo` PAT can write to it, and it sits 30 commits behind upstream and 0 ahead.

<details><summary>Skills used</summary>

| Skill | Version |
| --- | --- |
| `pr-review` | v0.13.0 |
| `docs` | v0.12.4 |
| `software-engineering` | v0.13.0 |

</details>

— Claude
