### PR TITLE
fix: reject TOML-only keys in yamllint-compatible YAML config

### DIFF
--- a/docs/file-ignores.md
+++ b/docs/file-ignores.md
@@ -95,8 +95,8 @@ present = true
 Each key is a path glob with the same semantics as `ignore`, including `!`
 negation. Each value is a list of rule IDs.
 
-`per-file-ignores` is **ryl-only** and configured in TOML only; yamllint has no
-equivalent. Unlike [`per-line-ignores`](per-line-ignores.md), it accepts rule IDs
+`per-file-ignores` is **ryl-only** and configured in TOML only (yamllint has no
+equivalent); it is rejected in yamllint-compatible YAML config. Unlike [`per-line-ignores`](per-line-ignores.md), it accepts rule IDs
 only &mdash; there is no `"ALL"` shorthand for every rule. To skip a file
 outright, use `ignore`.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1469,8 +1469,8 @@ present = true
 Each key is a path glob with the same semantics as `ignore`, including `!`
 negation. Each value is a list of rule IDs.
 
-`per-file-ignores` is **ryl-only** and configured in TOML only; yamllint has no
-equivalent. Unlike [`per-line-ignores`](https://ryl-docs.pages.dev/per-line-ignores/), it accepts rule IDs
+`per-file-ignores` is **ryl-only** and configured in TOML only (yamllint has no
+equivalent); it is rejected in yamllint-compatible YAML config. Unlike [`per-line-ignores`](https://ryl-docs.pages.dev/per-line-ignores/), it accepts rule IDs
 only &mdash; there is no `"ALL"` shorthand for every rule. To skip a file
 outright, use `ignore`.
 
@@ -1527,9 +1527,9 @@ Each region is linted as its **own independent YAML document**, and every
 diagnostic's line and column point back into the original Markdown file.
 
 This is a ryl-only capability, so it is configured exclusively in **TOML**
-(`ryl.toml`, `.ryl.toml`, or `[tool.ryl]` in `pyproject.toml`). The YAML
-(`yamllint`-compatible) configuration uses the legacy `yaml-files` key and has no
-markdown support.
+(`ryl.toml`, `.ryl.toml`, or `[tool.ryl]` in `pyproject.toml`) and rejected in
+yamllint-compatible YAML config. The YAML (`yamllint`-compatible) configuration
+uses the legacy `yaml-files` key and has no markdown support.
 
 ## Source kinds and the `[files]` table
 
@@ -1559,7 +1559,8 @@ markdown = ["*.md", "docs/**/*.md"]           # opt-in: enables markdown linting
   no kind is simply skipped.
 
 > The legacy `yaml-files` key is **not** valid in TOML — use `[files].yaml`. It
-> remains valid in the yamllint-compatible YAML config.
+> remains valid in the yamllint-compatible YAML config, which conversely rejects
+> `[files]` itself.
 
 Markdown behaviour is tuned in a separate `[markdown]` table (both default `true`):
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -12,9 +12,9 @@ Each region is linted as its **own independent YAML document**, and every
 diagnostic's line and column point back into the original Markdown file.
 
 This is a ryl-only capability, so it is configured exclusively in **TOML**
-(`ryl.toml`, `.ryl.toml`, or `[tool.ryl]` in `pyproject.toml`). The YAML
-(`yamllint`-compatible) configuration uses the legacy `yaml-files` key and has no
-markdown support.
+(`ryl.toml`, `.ryl.toml`, or `[tool.ryl]` in `pyproject.toml`) and rejected in
+yamllint-compatible YAML config. The YAML (`yamllint`-compatible) configuration
+uses the legacy `yaml-files` key and has no markdown support.
 
 ## Source kinds and the `[files]` table
 
@@ -44,7 +44,8 @@ markdown = ["*.md", "docs/**/*.md"]           # opt-in: enables markdown linting
   no kind is simply skipped.
 
 > The legacy `yaml-files` key is **not** valid in TOML — use `[files].yaml`. It
-> remains valid in the yamllint-compatible YAML config.
+> remains valid in the yamllint-compatible YAML config, which conversely rejects
+> `[files]` itself.
 
 Markdown behaviour is tuned in a separate `[markdown]` table (both default `true`):
 

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -1185,13 +1185,15 @@ fn parse_string_items(
 
 /// TOML rejects an unknown key structurally, while the yamllint-compatible YAML path
 /// tolerates one, so every ryl-native top-level key has to be listed here to be caught.
-const TOML_ONLY_CONFIG_KEYS: [&str; 6] = [
-    "files",
-    "fix",
-    "markdown",
-    "output",
-    "per-file-ignores",
-    "per-line-ignores",
+/// The second field names the YAML spelling where one exists, since "use TOML" would
+/// send that user to the wrong fix.
+const TOML_ONLY_CONFIG_KEYS: [(&str, Option<&str>); 6] = [
+    ("files", Some("`yaml-files`")),
+    ("fix", None),
+    ("markdown", None),
+    ("output", None),
+    ("per-file-ignores", None),
+    ("per-line-ignores", None),
 ];
 
 pub(crate) fn parse_yaml_config(doc: &YamlOwned) -> Result<ParsedYamlConfig, String> {
@@ -1199,12 +1201,18 @@ pub(crate) fn parse_yaml_config(doc: &YamlOwned) -> Result<ParsedYamlConfig, Str
         return Err("invalid config: not a mapping".to_string());
     }
 
-    if let Some(key) = TOML_ONLY_CONFIG_KEYS
+    if let Some((key, yaml_spelling)) = TOML_ONLY_CONFIG_KEYS
         .into_iter()
-        .find(|key| doc.as_mapping_get(key).is_some())
+        .find(|(key, _)| doc.as_mapping_get(key).is_some())
     {
-        return Err(format!(
-            "invalid config: {key} is only supported in TOML configuration"
+        return Err(yaml_spelling.map_or_else(
+            || format!("invalid config: {key} is only supported in TOML configuration"),
+            |spelling| {
+                format!(
+                    "invalid config: `{key}` is not valid in yamllint-compatible YAML \
+                     config; use {spelling} instead"
+                )
+            },
         ));
     }
 

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -1185,8 +1185,7 @@ fn parse_string_items(
 
 /// TOML rejects an unknown key structurally, while the yamllint-compatible YAML path
 /// tolerates one, so every ryl-native top-level key has to be listed here to be caught.
-/// The second field names the YAML spelling where one exists, since "use TOML" would
-/// send that user to the wrong fix.
+/// `files` carries its YAML spelling because "use TOML" would be the wrong fix for it.
 const TOML_ONLY_CONFIG_KEYS: [(&str, Option<&str>); 6] = [
     ("files", Some("`yaml-files`")),
     ("fix", None),

--- a/src/config_schema.rs
+++ b/src/config_schema.rs
@@ -1183,29 +1183,29 @@ fn parse_string_items(
     map(text)
 }
 
+/// TOML rejects an unknown key structurally, while the yamllint-compatible YAML path
+/// tolerates one, so every ryl-native top-level key has to be listed here to be caught.
+const TOML_ONLY_CONFIG_KEYS: [&str; 6] = [
+    "files",
+    "fix",
+    "markdown",
+    "output",
+    "per-file-ignores",
+    "per-line-ignores",
+];
+
 pub(crate) fn parse_yaml_config(doc: &YamlOwned) -> Result<ParsedYamlConfig, String> {
     if doc.as_mapping().is_none() {
         return Err("invalid config: not a mapping".to_string());
     }
 
-    if doc.as_mapping_get("fix").is_some() {
-        return Err(
-            "invalid config: fix is only supported in TOML configuration".to_string(),
-        );
-    }
-
-    if doc.as_mapping_get("per-line-ignores").is_some() {
-        return Err(
-            "invalid config: per-line-ignores is only supported in TOML configuration"
-                .to_string(),
-        );
-    }
-
-    if doc.as_mapping_get("output").is_some() {
-        return Err(
-            "invalid config: output is only supported in TOML configuration"
-                .to_string(),
-        );
+    if let Some(key) = TOML_ONLY_CONFIG_KEYS
+        .into_iter()
+        .find(|key| doc.as_mapping_get(key).is_some())
+    {
+        return Err(format!(
+            "invalid config: {key} is only supported in TOML configuration"
+        ));
     }
 
     let typed = parse_typed_yaml_config(doc)?;

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -1112,7 +1112,6 @@ fn toml_schema_root_rejects_unknown_top_level_keys() {
 #[test]
 fn yaml_config_rejects_every_toml_only_key() {
     let cases = [
-        ("files", "files:\n  yaml: [\"*.yaml\"]\n"),
         ("fix", "fix:\n  fixable: [comments]\n"),
         ("markdown", "markdown:\n  fenced: true\n"),
         ("output", "output:\n  format: parsable\n"),
@@ -1142,4 +1141,24 @@ fn yaml_config_rejects_every_toml_only_key() {
             "`{key}` in a yamllint-style YAML config must name itself in the error"
         );
     }
+}
+
+#[test]
+fn yaml_config_rejecting_files_points_at_the_yaml_spelling() {
+    let err = ryl::config::discover_config(
+        &[],
+        &ryl::config::Overrides {
+            config_file: None,
+            config_data: Some("files:\n  yaml: [\"*.yaml\"]\n".to_string()),
+        },
+    )
+    .expect_err("yaml config should reject the TOML `files` table");
+
+    assert_eq!(
+        err,
+        "invalid config: `files` is not valid in yamllint-compatible YAML config; \
+         use `yaml-files` instead",
+        "`files` has a YAML spelling, so the error must name it rather than sending \
+         the reader to TOML"
+    );
 }

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -1108,3 +1108,38 @@ fn toml_schema_root_rejects_unknown_top_level_keys() {
         "a config using only known top-level keys should pass"
     );
 }
+
+#[test]
+fn yaml_config_rejects_every_toml_only_key() {
+    let cases = [
+        ("files", "files:\n  yaml: [\"*.yaml\"]\n"),
+        ("fix", "fix:\n  fixable: [comments]\n"),
+        ("markdown", "markdown:\n  fenced: true\n"),
+        ("output", "output:\n  format: parsable\n"),
+        (
+            "per-file-ignores",
+            "per-file-ignores:\n  \"*.yaml\": [comments]\n",
+        ),
+        (
+            "per-line-ignores",
+            "per-line-ignores:\n  - regex: \"a\"\n    rules: [comments]\n",
+        ),
+    ];
+
+    for (key, data) in cases {
+        let err = ryl::config::discover_config(
+            &[],
+            &ryl::config::Overrides {
+                config_file: None,
+                config_data: Some(data.to_string()),
+            },
+        )
+        .expect_err(&format!("yaml config should reject `{key}`"));
+
+        assert_eq!(
+            err,
+            format!("invalid config: {key} is only supported in TOML configuration"),
+            "`{key}` in a yamllint-style YAML config must name itself in the error"
+        );
+    }
+}


### PR DESCRIPTION
## What changed

`files`, `markdown` and `per-file-ignores` in a yamllint-style YAML config were accepted and then ignored — no effect, no message, indistinguishable from a typo. They now exit 2, matching `fix`, `output` and `per-line-ignores`.

TOML rejects an unknown key structurally, so only the YAML path ever needed a guard; three of the six had one. They collapse into a single table here.

## The `files` exception

`files` has a YAML spelling, so its message names `yaml-files` rather than saying "use TOML" — mirroring the existing message for the reverse direction. The other five keep their wording byte-identical.

## Risk

A config carrying a dead key today lints green and will now exit 2. Nothing it was doing stops working — the key never did anything — but a green CI can go red.

<details><summary>Skills used</summary>

| Skill | Version |
| --- | --- |
| `pr-review` | v0.13.1 |
| `rust-code-style` | v0.13.0 |
| `rust-testing` | v0.13.0 |
| `docs` | v0.14.1 |
| `software-engineering` | v0.13.0 |

</details>

— Claude

https://claude.ai/code/session_01T9E5sCRuxtAWJZQtuFgxvT
