### PR TITLE
chore: bump five prek pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1018,7 +1018,7 @@ jobs:
     if: >-
       startsWith(github.ref, 'refs/tags/v') &&
       (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true))
-    uses: ./.github/workflows/sync-schemastore.yml
+    uses: $/.github/workflows/sync-schemastore.yml
     with:
       source_ref: ${{ github.sha }}
     secrets:

--- a/prek.toml
+++ b/prek.toml
@@ -154,14 +154,14 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/rvben/rumdl-pre-commit"
-rev = "v0.2.62"
+rev = "v0.2.67"
 hooks = [
   { id = "rumdl" }
 ]
 
 [[repos]]
 repo = "https://github.com/charliermarsh/ruff-pre-commit"
-rev = "v0.16.5"
+rev = "v0.16.6"
 hooks = [
   {
     id = "ruff-check",
@@ -188,7 +188,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/owenlamont/ryl-pre-commit"
-rev = "v0.21.0"
+rev = "v0.22.0"
 hooks = [
   { id = "ryl", args = ["--fix"] },
   { id = "ryl-markdown", args = ["--fix"] }
@@ -196,7 +196,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/adhtruong/mirrors-typos"
-rev = "v1.50.0"
+rev = "v1.50.1"
 hooks = [
   {
     id = "typos",
@@ -206,7 +206,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/woodruffw/zizmor-pre-commit"
-rev = "v1.29.0"
+rev = "v1.30.0"
 hooks = [
   {
     id = "zizmor",


### PR DESCRIPTION
## What changed

`prek autoupdate` — five pins:

| Hook | From | To |
| :--- | :--- | :--- |
| rumdl | v0.2.62 | v0.2.67 |
| ruff | v0.16.5 | v0.16.6 |
| ryl-pre-commit | v0.21.0 | v0.22.0 |
| typos | v1.50.0 | v1.50.1 |
| zizmor | v1.29.0 | v1.30.0 |

## Notes for the reviewer

zizmor 1.30.0 adds the `self-repository` audit, which auto-fixed `release.yml`:

```diff
-    uses: ./.github/workflows/sync-schemastore.yml
+    uses: $/.github/workflows/sync-schemastore.yml
```

[GitHub documents](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows) `$/` as the recommended form for a same-repository reusable workflow, with `./` still valid. `$/` is unavailable on GitHub Enterprise Server, which this repo does not target.

That is the only behavioural line in the diff, and it sits in the release path — worth a look before merge.

— Claude
